### PR TITLE
i18n: fix and sync translations

### DIFF
--- a/applications/luci-app-adblock/po/zh-tw/adblock.po
+++ b/applications/luci-app-adblock/po/zh-tw/adblock.po
@@ -93,7 +93,9 @@ msgstr "未揾到拉黑檔案清單!"
 msgid ""
 "Choose 'none' to disable automatic startups, 'timed' to use a classic "
 "timeout (default 30 sec.) or select another trigger interface."
-msgstr "選擇\"無\"以禁用自動啟動，\"超時\"以使用經典超時（預設為 30 秒）或選擇其他觸發器介面。"
+msgstr ""
+"選擇\"無\"以禁用自動啟動，\"超時\"以使用經典超時（預設為 30 秒）或選擇其他觸"
+"發器介面。"
 
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:83
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:89
@@ -201,6 +203,10 @@ msgstr "下載實用程式（SSL 庫）"
 msgid "E-Mail Notification"
 msgstr "電子郵件通知"
 
+#: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:157
+msgid "E-Mail Receiver Address"
+msgstr ""
+
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:260
 msgid "E-mail Notification Count"
 msgstr "電子郵件通知計數"
@@ -208,10 +214,6 @@ msgstr "電子郵件通知計數"
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:255
 msgid "E-mail Profile"
 msgstr "電子郵件設定檔"
-
-#: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:157
-msgid "E-mail Receiver Address"
-msgstr "電子郵件接收方位址"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:245
 msgid "E-mail Sender Address"
@@ -673,6 +675,9 @@ msgid ""
 "e.g. to receive an e-mail notification with every adblock run set this value "
 "to 200000."
 msgstr ""
+
+#~ msgid "E-mail Receiver Address"
+#~ msgstr "電子郵件接收方位址"
 
 #~ msgid "'Jail' Blocklist Creation"
 #~ msgstr "“Jail”攔截列表建立"

--- a/applications/luci-app-advanced-reboot/po/bg/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/bg/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/ca/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/ca/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr "S’està carregant"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -94,14 +94,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr "Estat"
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -121,7 +121,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -129,36 +129,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -209,10 +209,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""
 

--- a/applications/luci-app-advanced-reboot/po/cs/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/cs/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Rozšířený restart"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Načítání"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 "Není přístup k nástrojům /usr/sbin/fw_printenv nebo /usr/sbin/fw_setenv!"
@@ -95,14 +95,14 @@ msgstr "Restartovat do alternativního oddílu..."
 msgid "Reboot to current partition"
 msgstr "Restartovat do aktuálního oddílu"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Probíhá restartování…"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Probíhá vypínání..."
 
@@ -114,7 +114,7 @@ msgstr "Stav"
 msgid "System"
 msgstr "Systém"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -125,19 +125,19 @@ msgstr ""
 "minut, než se pokusíte znovu připojit. Může být nutné obnovit IP adresu "
 "počítače pro spojení se zařízením, a to v závislosti na nastavení."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
-"Systém nyní bootuje alternativní oddíl.<br/>NEVYPÍNEJTE PŘÍSTROJ!<br/>"
-"Počkejte několik minut, než se pokusíte znovu připojit. Může být nutné "
+"Systém nyní bootuje alternativní oddíl.<br/>NEVYPÍNEJTE PŘÍSTROJ!<br/"
+">Počkejte několik minut, než se pokusíte znovu připojit. Může být nutné "
 "obnovit IP adresu počítače pro spojení se zařízením, a to v závislosti na "
 "nastavení."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -146,29 +146,29 @@ msgstr ""
 "Systém se nyní vypíná.<br/>NEVYPÍNEJTE PŘÍSTROJ!<br/>Může být nutné obnovit "
 "IP adresu počítače pro spojení se zařízením, a to v závislosti na nastavení."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Nelze najít druhý oddíl s příznakem pro bootovaní."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Nelze získat proměnnou prostředí firmwaru"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "Nelze nastavit bootvací příznak oddílu pro duální spuštění"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Nelze nastavit proměnnou prostředí firmwaru"
 
@@ -186,8 +186,8 @@ msgstr ""
 "VAROVÁNÍ: Alternativní oddíl může mít vlastní nastavení a zcela odlišný "
 "firmware. <br /> <br />Protože se vaše síťové nastavení a WiFi SSID / heslo "
 "v alternativním oddílu mohou lišit, možná bude nutné upravit nastavení "
-"počítače, aby bylo možné se k vašemu zařízení připojit po restartu. <br /> <"
-"br /> Mějte prosím na paměti, že firmware alternativního oddílu nemusí "
+"počítače, aby bylo možné se k vašemu zařízení připojit po restartu. <br /> "
+"<br /> Mějte prosím na paměti, že firmware alternativního oddílu nemusí "
 "poskytovat snadný způsob přepnutí aktivního oddílu a spuštění zpět do "
 "aktuálně aktivního oddílu. <br /> <br /> Klepnutím na 'Pokračovat' níže "
 "restartujte zařízení do jiného oddílu."
@@ -198,8 +198,8 @@ msgid ""
 "support power off.<br /><br /> Click \"Proceed\" below to power off your "
 "device."
 msgstr ""
-"VAROVÁNÍ: Vypnutí může vést k restartu zařízení, které nepodporuje vypínání.<"
-"br /> <br /> Chcete-li zařízení vypnout, klepněte níže na 'Pokračovat'."
+"VAROVÁNÍ: Vypnutí může vést k restartu zařízení, které nepodporuje vypínání."
+"<br /> <br /> Chcete-li zařízení vypnout, klepněte níže na 'Pokračovat'."
 
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:46
 msgid "Waiting for changes to be applied..."
@@ -231,9 +231,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "na"

--- a/applications/luci-app-advanced-reboot/po/de/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/de/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Erweitertes Neustarten"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Lade"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Kein Zugriff auf fw_printenv oder fw_setenv!"
 
@@ -94,14 +94,14 @@ msgstr "Von alternativer Partition neu starten..."
 msgid "Reboot to current partition"
 msgstr "Von aktueller Partition neu starten"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Starte neu..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Fahre herunter..."
 
@@ -113,7 +113,7 @@ msgstr "Status"
 msgid "System"
 msgstr "System"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -125,7 +125,7 @@ msgstr ""
 "wiederherzustellen. Es kann notwendig sein, die Adresse des Computers zu "
 "erneuern, um das Gerät je nach Einstellungen wieder zu erreichen."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -138,7 +138,7 @@ msgstr ""
 "Computers zu erneuern, um das Gerät je nach den Einstellungen wieder zu "
 "erreichen."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -148,30 +148,30 @@ msgstr ""
 "Es kann notwendig sein, die Adresse des Computers zu erneuern, um das Gerät "
 "je nach den Einstellungen wieder zu erreichen."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Dual Boot Flag-Partition konnte nicht gefunden werden."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Firmware-Umgebungsvariable kann nicht abgerufen werden"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 "Eintrag Dual Boot Flag Partition kann für die Partition nicht gesetzt werden"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Die Umgebungsvariable für die Firmware kann nicht gesetzt werden"
 
@@ -236,10 +236,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "zu"
 

--- a/applications/luci-app-advanced-reboot/po/el/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/el/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Προχωρημένη Επανεκκίνηση"
@@ -51,7 +51,7 @@ msgstr "Υλικολογισμικό"
 msgid "Loading"
 msgstr "Φόρτωση"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Δεν υπάρχει πρόσβαση στο fw_printenv ή fw_printenv!"
 
@@ -94,14 +94,14 @@ msgstr "Επανεκκίνηση σε εναλλακτικό διαμερισμ�
 msgid "Reboot to current partition"
 msgstr "Επανεκκίνηση στον τρέχον διαμερισμό"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Επανεκκίνηση..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Απενεργοποίηση..."
 
@@ -113,19 +113,19 @@ msgstr "Κατάσταση"
 msgid "System"
 msgstr "Σύστημα"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
 "address of your computer to reach the device again, depending on your "
 "settings."
 msgstr ""
-"Το σύστημα επανεκκινείται τώρα. <br /> ΜΗΝ ΑΠΕΝΕΡΓΟΠΟΙΗΣΕΤΕ ΤΗΝ ΣΥΣΚΕΥΗ! <br "
-"/> Περιμένετε λίγα λεπτά προτού προσπαθήσετε να επανασυνδεθείτε. Ίσως "
+"Το σύστημα επανεκκινείται τώρα. <br /> ΜΗΝ ΑΠΕΝΕΡΓΟΠΟΙΗΣΕΤΕ ΤΗΝ ΣΥΣΚΕΥΗ! "
+"<br /> Περιμένετε λίγα λεπτά προτού προσπαθήσετε να επανασυνδεθείτε. Ίσως "
 "χρειαστεί να ανανεώσετε τη διεύθυνση του υπολογιστή σας για να συνδεθείται "
 "ξανά στη συσκευή, ανάλογα με τις ρυθμίσεις σας."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -138,39 +138,39 @@ msgstr ""
 "του υπολογιστή σας για να συνδεθείτε ξανά στη συσκευή, ανάλογα με τις "
 "ρυθμίσεις σας."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
-"Το σύστημα απενεργοποιείται τώρα. <br /> ΜΗΝ ΑΠΕΝΕΡΓΟΠΟΙΗΣΕΤΕ ΤΗ ΣΥΣΚΕΥΗ! <"
-"br /> Ίσως χρειαστεί να ανανεώσετε τη διεύθυνση του υπολογιστή σας για να "
+"Το σύστημα απενεργοποιείται τώρα. <br /> ΜΗΝ ΑΠΕΝΕΡΓΟΠΟΙΗΣΕΤΕ ΤΗ ΣΥΣΚΕΥΗ! "
+"<br /> Ίσως χρειαστεί να ανανεώσετε τη διεύθυνση του υπολογιστή σας για να "
 "συνδεθείτε ξανά στη συσκευή, ανάλογα με τις ρυθμίσεις σας."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Δεν είναι δυνατή η εύρεση Διπλής καταχώρησης Σημαίας Εκκίνησης."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Αδύνατη λήψη μεταβλητής περιβάλλοντος υλικολογισμικού"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -221,9 +221,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/en/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/en/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/es/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/es/advanced-reboot.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Reinicio avanzado"
@@ -54,7 +54,7 @@ msgstr "Firmware"
 msgid "Loading"
 msgstr "Cargando"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Sin acceso a fw_printenv o fw_printenv!"
 
@@ -97,14 +97,14 @@ msgstr "Reiniciar a la partición alternativa ..."
 msgid "Reboot to current partition"
 msgstr "Reiniciar a la partición actual"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Reiniciando..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Apagando..."
 
@@ -116,7 +116,7 @@ msgstr "Estado"
 msgid "System"
 msgstr "Sistema"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -128,7 +128,7 @@ msgstr ""
 "sea necesario renovar la dirección de su computadora para llegar al "
 "dispositivo nuevamente, dependiendo de su configuración."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -141,7 +141,7 @@ msgstr ""
 "computadora para llegar al dispositivo nuevamente, dependiendo de su "
 "configuración."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -151,31 +151,31 @@ msgstr ""
 "Puede que sea necesario renovar la dirección de su computadora para llegar "
 "al dispositivo nuevamente, dependiendo de la configuración."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "No se puede encontrar la partición de bandera de arranque dual."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "No se puede obtener la variable de entorno de firmware"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 "No se puede establecer la entrada de la partición del indicador de inicio "
 "dual para la partición"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "No se puede establecer la variable de entorno de firmware"
 
@@ -241,10 +241,10 @@ msgstr "intentando montar una partición alternativa"
 msgid "attempting to unmount alternative partition"
 msgstr "intentando desmontar una partición alternativa"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "a"
 

--- a/applications/luci-app-advanced-reboot/po/fr/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/fr/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Redémarrage avancé"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Chargement"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Pas d'accès à fw_printenv ou fw_printenv !"
 
@@ -94,14 +94,14 @@ msgstr "Redémarrer sur une autre partition…"
 msgid "Reboot to current partition"
 msgstr "Redémarrer sur la partition courante"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Redémarrage…"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Arrêt en cours…"
 
@@ -113,7 +113,7 @@ msgstr "État"
 msgid "System"
 msgstr "Système"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -125,7 +125,7 @@ msgstr ""
 "fonction de vos paramètres, il peut être nécessaire de renouveler l'adresse "
 "IP de votre ordinateur pour accéder à nouveau à l'appareil."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -137,7 +137,7 @@ msgstr ""
 "reconnecter. En fonction de vos paramètres, il peut être nécessaire de "
 "renouveler votre adresse IP pour accéder à nouveau à votre appareil."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -147,29 +147,29 @@ msgstr ""
 "fonction de vos paramètres, il peut être nécessaire de renouveler votre "
 "adresse IP pour accéder à nouveau à votre appareil."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Impossible de trouver une partition en démarrage double."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Impossible de récupérer la variable d'environnement du micrologiciel"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "Impossible de définir l'entrée de démarrage double de la partition"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Impossible de définir la variable d'environnement du micrologiciel"
 
@@ -239,10 +239,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "vers"
 

--- a/applications/luci-app-advanced-reboot/po/he/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/he/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/hi/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/hi/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/hu/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/hu/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Speciális újraindítás"
@@ -51,7 +51,7 @@ msgstr "Firmware"
 msgid "Loading"
 msgstr "Betöltés"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 "Nincs hozzáférés az fw_printenv vagy az fw_printenv környezeti változókhoz!"
@@ -95,14 +95,14 @@ msgstr "Újraindítás alternatív partíción…"
 msgid "Reboot to current partition"
 msgstr "Újraindítás a jelenlegi partíción"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Újraindítás…"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Leállítás…"
 
@@ -114,7 +114,7 @@ msgstr "Állapot"
 msgid "System"
 msgstr "Rendszer"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -126,7 +126,7 @@ msgstr ""
 "szükség lehet a számítógépe címének megújításához, hogy újra elérje az "
 "eszközt."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -138,7 +138,7 @@ msgstr ""
 "beállításoktól függően szükség lehet a számítógépe címének megújításához, "
 "hogy újra elérje az eszközt."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -148,31 +148,31 @@ msgstr ""
 "beállításoktól függően szükség lehet a számítógépe címének megújításához, "
 "hogy újra elérje az eszközt."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Nem található kettős rendszerindítási jelző partíció."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Nem lehet megszerezni a firmware környezeti változóját"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 "Nem lehet beállítani a kettős rendszerindítási jelző partíció bejegyzését a "
 "partíciónál"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Nem lehet beállítani a firmware környezeti változóját"
 
@@ -193,8 +193,8 @@ msgstr ""
 "állítania a számítógép beállításait, hogy képes legyen elérni az eszközt, "
 "amikor az újraindul.<br /><br /> Vegye figyelembe azt is, hogy az alternatív "
 "partíció firmware-je esetleg nem biztosít egyszerű módot az aktív partíció "
-"átváltásához és a jelenleg aktív partícióra történő visszalépéshez.<br /><br "
-"/> Kattintson a lenti „Folytatás” gombra az eszköz újraindításához egy "
+"átváltásához és a jelenleg aktív partícióra történő visszalépéshez.<br /"
+"><br /> Kattintson a lenti „Folytatás” gombra az eszköz újraindításához egy "
 "alternatív partíción."
 
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm:12
@@ -238,9 +238,9 @@ msgstr "kísérlet az alternatív partíció csatolására"
 msgid "attempting to unmount alternative partition"
 msgstr "kísérlet az alternatív partíció leválasztására"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "erre:"

--- a/applications/luci-app-advanced-reboot/po/it/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/it/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -94,14 +94,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr "Stato"
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -121,7 +121,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -129,36 +129,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -209,10 +209,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""
 

--- a/applications/luci-app-advanced-reboot/po/ja/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/ja/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/ko/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/ko/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/mr/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/mr/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "प्रगत रीबूट"
@@ -51,7 +51,7 @@ msgstr "फर्मवेअर"
 msgid "Loading"
 msgstr "लोड करीत आहे"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -94,14 +94,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -121,7 +121,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -129,36 +129,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -209,9 +209,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/ms/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/ms/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/nb_NO/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/nb_NO/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -94,14 +94,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -121,7 +121,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -129,36 +129,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -209,10 +209,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""
 

--- a/applications/luci-app-advanced-reboot/po/pl/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/pl/advanced-reboot.po
@@ -11,7 +11,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Zaawansowany restart"
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Ładowanie"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Brak dostępu do fw_printenv lub fw_setenv!"
 
@@ -95,14 +95,14 @@ msgstr "Ponowne uruchomienie do innej partycji..."
 msgid "Reboot to current partition"
 msgstr "Ponowne uruchomienie na obecnej partycji"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Ponowne uruchamianie..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Zamykanie..."
 
@@ -114,7 +114,7 @@ msgstr "Status"
 msgid "System"
 msgstr "System"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -126,7 +126,7 @@ msgstr ""
 "połączenia. W zależności od ustawień może być konieczne odnowienie adresu "
 "komputera, aby ponownie połączyć się z urządzeniem."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -138,7 +138,7 @@ msgstr ""
 "nawiązania połączenia. W zależności od ustawień może być konieczne "
 "odnowienie adresu komputera, aby ponownie połączyć się z urządzeniem."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -149,30 +149,30 @@ msgstr ""
 "zależności od ustawień może być konieczne odnowienie adresu komputera, aby "
 "ponownie połączyć się z urządzeniem."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Nie można odnaleźć partycji z flagą Dual Boot."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Nie można uzyskać zmiennej środowiskowej oprogramowania układowego"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 "Nie można ustawić wpisu flagi partycji podwójnego rozruchu dla partycji"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Nie można ustawić zmiennej środowiskowej oprogramowania układowego"
 
@@ -239,10 +239,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "do"
 

--- a/applications/luci-app-advanced-reboot/po/pt/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/pt/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Reinicio Avançado"
@@ -51,7 +51,7 @@ msgstr "Firmware"
 msgid "Loading"
 msgstr "A carregar"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Sem acesso ao fw_printenv ou ao fw_printenv!"
 
@@ -94,14 +94,14 @@ msgstr "Reiniciar para uma partição alternativa..."
 msgid "Reboot to current partition"
 msgstr "Reiniciar para a partição atual"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "A reiniciar..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "A encerrar..."
 
@@ -113,7 +113,7 @@ msgstr "Estado"
 msgid "System"
 msgstr "Sistema"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -125,7 +125,7 @@ msgstr ""
 "renovar o endereço do seu computador para aceder ao dispositivo de novo, "
 "dependendo das suas definições."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -137,7 +137,7 @@ msgstr ""
 "Pode ser necessário renovar o endereço do seu computador para aceder ao "
 "dispositivo de novo, dependendo das suas definições."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -148,29 +148,29 @@ msgstr ""
 "renovar o endereço do seu computador para aceder ao dispositivo de novo, "
 "dependendo das suas definições."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Não foi encontrada a Flag Dual Boot Partition."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Não foi possível obter a variável de ambiente do firmware"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "Não foi possível definir a Flag Dual Boot Partition para a partição"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Não foi possível definir a variável de ambiente do firmware"
 
@@ -236,10 +236,10 @@ msgstr "tentando montar partição alternativa"
 msgid "attempting to unmount alternative partition"
 msgstr "tentando desmontar uma partição alternativa"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "para"
 

--- a/applications/luci-app-advanced-reboot/po/pt_BR/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/pt_BR/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Reinicio Avançado"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Carregando"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Sem acesso ao fw_printenv ou fw_printenv!"
 
@@ -94,14 +94,14 @@ msgstr "Reiniciando em uma partição diferente..."
 msgid "Reboot to current partition"
 msgstr "Reiniciar na partição atual"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Reiniciando..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Desligando..."
 
@@ -113,7 +113,7 @@ msgstr "Condição"
 msgid "System"
 msgstr "Sistema"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -126,7 +126,7 @@ msgstr ""
 "trocar o endereço IP do seu computador dependendo das configurações "
 "realizadas."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -139,40 +139,40 @@ msgstr ""
 "necessário renovar ou trocar o endereço IP do seu computador dependendo das "
 "configurações realizadas."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
-"O sistema está sendo desligado.<br /> NÃO DESLIGUE A FORÇA DO DISPOSITIVO!<"
-"br /> Para ter acesso ao dispositivo novamente, pode ser necessário renovar "
+"O sistema está sendo desligado.<br /> NÃO DESLIGUE A FORÇA DO DISPOSITIVO!"
+"<br /> Para ter acesso ao dispositivo novamente, pode ser necessário renovar "
 "ou trocar o endereço IP do seu computador dependendo das configurações "
 "realizadas."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Não foi possível encontrar a partição Dual Boot Flag."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Não foi possível obter a variável de ambiente para o firmware"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "Não foi possível definir a entrada Dual Boot Flag na partição"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Não foi possível definir a variável de ambiente para o firmware"
 
@@ -238,9 +238,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "para"

--- a/applications/luci-app-advanced-reboot/po/ro/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/ro/advanced-reboot.po
@@ -11,7 +11,7 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Repornire Avansata"
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Incarcare"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Nu aveți acces la fw_printenv sau fw_printenv!"
 
@@ -95,14 +95,14 @@ msgstr "Reporniți in partiția alternativă"
 msgid "Reboot to current partition"
 msgstr "Reporniți in partitia curenta"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Reporneste"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Oprire"
 
@@ -114,7 +114,7 @@ msgstr "stsatus"
 msgid "System"
 msgstr "Sistem"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -126,7 +126,7 @@ msgstr ""
 "necesar să reînoiți adresa computerului pentru a ajunge din nou la "
 "dispozitiv, în funcție de setările dvs."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -138,7 +138,7 @@ msgstr ""
 "reconectați. Poate fi necesar să reînnoiți adresa computerului pentru a "
 "ajunge din nou la dispozitiv, în funcție de setările dvs."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -148,29 +148,29 @@ msgstr ""
 "putea fi necesar să reînnoiești adresa computerului pentru a ajunge din nou "
 "la dispozitiv, în funcție de setările tale."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Imposibil de găsit partiția Dual Boot"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -221,10 +221,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""
 

--- a/applications/luci-app-advanced-reboot/po/ru/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/ru/advanced-reboot.po
@@ -14,7 +14,7 @@ msgstr ""
 "4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Дополнительная перезагрузка"
@@ -55,7 +55,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Загружаем"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Нет доступа к fw_printenv или fw_printenv!"
 
@@ -98,14 +98,14 @@ msgstr "Перезагрузить до альтернативного разд�
 msgid "Reboot to current partition"
 msgstr "Перезагрузка к текущему разделу"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Перезагрузка..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Отключается..."
 
@@ -117,7 +117,7 @@ msgstr "Состояние"
 msgid "System"
 msgstr "Система"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -129,7 +129,7 @@ msgstr ""
 "снова. Возможно, потребуется обновить адрес компьютера для повторного "
 "доступа к устройству в зависимости от ваших настроек."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -141,7 +141,7 @@ msgstr ""
 "установить соединение снова. Возможно, потребуется обновить адрес компьютера "
 "для повторного доступа к устройству в зависимости от ваших настроек."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -151,29 +151,29 @@ msgstr ""
 "Возможно, потребуется обновить адрес компьютера для повторного доступа к "
 "устройству в зависимости от настроек."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Невозможно найти Dual Boot раздел."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Невозможно получить переменную среды прошивки"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "Невозможно использовать Dual Boot раздел."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Невозможно установить переменную среды прошивки"
 
@@ -239,10 +239,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "в"
 

--- a/applications/luci-app-advanced-reboot/po/sk/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/sk/advanced-reboot.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -88,14 +88,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -115,7 +115,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -123,36 +123,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -203,9 +203,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/sv/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/sv/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Avancerad omstart"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Laddar"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -94,14 +94,14 @@ msgstr "Starta om till alternativ partition..."
 msgid "Reboot to current partition"
 msgstr "Starta om till nuvarande partition"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Startar om..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Stänger av..."
 
@@ -113,7 +113,7 @@ msgstr "Status"
 msgid "System"
 msgstr "System"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -121,7 +121,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -129,7 +129,7 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -139,29 +139,29 @@ msgstr ""
 "inställningar så kan det vara nödvändigt att förnya din dators adress för "
 "att nå enheten igen."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -216,10 +216,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""
 

--- a/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
+++ b/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -42,7 +42,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -85,14 +85,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -104,7 +104,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -112,7 +112,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -120,36 +120,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -200,9 +200,9 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/po/tr/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/tr/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Gelişmiş Yeniden Başlatma"
@@ -51,7 +51,7 @@ msgstr "Cihaz yazılımı"
 msgid "Loading"
 msgstr "Yükleniyor"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "fw_printenv e veya fw_printenv e erişim yok!"
 
@@ -94,14 +94,14 @@ msgstr "alternatif bölüm için yeniden başlat..."
 msgid "Reboot to current partition"
 msgstr "Mevcut bölüm için yeniden başlat"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Yeniden Başlatılıyor..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Kapatılıyor..."
 
@@ -113,7 +113,7 @@ msgstr "Durum"
 msgid "System"
 msgstr "Sistem"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -125,7 +125,7 @@ msgstr ""
 "yeniden cihaza erişebilmeniz için, bilgisayar adresinin yenilenmesinde "
 "gereklidir."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -137,36 +137,36 @@ msgstr ""
 "Ayarlarınıza bağlı olarak, aygıta tekrar erişmek için bilgisayarınızın "
 "adresini yenilemeniz gerekebilir."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Dual Boot Flag bölümü bulunamadı."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Firmware ortam değişkenine ulaşılamıyor"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -217,10 +217,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "a"
 

--- a/applications/luci-app-advanced-reboot/po/uk/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/uk/advanced-reboot.po
@@ -11,7 +11,7 @@ msgstr ""
 "4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Розширене перезавантаження"
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Завантаження"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -95,14 +95,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Перезавантаження..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr "Стан"
 msgid "System"
 msgstr "Система"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -122,7 +122,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -130,36 +130,36 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr ""
 
@@ -211,10 +211,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr ""
 

--- a/applications/luci-app-advanced-reboot/po/vi/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/vi/advanced-reboot.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "Khởi động nâng cao"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Loading"
 msgstr "Đang tải"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "Không thể truy cập tới fw_printenv!"
 
@@ -94,14 +94,14 @@ msgstr "Đang khởi động vào phân vùng thay thế..."
 msgid "Reboot to current partition"
 msgstr "Khởi động lại vào phần vùng hiện tại"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Đang khởi động lại..."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "Đang tắt nguồn..."
 
@@ -113,7 +113,7 @@ msgstr "Trạng thái"
 msgid "System"
 msgstr "Hệ thống"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -125,7 +125,7 @@ msgstr ""
 "phải cập nhật lại địa chỉ máy tính để kết nối lại với thiết bị, phụ thuộc "
 "vào cài đặt máy tính."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -137,7 +137,7 @@ msgstr ""
 "nối lại. Bạn có thể cần phải cập nhật lại địa chỉ máy tính để kết nối lại "
 "với thiết bị, phụ thuộc vào cài đặt máy tính."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -147,29 +147,29 @@ msgstr ""
 "<br /> Bạn có thể cần phải cập nhật lại địa chỉ máy tính để kết nối lại với "
 "thiết bị, phụ thuộc vào cài đặt máy tính."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "Không tìm thấy phân vùng khởi động kép."
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "Không thể lấy được biến bộ nạp khởi động"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "Không thể cài phân vùng khởi động kép"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "Không thể cài biến môi trường khởi động"
 
@@ -222,10 +222,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "đến"
 

--- a/applications/luci-app-advanced-reboot/po/zh-cn/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/zh-cn/advanced-reboot.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "高级重启"
@@ -57,7 +57,7 @@ msgstr "固件"
 msgid "Loading"
 msgstr "加载中"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "无法访问 fw_printenv 或 fw_printenv！"
 
@@ -100,14 +100,14 @@ msgstr "重启到备用分区…"
 msgid "Reboot to current partition"
 msgstr "重启到当前分区"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "正在重启…"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "正在关机…"
 
@@ -119,7 +119,7 @@ msgstr "状态"
 msgid "System"
 msgstr "系统"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -129,7 +129,7 @@ msgstr ""
 "系统正在重启。<br />切勿关闭电源！ DO NOT POWER OFF THE DEVICE!<br />等待数分"
 "钟后即可尝试重新连接到路由。您可能需要更改计算机的 IP 地址以重新连接。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -140,7 +140,7 @@ msgstr ""
 "<br />等待数分钟后即可尝试重新连接到路由。您可能需要更改计算机的 IP 地址以重"
 "新连接。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -149,29 +149,29 @@ msgstr ""
 "系统现在正在关机。<br />切勿关闭电源！ DO NOT POWER OFF THE DEVICE!<br />等待"
 "数分钟后即可尝试重新连接到路由。您可能需要更改计算机的 IP 地址以重新连接。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "无法找到双引导标志分区。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "无法获取固件环境变量"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "无法为分区设置双引导标志分区项"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "无法设置固件环境变量"
 
@@ -228,10 +228,10 @@ msgstr "正在尝试装载备用分区"
 msgid "attempting to unmount alternative partition"
 msgstr "正在尝试卸载备用分区"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "至"
 

--- a/applications/luci-app-advanced-reboot/po/zh-tw/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/zh-tw/advanced-reboot.po
@@ -11,7 +11,7 @@ msgstr ""
 "PO-Revision-Date: 2018-08-07 20:31+0800\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:189
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr "高階重啟"
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:231
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr "無法訪問 fw_printenv 或 fw_printenv！"
 
@@ -95,14 +95,14 @@ msgstr "重啟到備用分割槽…"
 msgid "Reboot to current partition"
 msgstr "重啟到當前分割槽"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:210
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:282
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "正在重啟…"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:315
 msgid "Shutting down..."
 msgstr "正在關機…"
 
@@ -114,7 +114,7 @@ msgstr "狀態"
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:211
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -124,7 +124,7 @@ msgstr ""
 "系統正在重啟。<br />切勿關閉電源！ DO NOT POWER OFF THE DEVICE!<br />等待數分"
 "鍾後即可嘗試重新連線到路由。您可能需要更改計算機的 IP 位址以重新連線。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:283
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -135,7 +135,7 @@ msgstr ""
 "DEVICE!<br />等待數分鐘後即可嘗試重新連線到路由。您可能需要更改計算機的 IP 地"
 "址以重新連線。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:316
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
@@ -144,29 +144,29 @@ msgstr ""
 "系統現在正在關機。<br />切勿關閉電源！ DO NOT POWER OFF THE DEVICE!<br />等待"
 "數分鐘後即可嘗試重新連線到路由。您可能需要更改計算機的 IP 位址以重新連線。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:156
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:157
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:266
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:267
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr "無法找到雙引導標誌分割槽。"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:238
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:239
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:252
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:253
 msgid "Unable to obtain firmware environment variable"
 msgstr "無法獲取韌體環境變數"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:274
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:275
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr "無法為分割槽設定雙引導標誌分割槽項"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "Unable to set firmware environment variable"
 msgstr "無法設定韌體環境變數"
 
@@ -224,10 +224,10 @@ msgstr ""
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:244
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:245
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:258
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:259
 msgid "to"
 msgstr "至"
 

--- a/applications/luci-app-ddns/po/pl/ddns.po
+++ b/applications/luci-app-ddns/po/pl/ddns.po
@@ -18,6 +18,11 @@ msgstr ""
 msgid "\"../\" not allowed in path for Security Reason."
 msgstr "„../” jest niedozwolone ze względów bezpieczeństwa."
 
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:294
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:323
+msgid "Add new services..."
+msgstr ""
+
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
@@ -44,7 +49,8 @@ msgstr "BusyBox nslookup i Wget nie obsługują określania"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:261
 msgid "BusyBox's nslookup and hostip do not support to specify to use TCP"
-msgstr "Nslookup, hostip i BusyBox nie obsługują określania używanego przez TCP"
+msgstr ""
+"Nslookup, hostip i BusyBox nie obsługują określania używanego przez TCP"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:272
 msgid "BusyBox's nslookup in the current compiled version"
@@ -58,8 +64,7 @@ msgstr "Anuluj"
 msgid "Check Interval"
 msgstr "Interwał sprawdzania"
 
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/overview.lua:102
-#: applications/luci-app-ddns/luasrc/view/ddns/system_status.htm:48
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/status/include/70_ddns.js:26
 msgid "Configuration"
 msgstr "Konfiguracja"
 
@@ -218,9 +223,9 @@ msgstr "Błąd interwału powtórzeń"
 msgid "Event Network"
 msgstr "Zdarzenia sieciowe"
 
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:469
-msgid "File not found"
-msgstr "Nie znaleziono pliku"
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:654
+msgid "Example for IPv4"
+msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:655
 msgid "Example for IPv6"
@@ -232,7 +237,8 @@ msgstr "Plik"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:929
 msgid "For detailed information about parameter settings look here."
-msgstr "Szczegółowe informacje na temat ustawień parametrów znajdują się tutaj."
+msgstr ""
+"Szczegółowe informacje na temat ustawień parametrów znajdują się tutaj."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:944
 msgid "For supported codes look here"
@@ -266,7 +272,8 @@ msgstr "Format: IP lub FQDN"
 msgid ""
 "GNU Wget will use the IP of given network, cURL will use the physical "
 "interface."
-msgstr "GNU Wget użyje adresu IP danej sieci, cURL użyje fizycznego interfejsu."
+msgstr ""
+"GNU Wget użyje adresu IP danej sieci, cURL użyje fizycznego interfejsu."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:923
 msgid "Global Configuration"
@@ -310,13 +317,7 @@ msgstr "IPv6 nie jest obsługiwany"
 msgid "IPv6-Address"
 msgstr "Adres IPv6"
 
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua:114
-msgid "If both cURL and GNU Wget are installed, Wget is used by default."
-msgstr ""
-"Jeśli zainstalowano jednocześnie cURL i GNU Wget, Wget jest używany "
-"domyślnie."
-
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:272
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:977
 msgid ""
 "If Wget and cURL package are installed, Wget is used for communication by "
 "default."
@@ -346,6 +347,10 @@ msgstr ""
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:774
 msgid "Info"
 msgstr "Informacja"
+
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:150
+msgid "Information"
+msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:286
 msgid "Install 'ca-certificates' package or needed certificates"
@@ -409,9 +414,10 @@ msgstr "Loguj do logu systemowego (syslog)"
 msgid "Lookup Hostname"
 msgstr "Nazwa Hosta Serwera"
 
-#: applications/luci-app-ddns/luasrc/controller/ddns.lua:101
-msgid "NOT installed"
-msgstr "Nie zainstalowany"
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:311
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:388
+msgid "Name"
+msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:224
 msgid ""
@@ -473,6 +479,11 @@ msgstr "Brak logowania"
 msgid "Non-public and by default blocked IP's"
 msgstr "Niepubliczne i domyślnie zablokowane IP"
 
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:92
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:433
+msgid "Not Running"
+msgstr ""
+
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:775
 msgid "Notice"
 msgstr "Spostrzeżenie"
@@ -483,7 +494,8 @@ msgstr "Liczba ostatnich wierszy przechowywanych w plikach dziennika"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:723
 msgid "OPTIONAL: Force the usage of pure IPv4/IPv6 only communication."
-msgstr "OPCJONALNIE: Wymuś użycie komunikacji opartej wyłącznie na IPv4 / IPv6."
+msgstr ""
+"OPCJONALNIE: Wymuś użycie komunikacji opartej wyłącznie na IPv4 / IPv6."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:747
 msgid "OPTIONAL: Force the use of TCP instead of default UDP on DNS requests."
@@ -500,8 +512,8 @@ msgstr "OPCJONALNIE: Serwer proxy do wykrywania i aktualizacji."
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:734
 msgid "OPTIONAL: Use non-default DNS-Server to detect 'Registered IP'."
 msgstr ""
-"OPCJONALNIE: Użyj serwera DNS innego niż domyślny, aby wykryć „"
-"Zarejestrowany adres IP”."
+"OPCJONALNIE: Użyj serwera DNS innego niż domyślny, aby wykryć "
+"„Zarejestrowany adres IP”."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:882
 msgid "On Error the script will retry the failed action after given time"
@@ -587,6 +599,11 @@ msgstr "Resetuj DDns"
 msgid "Run once"
 msgstr "Uruchom raz"
 
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:103
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:436
+msgid "Running"
+msgstr ""
+
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:610
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:672
 msgid "Script"
@@ -651,8 +668,8 @@ msgid ""
 "This is the default if you run DDNS scripts by yourself (i.e. via cron with "
 "force_interval set to '0')"
 msgstr ""
-"To jest ustawienie domyślne, jeśli uruchamiasz skrypty DDNS samodzielnie ("
-"tj. Za pomocą crona z force_interval ustawionym na „0”)"
+"To jest ustawienie domyślne, jeśli uruchamiasz skrypty DDNS samodzielnie "
+"(tj. Za pomocą crona z force_interval ustawionym na „0”)"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:699
 msgid "This will be autoset to the selected interface"
@@ -703,6 +720,10 @@ msgstr "Używanie określonego serwera DNS nie jest obsługiwane"
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:804
 msgid "Values below 5 minutes == 300 seconds are not supported"
 msgstr "Wartości poniżej 5 minut == 300 sekund nie są obsługiwane"
+
+#: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:841
+msgid "Values lower 'Check Interval' except '0' are not supported"
+msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:13
 msgid "Verify"
@@ -813,7 +834,19 @@ msgstr "sekundy"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:591
 msgid "to run HTTPS without verification of server certificates (insecure)"
-msgstr "uruchomić HTTPS bez weryfikacji certyfikatów serwera (niezabezpieczony)"
+msgstr ""
+"uruchomić HTTPS bez weryfikacji certyfikatów serwera (niezabezpieczony)"
+
+#~ msgid "File not found"
+#~ msgstr "Nie znaleziono pliku"
+
+#~ msgid "If both cURL and GNU Wget are installed, Wget is used by default."
+#~ msgstr ""
+#~ "Jeśli zainstalowano jednocześnie cURL i GNU Wget, Wget jest używany "
+#~ "domyślnie."
+
+#~ msgid "NOT installed"
+#~ msgstr "Nie zainstalowany"
 
 #~ msgid "-- custom --"
 #~ msgstr "-- własne --"

--- a/applications/luci-app-ddns/po/pl/ddns.po
+++ b/applications/luci-app-ddns/po/pl/ddns.po
@@ -18,11 +18,6 @@ msgstr ""
 msgid "\"../\" not allowed in path for Security Reason."
 msgstr "„../” jest niedozwolone ze względów bezpieczeństwa."
 
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:562
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:591
-msgid "-- custom --"
-msgstr "-- własne --"
-
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
@@ -62,10 +57,6 @@ msgstr "Anuluj"
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:794
 msgid "Check Interval"
 msgstr "Interwał sprawdzania"
-
-#: applications/luci-app-ddns/luasrc/view/ddns/system_status.htm:55
-msgid "Collecting data..."
-msgstr "Trwa zbieranie danych..."
 
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/overview.lua:102
 #: applications/luci-app-ddns/luasrc/view/ddns/system_status.htm:48
@@ -226,10 +217,6 @@ msgstr "Błąd interwału powtórzeń"
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:692
 msgid "Event Network"
 msgstr "Zdarzenia sieciowe"
-
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:1295
-msgid "File"
-msgstr "Plik"
 
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:469
 msgid "File not found"
@@ -486,10 +473,6 @@ msgstr "Brak logowania"
 msgid "Non-public and by default blocked IP's"
 msgstr "Niepubliczne i domyślnie zablokowane IP"
 
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:1284
-msgid "Notice"
-msgstr "Spostrzeżenie"
-
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:775
 msgid "Notice"
 msgstr "Spostrzeżenie"
@@ -604,16 +587,10 @@ msgstr "Resetuj DDns"
 msgid "Run once"
 msgstr "Uruchom raz"
 
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:667
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:717
-#: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:981
-msgid "Script"
-msgstr "Skrypt"
-
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:610
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:672
 msgid "Script"
-msgstr ""
+msgstr "Skrypt"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:291
 msgid "Services"
@@ -726,12 +703,6 @@ msgstr "Używanie określonego serwera DNS nie jest obsługiwane"
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:804
 msgid "Values below 5 minutes == 300 seconds are not supported"
 msgstr "Wartości poniżej 5 minut == 300 sekund nie są obsługiwane"
-
-#: applications/luci-app-ddns/luasrc/controller/ddns.lua:95
-#: applications/luci-app-ddns/luasrc/controller/ddns.lua:97
-#: applications/luci-app-ddns/luasrc/controller/ddns.lua:100
-msgid "Version"
-msgstr "Wersja"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:13
 msgid "Verify"

--- a/applications/luci-app-firewall/po/bg/firewall.po
+++ b/applications/luci-app-firewall/po/bg/firewall.po
@@ -47,8 +47,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -83,12 +83,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -136,15 +136,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -183,7 +183,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -325,12 +325,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -339,7 +339,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -382,11 +382,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -396,17 +396,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -439,7 +439,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -501,7 +501,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -557,41 +557,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -621,15 +621,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -649,19 +649,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -674,8 +674,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -703,11 +703,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -730,12 +730,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -762,11 +762,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -793,7 +793,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/ca/firewall.po
+++ b/applications/luci-app-firewall/po/ca/firewall.po
@@ -52,8 +52,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Acció"
 
@@ -71,7 +71,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Ajusts avançats"
@@ -88,12 +88,12 @@ msgstr "Permet el reenviament des dels <em>zones d'origen</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Permet el reenviament als <em>zones de destí</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Qualsevol"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -145,15 +145,15 @@ msgstr ""
 "ordres s'executen després de cada reinici de tallafocs, just després el "
 "conjunt de regles per defecte s'ha carregat."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Adreça de destí"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Port de destí"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Zona de destí"
 
@@ -192,7 +192,7 @@ msgid "Drop invalid packets"
 msgstr "Descarta els paquets invàlids"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Activa"
 
@@ -225,7 +225,7 @@ msgid "External port"
 msgstr "Port extern"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Paràmetres extres"
 
@@ -253,7 +253,7 @@ msgstr "Tallafocs - Regles personalitzades"
 msgid "Firewall - Port Forwards"
 msgstr "Tallafocs - Reenviaments de port"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Tallafocs - Regles de tràfic"
 
@@ -270,7 +270,7 @@ msgstr "Reenvia"
 msgid "Forward to"
 msgstr "Reenvia a"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Divendres"
 
@@ -302,7 +302,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -330,12 +330,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 i IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Només IPv4"
@@ -344,7 +344,7 @@ msgstr "Només IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Només IPv6"
@@ -387,11 +387,11 @@ msgid "Masquerading"
 msgstr "Mascarada"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Coincideix"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Coincideix amb el tipus ICMP"
 
@@ -403,17 +403,17 @@ msgstr ""
 "Coincideix amb trànsit entrant dirigit al port o rang de ports de destí en "
 "aquest host donat"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Dilluns"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nom"
@@ -448,7 +448,7 @@ msgid "Output"
 msgstr "Sortida"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "Passa paràmetres addicionals al iptables. Utilitzeu-ho amb cura!"
 
@@ -475,7 +475,7 @@ msgstr ""
 "connectin a un ordinador o servei específic dins del LAN privat."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -512,7 +512,7 @@ msgstr "Restringeix la mascarada a les subxarxes de destí donades"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Restringeix la mascarada a les subxarxes d'origen donades"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Restringeix a la família d'adreces"
@@ -521,7 +521,7 @@ msgstr "Restringeix a la família d'adreces"
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Dissabte"
 
@@ -538,41 +538,41 @@ msgid "Source IP address"
 msgstr "Adreça IP d'origen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Adreça MAC d'origen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Adreça d'origen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Port d'origen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zona d'origen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Diumenge"
 
@@ -617,15 +617,15 @@ msgstr ""
 "<em>Xarxes cobertes</em> especifica quines xarxes disponibles són membres "
 "d'aquesta zona."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Dijous"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -645,12 +645,12 @@ msgstr "A %s en <var>aquest dispositiu</var>"
 msgid "To %s, %s in %s"
 msgstr "A %s, %s en %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Regles de trànsit"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -660,7 +660,7 @@ msgstr ""
 "zones distintes, per exemple per a rebutjar trànsit entre certs hosts o "
 "obrir ports WAN en el encaminador."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Dimarts"
 
@@ -673,8 +673,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -702,11 +702,11 @@ msgstr "Via %s"
 msgid "Via %s at %s"
 msgstr "Via %s a %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Dimecres"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr "Zona ⇒ Reenviaments"
 msgid "Zones"
 msgstr "Zones"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -729,12 +729,12 @@ msgstr "accepta"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "qualsevol"
 
@@ -761,11 +761,11 @@ msgstr "qualsevol zona"
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "no rastregis"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -792,7 +792,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/cs/firewall.po
+++ b/applications/luci-app-firewall/po/cs/firewall.po
@@ -48,8 +48,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Akce"
 
@@ -67,7 +67,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Pokročilé nastavení"
@@ -84,12 +84,12 @@ msgstr "Povolit přesměrování ze <em>zdrojových oblastí</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Povolit přesměrování do <em>zdrojových oblastí</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Libovolné"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -140,15 +140,15 @@ msgstr ""
 "nejsou jinak pokryté frameworkem firewallu. Příkazy jsou spuštěny po každém "
 "restartu firewallu, právě po načtení výchozí sady pravidel."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Cílová adresa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Cílový port"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Cílová zóna"
 
@@ -187,7 +187,7 @@ msgid "Drop invalid packets"
 msgstr "Zahazovat neplatné pakety"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Povolit"
 
@@ -220,7 +220,7 @@ msgid "External port"
 msgstr "Vnější port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Další argumenty volání"
 
@@ -248,7 +248,7 @@ msgstr "Firewall - Vlastní pravidla"
 msgid "Firewall - Port Forwards"
 msgstr "Firewall - Přesměrování portů"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Firewall - Pravidla síťového provozu"
 
@@ -265,7 +265,7 @@ msgstr "Přesměrování"
 msgid "Forward to"
 msgstr "Přesměrovat na"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Pátek"
 
@@ -297,7 +297,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -325,12 +325,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 a IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "pouze IPv4"
@@ -339,7 +339,7 @@ msgstr "pouze IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "pouze IPv6"
@@ -382,11 +382,11 @@ msgid "Masquerading"
 msgstr "Maškárádování"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Shoda"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Odpovídá ICMP typu"
 
@@ -398,17 +398,17 @@ msgstr ""
 "Vybrat příchozí provoz, směrovaný na zadaný cílový port nebo rozsah portů "
 "tohoto hostitele"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Pondělí"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Dny v měsíci"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Název"
@@ -443,7 +443,7 @@ msgid "Output"
 msgstr "Výstup"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "Předává další argumenty iptables. Používat opatrně!"
 
@@ -471,7 +471,7 @@ msgstr ""
 "LAN."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protokol"
 
@@ -509,7 +509,7 @@ msgstr "Omezit maškarádování na uvedené cílové podsítě"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Omezit maškarádování na uvedené zdrojové podsítě"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Omezit na rodinu adres"
@@ -518,7 +518,7 @@ msgstr "Omezit na rodinu adres"
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Sobota"
 
@@ -535,41 +535,41 @@ msgid "Source IP address"
 msgstr "Zdrojová IP adresa"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Zdrojová MAC adresa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Zdrojová adresa"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Zdrojový port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zdrojová zóna"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Neděle"
 
@@ -612,15 +612,15 @@ msgstr ""
 "pro přesměrování provozu mezi rozdílnými sítěmi uvnitř jedné zóny. "
 "<em>Pokryté sítě</em> určuje, které z dostupných sítí jsou členy této zóny."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Čtvrtek"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Časová omezení"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Čas v UTC"
 
@@ -640,12 +640,12 @@ msgstr "Na %s na <var>tomto zařízení</var>"
 msgid "To %s, %s in %s"
 msgstr "Na %s, %s v %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Pravidla síťového provozu"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -655,7 +655,7 @@ msgstr ""
 "různými zónami, například pro odmítnutí provozu mezi jistými hostiteli nebo "
 "pro otevření WAN portů na routeru."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Úterý"
 
@@ -668,8 +668,8 @@ msgstr "Nelze uložit obsah: %s"
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Nepojmenované pravidlo"
 
@@ -697,11 +697,11 @@ msgstr "Prostřednictvím %s"
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Středa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -713,7 +713,7 @@ msgstr "Zóna ⇒ Přesměrování"
 msgid "Zones"
 msgstr "Zóny"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -724,12 +724,12 @@ msgstr "přijmout"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "libovolný"
 
@@ -756,11 +756,11 @@ msgstr "libovolná zóna"
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "nesledovat"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -787,7 +787,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/de/firewall.po
+++ b/applications/luci-app-firewall/po/de/firewall.po
@@ -50,8 +50,8 @@ msgstr "Eingang akzeptieren"
 msgid "Accept output"
 msgstr "Ausgang akzeptieren"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Aktion"
 
@@ -75,7 +75,7 @@ msgstr ""
 "eingehenden HTTPS-Verkehr übereinstimmen zu lassen."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
@@ -92,12 +92,12 @@ msgstr "Erlaube Weiterleitung von <em>Quellzone</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Erlaube Weiterleitung zu <em>Zielzone</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Beliebig"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Beliebig"
 
@@ -151,15 +151,15 @@ msgstr ""
 "Befehle werden mit jedem Firewall-Neustart abgearbeitet, direkt nach dem "
 "Laden der Basisregeln."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Zieladresse"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Zielport"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Ziel-Zone"
 
@@ -201,7 +201,7 @@ msgid "Drop invalid packets"
 msgstr "Ungültige Pakete verwerfen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Aktivieren"
 
@@ -235,7 +235,7 @@ msgid "External port"
 msgstr "Externer Port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Zusätzliche Argumente"
 
@@ -263,7 +263,7 @@ msgstr "Firewall - Benutzerdefinierte Regeln"
 msgid "Firewall - Port Forwards"
 msgstr "Firewall - Portweiterleitungen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Firewall - Traffic-Regeln"
 
@@ -280,7 +280,7 @@ msgstr "Weitergeleitet"
 msgid "Forward to"
 msgstr "Weiterleiten an"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Freitag"
 
@@ -312,7 +312,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "Von %s auf <var>dieses Gerät</var> mit Quelle %s und %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -340,12 +340,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 und IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "nur IPv4"
@@ -354,7 +354,7 @@ msgstr "nur IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "nur IPv6"
@@ -397,11 +397,11 @@ msgid "Masquerading"
 msgstr "NAT aktivieren"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Filter"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Nach ICMP-Typ filtern"
 
@@ -413,17 +413,17 @@ msgstr ""
 "Eingehende Verbindungen filtern welche an den angegebenen Port oder "
 "Portbereich auf dem lokalen Gerät gerichtet sind"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Montag"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Monatstage"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Name"
@@ -458,7 +458,7 @@ msgid "Output"
 msgstr "Ausgehend"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 "Gibt zusätzliche Kommandozeilenargumente an iptables weiter. Mit Vorsicht "
@@ -493,7 +493,7 @@ msgstr ""
 "bestimmte Computer oder Dienste im lokalen LAN zuzugreifen."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -533,7 +533,7 @@ msgstr "NAT auf die angegebenen Ziel-Subnetze beschränken"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "NAT auf die angegebenen Quell-Subnetze beschränken"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Beschränke auf Adressfamilie"
@@ -542,7 +542,7 @@ msgstr "Beschränke auf Adressfamilie"
 msgid "Routing/NAT Offloading"
 msgstr "Routing/NAT-Beschleunigung"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Samstag"
 
@@ -559,41 +559,41 @@ msgid "Source IP address"
 msgstr "Quell-IP-Adresse"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Quell-MAC-Adresse"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Quelladresse"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Quellport"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Quell-Zone"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Startdatum (JJJJ-MM-TT)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Startzeit (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Enddatum (JJJJ-MM-TT)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Stoppzeit (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Sonntag"
 
@@ -618,10 +618,11 @@ msgstr ""
 "Die untenstehenden Optionen regeln die Verfahrensweisen für Traffic zwischen "
 "dieser Zone (%s) und anderen Zonen. <em>Ziel-Zonen</em> decken "
 "weitergeleiteten Traffic <strong>von %q</strong> ab. <em>Quell-Zonen</em> "
-"treffen auf weitergeleiteten Traffic aus anderen Zonen zu, welcher <strong>"
-"an %q gerichtet</strong> ist. Die Weiterleitung gilt nur in eine Richtung, "
-"d. h. eine erlaubte Weiterleitung von LAN nach WAN bedeutet <em>nicht</em> "
-"zusätzlich die Erlaubnis, auch von WAN nach LAN weiterzuleiten."
+"treffen auf weitergeleiteten Traffic aus anderen Zonen zu, welcher "
+"<strong>an %q gerichtet</strong> ist. Die Weiterleitung gilt nur in eine "
+"Richtung, d. h. eine erlaubte Weiterleitung von LAN nach WAN bedeutet "
+"<em>nicht</em> zusätzlich die Erlaubnis, auch von WAN nach LAN "
+"weiterzuleiten."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
 msgid ""
@@ -633,20 +634,20 @@ msgid ""
 msgstr ""
 "Dieser Abschnitt definiert allgemeine Eigenschaften der %q-Zone. Die "
 "<em>input</em>- und <em>output</em>-Optionen definieren die Regeln für "
-"Datenverkehr, der in diese Zone eintritt oder diese verlässt. "
-"<em>forward</em> trifft auf Datenverkehr zwischen verschiedenen "
-"Schnittstellen innerhalb dieser Zone zu. <em>Covered networks</em> definiert "
-"welche der verfügbaren Netzwerke zu dieser Zone gehören."
+"Datenverkehr, der in diese Zone eintritt oder diese verlässt. <em>forward</"
+"em> trifft auf Datenverkehr zwischen verschiedenen Schnittstellen innerhalb "
+"dieser Zone zu. <em>Covered networks</em> definiert welche der verfügbaren "
+"Netzwerke zu dieser Zone gehören."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Donnerstag"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Zeitbeschränkungen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Zeit ist UTC"
 
@@ -666,12 +667,12 @@ msgstr "Zu %s auf <var>diesem Gerät</var>"
 msgid "To %s, %s in %s"
 msgstr "Zu %s, %s in %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Traffic-Regeln"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -681,7 +682,7 @@ msgstr ""
 "zum Beispiel um Traffic zwischen bestimmten Rechnern zu unterbinden oder um "
 "WAN-Ports auf dem Router zu öffnen."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Dienstag"
 
@@ -694,8 +695,8 @@ msgstr "Inhalt kann nicht gespeichert werden: %s"
 msgid "Unnamed forward"
 msgstr "Unbenannte Portweiterleitung"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Unbennante Regel"
 
@@ -727,11 +728,11 @@ msgstr "Über %s"
 msgid "Via %s at %s"
 msgstr "Über %s an %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Mittwoch"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Wochentage"
 
@@ -745,7 +746,7 @@ msgstr "Zonen"
 
 # Die richtige Übersetzung von ACCEPT im Firewallkontext ist nicht "Annehmen" sondern "Zulassen". Man kann ja keinen
 # ausgehenden Traffic annehmen. 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -756,12 +757,12 @@ msgstr "zulassen"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "beliebig"
 
@@ -788,11 +789,11 @@ msgstr "beliebige Zone"
 msgid "day"
 msgstr "Tag"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "nicht verfolgen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -819,7 +820,7 @@ msgstr "Port"
 msgid "ports"
 msgstr "Ports"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/el/firewall.po
+++ b/applications/luci-app-firewall/po/el/firewall.po
@@ -50,8 +50,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Ενέργεια"
 
@@ -69,7 +69,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Ρυθμίσεις για προχωρημένους"
@@ -86,12 +86,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Οποιοδήποτε"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -139,15 +139,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Διεύθυνση προορισμού"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Θύρα προορισμού"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Ζώνη προορισμού"
 
@@ -186,7 +186,7 @@ msgid "Drop invalid packets"
 msgstr "Αγνόηση μη-έγκυρων πακετών"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Ενεργοποίηση"
 
@@ -220,7 +220,7 @@ msgid "External port"
 msgstr "Εξωτερική θύρα"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Επιπλέον παράμετροι"
 
@@ -248,7 +248,7 @@ msgstr "Τείχος προστασίας - Προσαρμοσμένοι Καν�
 msgid "Firewall - Port Forwards"
 msgstr "Τείχος προστασίας - Προώθηση Θυρών"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Τείχος προστασίας - Κανόνες Κίνησεις"
 
@@ -265,7 +265,7 @@ msgstr "Προώθηση"
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -325,12 +325,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 και IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Μόνο IPv4"
@@ -339,7 +339,7 @@ msgstr "Μόνο IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Μόνο IPv6"
@@ -385,11 +385,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -399,17 +399,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Όνομα"
@@ -442,7 +442,7 @@ msgid "Output"
 msgstr "Έξοδος"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Πρωτόκολλο"
 
@@ -504,7 +504,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -531,43 +531,43 @@ msgid "Source IP address"
 msgstr "Διεύθυνση MAC πηγής"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 #, fuzzy
 msgid "Source address"
 msgstr "Διεύθυνση MAC πηγής"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Θύρα πηγής"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 #, fuzzy
 msgid "Source zone"
 msgstr "Θύρα πηγής"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -599,15 +599,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -627,19 +627,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -652,8 +652,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Zones"
 msgstr "Ζώνες"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -708,12 +708,12 @@ msgstr "αποδοχή"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -740,11 +740,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -771,7 +771,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/en/firewall.po
+++ b/applications/luci-app-firewall/po/en/firewall.po
@@ -47,8 +47,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Action"
 
@@ -66,7 +66,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -83,12 +83,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -136,15 +136,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Destination address"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Destination port"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Destination zone"
 
@@ -183,7 +183,7 @@ msgid "Drop invalid packets"
 msgstr "Drop invalid packets"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgid "External port"
 msgstr "External port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgstr "Forward"
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -325,12 +325,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -339,7 +339,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -382,11 +382,11 @@ msgid "Masquerading"
 msgstr "Masquerading"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -398,17 +398,17 @@ msgstr ""
 "Match incoming traffic directed at the given destination port or port range "
 "on this host"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Name"
@@ -441,7 +441,7 @@ msgid "Output"
 msgstr "Output"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -466,7 +466,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -504,7 +504,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -560,41 +560,41 @@ msgid "Source IP address"
 msgstr "Source IP address"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Source address"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Source port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Source zone"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -626,15 +626,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -654,19 +654,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -679,8 +679,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -708,11 +708,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -724,7 +724,7 @@ msgstr ""
 msgid "Zones"
 msgstr "Zones"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -735,12 +735,12 @@ msgstr "accept"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "any"
 
@@ -767,11 +767,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -798,7 +798,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/es/firewall.po
+++ b/applications/luci-app-firewall/po/es/firewall.po
@@ -51,8 +51,8 @@ msgstr "Aceptar entrada"
 msgid "Accept output"
 msgstr "Aceptar salida"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Acción"
 
@@ -76,7 +76,7 @@ msgstr ""
 "solo coincida con el tráfico HTTPS entrante."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
@@ -93,12 +93,12 @@ msgstr "Permitir reenvío desde <em>zonas de origen</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Permitir reenvío a <em>zonas de destino</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Cualquiera"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Cualquier día"
 
@@ -152,15 +152,15 @@ msgstr ""
 "cualquier reinicio del FIrewall, justo tras haber cargado el conjunto de "
 "reglas predeterminadas."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Dirección de destino"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Puerto de destino"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Zona de destino"
 
@@ -202,7 +202,7 @@ msgid "Drop invalid packets"
 msgstr "Descartar paquetes inválidos"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Activar"
 
@@ -237,7 +237,7 @@ msgid "External port"
 msgstr "Puerto externo"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Argumentos extra"
 
@@ -265,7 +265,7 @@ msgstr "Firewall - Reglas personalizadas"
 msgid "Firewall - Port Forwards"
 msgstr "Firewall - Reenvío de puertos"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Firewall - Reglas de tráfico"
 
@@ -282,7 +282,7 @@ msgstr "Reenviar"
 msgid "Forward to"
 msgstr "Reenviar a"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Viernes"
 
@@ -314,7 +314,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "De %s en <var>este dispositivo</var> con la fuente %s y %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -342,12 +342,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 e IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Sólo IPv4"
@@ -356,7 +356,7 @@ msgstr "Sólo IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Sólo IPv6"
@@ -399,11 +399,11 @@ msgid "Masquerading"
 msgstr "Enmascaramiento"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Coincidir"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Coincidir con tipo ICMP"
 
@@ -415,17 +415,17 @@ msgstr ""
 "Coincidir con tráfico de entrada dirigido al puerto o rango de puertos "
 "destino en este host"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Lunes"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Días del mes"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nombre"
@@ -460,7 +460,7 @@ msgid "Output"
 msgstr "Salida"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "Pasa argumentos adicionales a iptables. ¡Utilícelo con cuidado!"
 
@@ -493,7 +493,7 @@ msgstr ""
 "un ordenador o servicio específico en la LAN privada."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocolo"
 
@@ -534,7 +534,7 @@ msgstr "Restringir enmascaramiento a las subredes destino"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Restringir enmascaramiento a las subredes origen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Restringir a la familia de direcciones"
@@ -543,7 +543,7 @@ msgstr "Restringir a la familia de direcciones"
 msgid "Routing/NAT Offloading"
 msgstr "Enrutamiento/NAT Offloading"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Sábado"
 
@@ -560,41 +560,41 @@ msgid "Source IP address"
 msgstr "Dirección IP de origen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Dirección MAC de origen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Dirección de origen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Puerto de origen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zona de origen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Fecha de inicio (aaaa-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Hora de inicio (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Fecha de finalización (aaaa-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Hora de finalización (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Domingo"
 
@@ -639,15 +639,15 @@ msgstr ""
 "<em>Redes cubiertas</em> especifican qué redes disponibles son miembros de "
 "esta zona."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Jueves"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Restricciones de tiempo"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Tiempo en UTC"
 
@@ -667,12 +667,12 @@ msgstr "A %s por <var>este dispositivo</var>"
 msgid "To %s, %s in %s"
 msgstr "A %s, %s en %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Reglas de tráfico"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -682,7 +682,7 @@ msgstr ""
 "diferentes zonas, por ejemplo, para rechazar el tráfico entre ciertos hosts "
 "o para abrir puertos WAN en el enrutador."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Martes"
 
@@ -695,8 +695,8 @@ msgstr "No se puede guardar el contenido: %s"
 msgid "Unnamed forward"
 msgstr "Reenvío sin nombre"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Regla sin nombre"
 
@@ -728,11 +728,11 @@ msgstr "Vía %s"
 msgid "Via %s at %s"
 msgstr "Vía %s a %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Días de la semana"
 
@@ -744,7 +744,7 @@ msgstr "Zona ⇒ Reenvíos"
 msgid "Zones"
 msgstr "Zonas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -755,12 +755,12 @@ msgstr "Aceptar"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "cualquiera"
 
@@ -787,11 +787,11 @@ msgstr "cualquier zona"
 msgid "day"
 msgstr "Día"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "No seguir"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -818,7 +818,7 @@ msgstr "puerto"
 msgid "ports"
 msgstr "puertos"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/fr/firewall.po
+++ b/applications/luci-app-firewall/po/fr/firewall.po
@@ -50,8 +50,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Action"
 
@@ -69,7 +69,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
@@ -86,12 +86,12 @@ msgstr "Permettre la transmission des <em>zones source</em> :"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Permettre la transmission vers les <em>zones destination</em> :"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "N'importe lequel"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -139,15 +139,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Adresse de destination"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Port de destination"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Zone de destination"
 
@@ -186,7 +186,7 @@ msgid "Drop invalid packets"
 msgstr "Supprimer les paquets invalides"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Activer"
 
@@ -219,7 +219,7 @@ msgid "External port"
 msgstr "Port externe"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Arguments supplémentaires"
 
@@ -251,7 +251,7 @@ msgstr "Pare-feu - Règles personnalisées"
 msgid "Firewall - Port Forwards"
 msgstr "Pare-feu - Redirections de ports"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Pare-feu - Règles de trafic"
 
@@ -268,7 +268,7 @@ msgstr "Transférer"
 msgid "Forward to"
 msgstr "Transférer à"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Vendredi"
 
@@ -300,7 +300,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -328,12 +328,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 et IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "IPv4 seulement"
@@ -342,7 +342,7 @@ msgstr "IPv4 seulement"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "IPv6 seulement"
@@ -385,11 +385,11 @@ msgid "Masquerading"
 msgstr "Masquage"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Type ICMP correspondant"
 
@@ -401,17 +401,17 @@ msgstr ""
 "Prendre en compte le trafic dirigé vers le port de destination donné (ou la "
 "gamme de ports) sur cet hôte"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Lundi"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nom"
@@ -444,7 +444,7 @@ msgid "Output"
 msgstr "Sortie"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 "Passe des arguments supplémentaires aux tables d'adresses IP. A utiliser "
@@ -473,7 +473,7 @@ msgstr ""
 "connecter à un ordinateur ou service spécifié dans le réseau local privé."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocole"
 
@@ -516,7 +516,7 @@ msgstr ""
 "Restreindre la substitution d'adresses (Masquerade) à ces sous-réseaux "
 "sources"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Restreindre à cette famille d'adresses"
@@ -525,7 +525,7 @@ msgstr "Restreindre à cette famille d'adresses"
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Samedi"
 
@@ -572,41 +572,41 @@ msgid "Source IP address"
 msgstr "Adresse IP source"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Adresse MAC source"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Adresse source"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Port source"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zone source"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Dimanche"
 
@@ -652,15 +652,15 @@ msgstr ""
 "cette zone. Les <em>réseaux couverts</em> indiquent quels réseaux "
 "disponibles sont membre de cette zone."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -680,19 +680,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Règles de trafic"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Mardi"
 
@@ -705,8 +705,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -734,11 +734,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr "Zone ⇒ Transmissions"
 msgid "Zones"
 msgstr "Zones"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -761,12 +761,12 @@ msgstr "accepter"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "tous"
 
@@ -793,11 +793,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -824,7 +824,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/he/firewall.po
+++ b/applications/luci-app-firewall/po/he/firewall.po
@@ -44,8 +44,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -80,12 +80,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -133,15 +133,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -318,12 +318,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -332,7 +332,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -375,11 +375,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -389,17 +389,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -432,7 +432,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -457,7 +457,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -520,41 +520,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -584,15 +584,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -612,19 +612,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -637,8 +637,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -666,11 +666,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -693,12 +693,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -725,11 +725,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -756,7 +756,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/hi/firewall.po
+++ b/applications/luci-app-firewall/po/hi/firewall.po
@@ -47,8 +47,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -83,12 +83,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -136,15 +136,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -183,7 +183,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -325,12 +325,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -339,7 +339,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -382,11 +382,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -396,17 +396,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -439,7 +439,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -501,7 +501,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -557,41 +557,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -621,15 +621,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -649,19 +649,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -674,8 +674,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -703,11 +703,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -730,12 +730,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -762,11 +762,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -793,7 +793,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/hu/firewall.po
+++ b/applications/luci-app-firewall/po/hu/firewall.po
@@ -48,8 +48,8 @@ msgstr "Bemenet elfogadása"
 msgid "Accept output"
 msgstr "Kimenet elfogadása"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Művelet"
 
@@ -73,7 +73,7 @@ msgstr ""
 "forgalom illesztéséhez."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Speciális beállítások"
@@ -90,12 +90,12 @@ msgstr "Továbbítás engedélyezése a <em>forrászónákból</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Továbbítás engedélyezése ezekbe a <em>célzónákba</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Bármelyik"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Bármely nap"
 
@@ -149,15 +149,15 @@ msgstr ""
 "parancsok minden tűzfal-újraindítás után végrehajtásra kerülnek, közvetlenül "
 "az alapértelmezett szabálykészletek betöltődése után."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Célcím"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Célport"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Célzóna"
 
@@ -198,7 +198,7 @@ msgid "Drop invalid packets"
 msgstr "Érvénytelen csomagok eldobása"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Engedélyezés"
 
@@ -233,7 +233,7 @@ msgid "External port"
 msgstr "Külső port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "További argumentumok"
 
@@ -261,7 +261,7 @@ msgstr "Tűzfal – egyéni szabályok"
 msgid "Firewall - Port Forwards"
 msgstr "Tűzfal – porttovábbítások"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Tűzfal – forgalmi szabályok"
 
@@ -278,7 +278,7 @@ msgstr "Továbbítás"
 msgid "Forward to"
 msgstr "Továbbítás ide"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Péntek"
 
@@ -307,10 +307,11 @@ msgstr "Ettől: %s, <var>ezen az eszközön</var>, ezzel a forrással: %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:71
 msgid "From %s on <var>this device</var> with source %s and %s"
-msgstr "Ettől: %s, <var>ezen az eszközön</var>, ezekkel a forrásokkal: %s és %s"
+msgstr ""
+"Ettől: %s, <var>ezen az eszközön</var>, ezekkel a forrásokkal: %s és %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -338,12 +339,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 és IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Csak IPv4"
@@ -352,7 +353,7 @@ msgstr "Csak IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Csak IPv6"
@@ -395,11 +396,11 @@ msgid "Masquerading"
 msgstr "Álcázás"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Illesztés"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "ICMP-típus illesztése"
 
@@ -411,17 +412,17 @@ msgstr ""
 "Az ezen a gépen lévő megadott célportra vagy porttartományra irányított "
 "bejövő forgalom illesztése"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Hétfő"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Hónap napjai"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Név"
@@ -457,7 +458,7 @@ msgid "Output"
 msgstr "Kimenet"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 "Átadja a további argumentumokat az iptables részére. Használja "
@@ -493,7 +494,7 @@ msgstr ""
 "történő csatlakozását."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -530,7 +531,7 @@ msgstr "Álcázás korlátozása a megadott célalhálózatokra"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Álcázás korlátozása a megadott forrás alhálózatokra"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Korlátozás címcsaládra"
@@ -539,7 +540,7 @@ msgstr "Korlátozás címcsaládra"
 msgid "Routing/NAT Offloading"
 msgstr "Útválasztás vagy NAT kiürítés"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Szombat"
 
@@ -556,41 +557,41 @@ msgid "Source IP address"
 msgstr "Forrás IP-cím"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Forrás MAC-cím"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Forráscím"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Forrásport"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Forrászóna"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Kezdés dátuma (ÉÉÉÉ-HH-NN)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Kezdés ideje (ÓÓ.PP.MM)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Leállítás dátuma (ÉÉÉÉ-HH-NN)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Leállítás ideje (ÓÓ.PP.MM)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Vasárnap"
 
@@ -615,10 +616,10 @@ msgstr ""
 "Az alábbi beállítások vezérlik a továbbítási szabályokat a jelenlegi zóna "
 "(%s) és a többi zóna között. A <em>célzónák</em> fedik le a továbbított "
 "forgalmat, <strong>amelynek forrása %q</strong>. A <em>forrászónák</em> "
-"illesztik a továbbított forgalmat más zónákból, <strong>amelynek célja "
-"%q</strong>. A továbbítási szabály <em>egyirányú</em>, például egy "
-"továbbítás LAN-ból WAN-ba <em>nem</em> jelenti azt, hogy a továbbítás WAN-"
-"ból LAN-ba is engedélyezett."
+"illesztik a továbbított forgalmat más zónákból, <strong>amelynek célja %q</"
+"strong>. A továbbítási szabály <em>egyirányú</em>, például egy továbbítás "
+"LAN-ból WAN-ba <em>nem</em> jelenti azt, hogy a továbbítás WAN-ból LAN-ba is "
+"engedélyezett."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
 msgid ""
@@ -635,15 +636,15 @@ msgstr ""
 "belül. A <em>lefedett hálózatok</em> adják meg, hogy mely elérhető hálózatok "
 "tagjai ennek a zónának."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Csütörtök"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Időkorlátozások"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Idő UTC szerint"
 
@@ -663,12 +664,12 @@ msgstr "Ide: %s, <var>ezen az eszközön</var>"
 msgid "To %s, %s in %s"
 msgstr "Erre: %s, %s ebben: %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Forgalmi szabályok"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -678,7 +679,7 @@ msgstr ""
 "szabályokat határozzák meg, például bizonyos gépek közötti forgalom "
 "visszautasításához vagy WAN portok megnyitásához az útválasztón."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Kedd"
 
@@ -691,8 +692,8 @@ msgstr "Nem lehet elmenteni a tartalmat: %s"
 msgid "Unnamed forward"
 msgstr "Névtelen továbbítás"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Névtelen szabály"
 
@@ -724,11 +725,11 @@ msgstr "Ezen keresztül: %s"
 msgid "Via %s at %s"
 msgstr "Ezen keresztül: %s, itt: %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Szerda"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Hétköznapok"
 
@@ -740,7 +741,7 @@ msgstr "Zóna ⇒ Továbbítások"
 msgid "Zones"
 msgstr "Zónák"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -751,12 +752,12 @@ msgstr "elfogadás"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "bármely"
 
@@ -783,11 +784,11 @@ msgstr "bármely zóna"
 msgid "day"
 msgstr "nap"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "ne kövessen"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -814,7 +815,7 @@ msgstr "port"
 msgid "ports"
 msgstr "portok"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/it/firewall.po
+++ b/applications/luci-app-firewall/po/it/firewall.po
@@ -49,8 +49,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Azione"
 
@@ -68,7 +68,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Opzioni Avanzate"
@@ -85,12 +85,12 @@ msgstr "Permetti routing da <em>zone di origine</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Permetti rounting a <em>zone di destinazione</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Qualsiasi"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -142,15 +142,15 @@ msgstr ""
 "comandi sono eseguiti dopo ogni riavvio del firewall, giusto dopo le altre "
 "regole che sono state caricate."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Indirizzo di destinazione"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Porta di destinazione"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Zona di destinazione"
 
@@ -189,7 +189,7 @@ msgid "Drop invalid packets"
 msgstr "Scarta pacchetti invalidi"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Attiva"
 
@@ -222,7 +222,7 @@ msgid "External port"
 msgstr "Porta Esterna"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Comandi extra"
 
@@ -250,7 +250,7 @@ msgstr "Firewall - Regole Personalizzate"
 msgid "Firewall - Port Forwards"
 msgstr "Firewall - Inoltro Porte"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Firewall - Regole Traffico"
 
@@ -267,7 +267,7 @@ msgstr "Inoltra"
 msgid "Forward to"
 msgstr "Inoltra a"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Venerdì"
 
@@ -299,7 +299,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -327,12 +327,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 e IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Solo IPv4"
@@ -341,7 +341,7 @@ msgstr "Solo IPv4"
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Solo IPv6"
@@ -384,11 +384,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Corrispondenza"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Corrispondenza tipo ICMP"
 
@@ -400,17 +400,17 @@ msgstr ""
 "Corrispondi traffico in entrata diretto alla porta o intervallo di porte "
 "dato su questo host"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Lunedì"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Giorni del Mese"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nome"
@@ -445,7 +445,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "Passa comandi addizionali a iptables. Usare con cura!"
 
@@ -472,7 +472,7 @@ msgstr ""
 "connettersi a uno specifico computer o servizio presente nella LAN privata"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocollo"
 
@@ -509,7 +509,7 @@ msgstr "Limita il Masquerading alle subnet di destinazione date"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Limita il Masquerading alle subnet sorgente date"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Limita agli indirizzi famiglia"
@@ -518,7 +518,7 @@ msgstr "Limita agli indirizzi famiglia"
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Sabato"
 
@@ -556,41 +556,41 @@ msgid "Source IP address"
 msgstr "Indirizzo IP di origine"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Indirizzo MAC di origine"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Indirizzo di origine"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Porta di origine"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zona di origine"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Data di Inizio (yyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Data di Stop (yyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Domenica"
 
@@ -635,15 +635,15 @@ msgstr ""
 "differenti nella zona. Le <em>reti coperte</em> specificano quali reti "
 "disponibili sono membri di questa zona."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Giovedì"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Orario in UTC"
 
@@ -663,12 +663,12 @@ msgstr "Verso %s su <var>questo dispositivo</var>"
 msgid "To %s, %s in %s"
 msgstr "Verso %s, %s in %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Regole di Traffico"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -678,7 +678,7 @@ msgstr ""
 "tra zone differenti, per esempio per rifiutare il traffico tra certi host o "
 "per aprire porte WAN sul router."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Martedì"
 
@@ -691,8 +691,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -720,11 +720,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr "Via %s a %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Mercoledì"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Giorni della Settimana"
 
@@ -736,7 +736,7 @@ msgstr "Zona ⇒ Inoltri"
 msgid "Zones"
 msgstr "Zone"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -747,12 +747,12 @@ msgstr "accetta"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "qualsiasi"
 
@@ -779,11 +779,11 @@ msgstr "qualsiasi zona"
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "non tracciare"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -810,7 +810,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/ja/firewall.po
+++ b/applications/luci-app-firewall/po/ja/firewall.po
@@ -50,8 +50,8 @@ msgstr "入力を許可"
 msgid "Accept output"
 msgstr "出力を許可"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "動作"
 
@@ -75,7 +75,7 @@ msgstr ""
 "sport 443</code>）"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "詳細設定"
@@ -92,12 +92,12 @@ msgstr "<em>送信元ゾーン</em>からの転送を許可する:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "<em>宛先ゾーン</em>への転送を許可する:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "全て"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "全日"
 
@@ -151,15 +151,15 @@ msgstr ""
 "ドは、ファイアウォール機能の起動ごとに、標準のルールが読み込まれた後に実行さ"
 "れます。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "宛先アドレス"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "宛先ポート"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "宛先ゾーン"
 
@@ -201,7 +201,7 @@ msgid "Drop invalid packets"
 msgstr "無効なパケットを遮断する"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "有効"
 
@@ -234,7 +234,7 @@ msgid "External port"
 msgstr "外部ポート"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "追加の引数"
 
@@ -262,7 +262,7 @@ msgstr "ファイアウォール - 手動設定ルール"
 msgid "Firewall - Port Forwards"
 msgstr "ファイアウォール - ポートフォワーディング"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "ファイアウォール - トラフィック・ルール"
 
@@ -279,7 +279,7 @@ msgstr "転送"
 msgid "Forward to"
 msgstr "転送先"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "金曜日"
 
@@ -311,7 +311,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "送信元 %s, %s, %s (<var>デバイス</var>)"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -339,12 +339,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4及びIPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "IPv4のみ"
@@ -353,7 +353,7 @@ msgstr "IPv4のみ"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "IPv6のみ"
@@ -396,11 +396,11 @@ msgid "Masquerading"
 msgstr "マスカレード"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "対象"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "ICMPタイプの一致"
 
@@ -412,17 +412,17 @@ msgstr ""
 "設定された宛先ポート(またはポート範囲)に一致した受信トラフィックが対象になり"
 "ます"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "月曜日"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "月間"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "名前"
@@ -459,7 +459,7 @@ msgid "Output"
 msgstr "送信"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 "iptablesにパススルーする追加の引数を設定してください。ただし、注意して設定し"
@@ -494,7 +494,7 @@ msgstr ""
 "ます。"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "プロトコル"
 
@@ -533,7 +533,7 @@ msgstr "設定された宛先サブネットへのマスカレードを制限す
 msgid "Restrict Masquerading to given source subnets"
 msgstr "設定された送信元サブネットへのマスカレードを制限する"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "アドレスファミリの制限"
@@ -542,7 +542,7 @@ msgstr "アドレスファミリの制限"
 msgid "Routing/NAT Offloading"
 msgstr "ルーティング/NAT オフロード"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "土曜日"
 
@@ -559,41 +559,41 @@ msgid "Source IP address"
 msgstr "送信元IPアドレス"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "送信元MACアドレス"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "送信元アドレス"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "送信元ポート"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "送信元ゾーン"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "開始日 (yyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "開始時刻 (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "停止日 (yyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "停止時刻 (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "日曜日"
 
@@ -636,15 +636,15 @@ msgstr ""
 "準のポリシーになります。<em>対象ネットワーク</em>は、どのネットワーク設定がこ"
 "のゾーンに属するかを設定します。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "木曜日"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "時間制限"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "UTC時刻を使用"
 
@@ -664,12 +664,12 @@ msgstr "宛先 %s (<var>デバイス</var>)"
 msgid "To %s, %s in %s"
 msgstr "宛先 %s, %s (%s)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "トラフィック・ルール"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -679,7 +679,7 @@ msgstr ""
 "します。例えば、特定のホスト間や、ルーターのWANポートへのトラフィックの拒否を"
 "設定することができます。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "火曜日"
 
@@ -692,8 +692,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr "名称未設定の転送"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "名称未設定のルール"
 
@@ -725,11 +725,11 @@ msgstr "経由 %s"
 msgid "Via %s at %s"
 msgstr "経由 %s , %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "水曜日"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "曜日"
 
@@ -741,7 +741,7 @@ msgstr "ゾーン ⇒ 転送"
 msgid "Zones"
 msgstr "ゾーン"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -752,12 +752,12 @@ msgstr "許可"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "全て"
 
@@ -784,11 +784,11 @@ msgstr "全てのゾーン"
 msgid "day"
 msgstr "日"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "コネクション追跡を行わない"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -815,7 +815,7 @@ msgstr "ポート"
 msgid "ports"
 msgstr "ポート"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/ko/firewall.po
+++ b/applications/luci-app-firewall/po/ko/firewall.po
@@ -49,8 +49,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr ""
 
@@ -68,7 +68,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -85,12 +85,12 @@ msgstr "<em>Source zone</em> 로부터의 forward 허용:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "<em>Destination zone</em> 으로 forward 허용:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -141,15 +141,15 @@ msgstr ""
 "수 있도록 합니다.  입력된 명령어들은 매 방화벽 재시작시 실행되는데 default "
 "ruleset 이 load 된 후 시점입니다."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Destination 주소"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "활성화"
 
@@ -221,7 +221,7 @@ msgid "External port"
 msgstr "외부 port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "추가 argument"
 
@@ -249,7 +249,7 @@ msgstr "방화벽 - Custom Rules"
 msgid "Firewall - Port Forwards"
 msgstr "방화벽 - Port Forwards"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "방화벽 - Traffic Rules"
 
@@ -266,7 +266,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "금요일"
 
@@ -298,7 +298,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -326,12 +326,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -340,7 +340,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -383,11 +383,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -397,17 +397,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "월요일"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "이름"
@@ -440,7 +440,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "iptables 명령에 추가 인자들을 더합니다.  조심해 사용하세요!"
 
@@ -467,7 +467,7 @@ msgstr ""
 "나 서비스에 접속할 수 있도록 합니다."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgstr "주어진 destination subnet 으로 Masquerading 제한"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "주어진 source subnet 으로 Masquerading 제한"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Address family 제한"
@@ -513,7 +513,7 @@ msgstr "Address family 제한"
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "토요일"
 
@@ -530,41 +530,41 @@ msgid "Source IP address"
 msgstr "Source IP 주소"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Source MAC 주소"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Source 주소"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "시작 날짜 (yyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "종료 날짜 (yyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "일요일"
 
@@ -608,15 +608,15 @@ msgstr ""
 "를 오가는 forward traffic 에 대한 정책을 뜻합니다. <em>Covered networks</em> "
 "에서는 zone 의 영향을 받을 네트워크들을 지정할 수 있습니다."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "목요일"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "UTC 기준시"
 
@@ -636,12 +636,12 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Traffic Rule"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -651,7 +651,7 @@ msgstr ""
 "다. 예를 들어 특정 host 들 사이의 트래픽을 차단하거나 공유기의 WAN port 를 "
 "open 할때 사용됩니다."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "화요일"
 
@@ -664,8 +664,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -693,11 +693,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "수요일"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "주일"
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Zones"
 msgstr "Zone 내역"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -720,12 +720,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -752,11 +752,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -783,7 +783,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/mr/firewall.po
+++ b/applications/luci-app-firewall/po/mr/firewall.po
@@ -50,8 +50,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr ""
 
@@ -69,7 +69,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "प्रगत सेटिंग्ज"
@@ -86,12 +86,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -139,15 +139,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -186,7 +186,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "सक्षम करा"
 
@@ -219,7 +219,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -268,7 +268,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -300,7 +300,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -328,12 +328,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 आणि IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "केवळ IPv4"
@@ -342,7 +342,7 @@ msgstr "केवळ IPv4"
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "केवळ IPv6"
@@ -385,11 +385,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -399,17 +399,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "नाव"
@@ -442,7 +442,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "प्रोटोकॉल"
 
@@ -504,7 +504,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -560,41 +560,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -624,15 +624,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -652,19 +652,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -677,8 +677,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -706,11 +706,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -733,12 +733,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -765,11 +765,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -796,7 +796,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/ms/firewall.po
+++ b/applications/luci-app-firewall/po/ms/firewall.po
@@ -48,8 +48,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Tindakan"
 
@@ -67,7 +67,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -84,12 +84,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -137,15 +137,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -184,7 +184,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -294,7 +294,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -322,12 +322,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -379,11 +379,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -393,17 +393,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -436,7 +436,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -461,7 +461,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -524,41 +524,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -588,15 +588,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -616,19 +616,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -641,8 +641,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -670,11 +670,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -686,7 +686,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -697,12 +697,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -729,11 +729,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -760,7 +760,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/no/firewall.po
+++ b/applications/luci-app-firewall/po/no/firewall.po
@@ -44,8 +44,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Handling"
 
@@ -63,7 +63,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Avanserte Innstillinger"
@@ -80,12 +80,12 @@ msgstr "Tillat videresending fra <em>kilde soner</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Tillat videresending til <em>destinasjon soner</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Enhver"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -136,15 +136,15 @@ msgstr ""
 "som ikke dekkes av brannmurens standardoppsett. Kommandoene utføres etter "
 "hver omstart av brannmuren, rett etter at standard regelsett er lastet."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Destinasjon adresse"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Destinasjon port"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Destinasjon sone"
 
@@ -183,7 +183,7 @@ msgid "Drop invalid packets"
 msgstr "Forkast ugyldige pakker"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Aktiver"
 
@@ -216,7 +216,7 @@ msgid "External port"
 msgstr "Ekstern port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Ekstra argumenter"
 
@@ -244,7 +244,7 @@ msgstr "Brannmur - Egendefinerte Regler"
 msgid "Firewall - Port Forwards"
 msgstr "Brannmur - Port Videresending"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Brannmur - Trafikk Regler"
 
@@ -261,7 +261,7 @@ msgstr "Videresend"
 msgid "Forward to"
 msgstr "Videresend til"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -293,7 +293,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -321,12 +321,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 og IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Kun IPv4"
@@ -335,7 +335,7 @@ msgstr "Kun IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Kun IPv6"
@@ -378,11 +378,11 @@ msgid "Masquerading"
 msgstr "Masquerading"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Match"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Match ICMP type"
 
@@ -394,17 +394,17 @@ msgstr ""
 "Match innkommende trafikk rettet mot den oppgitte destinasjonsport eller "
 "portområdet på denne verten"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Navn"
@@ -439,7 +439,7 @@ msgid "Output"
 msgstr "Utdata"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "Sender flere argumenter til iptables. Bruk med forsiktighet!"
 
@@ -466,7 +466,7 @@ msgstr ""
 "seg til en bestemt maskin eller tjeneste innenfor det private LAN."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -505,7 +505,7 @@ msgstr "Begrens Masquerading til oppgitt destinasjons subnett"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Begrens Masqeuerading til oppgitt kilde subnett"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Begrens til adresse familie"
@@ -514,7 +514,7 @@ msgstr "Begrens til adresse familie"
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -531,41 +531,41 @@ msgid "Source IP address"
 msgstr "Kilde IP adresse"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Kilde MAC adresse"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Kilde adresse"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Kilde port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Kilde sone"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -610,15 +610,15 @@ msgstr ""
 "spesifiserer hvilken av de tilgjengelige nettverk som er medlem av denne "
 "sone."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -638,12 +638,12 @@ msgstr "Til %s på <var>denne enheten</var>"
 msgid "To %s, %s in %s"
 msgstr "Til %s, %s i %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Trafikk Regler"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -653,7 +653,7 @@ msgstr ""
 "for eksempel for å avvise trafikk mellom visse verter eller for å åpne WAN "
 "porter på ruteren."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -666,8 +666,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -695,11 +695,11 @@ msgstr "Via %s"
 msgid "Via %s at %s"
 msgstr "Via %s på %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr "Sone = Videresendinger"
 msgid "Zones"
 msgstr "Soner"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -722,12 +722,12 @@ msgstr "godta"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "enhver"
 
@@ -754,11 +754,11 @@ msgstr "enhver sone"
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "ikke track"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -785,7 +785,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/pl/firewall.po
+++ b/applications/luci-app-firewall/po/pl/firewall.po
@@ -52,8 +52,8 @@ msgstr "Zaakceptuj wejście"
 msgid "Accept output"
 msgstr "Zaakceptuj wyjście"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Akcja"
 
@@ -77,7 +77,7 @@ msgstr ""
 "ruchu przychodzącego HTTPS."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
@@ -94,12 +94,12 @@ msgstr "Zezwól na przekazywanie z <em>source zones</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Zezwól na przekazywanie do <em>destination zones</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Każdy"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Każdy dzień"
 
@@ -152,15 +152,15 @@ msgstr ""
 "są objęte składnią zapory. Polecenia wykonywane są po każdym restarcie "
 "zapory, zaraz po załadowaniu zestawu reguł domyślnych."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Adres docelowy"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Port docelowy"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Strefa docelowa"
 
@@ -202,7 +202,7 @@ msgid "Drop invalid packets"
 msgstr "Porzuć wadliwe pakiety"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Włącz"
 
@@ -236,7 +236,7 @@ msgid "External port"
 msgstr "Port zewnętrzny"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Dodatkowe argumenty"
 
@@ -267,7 +267,7 @@ msgstr "Zapora - Reguły własne"
 msgid "Firewall - Port Forwards"
 msgstr "Zapora - Przekazywanie portów"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Zapora - Reguły ruchu"
 
@@ -284,7 +284,7 @@ msgstr "Przekazuj"
 msgid "Forward to"
 msgstr "Przekazuj do"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Piątek"
 
@@ -316,7 +316,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "Z %s na <var>to urządzenie</var> ze źródłem %s oraz %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -344,12 +344,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 i IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Tylko IPv4"
@@ -358,7 +358,7 @@ msgstr "Tylko IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Tylko IPv6"
@@ -401,11 +401,11 @@ msgid "Masquerading"
 msgstr "Maskarada"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Dopasuj"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Dopasuj typ ICMP"
 
@@ -417,17 +417,17 @@ msgstr ""
 "Dopasuj ruch przychodzący do danego portu docelowego lub zakresu portów na "
 "tym hoście"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Poniedziałek"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Dni miesiąca"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nazwa"
@@ -462,7 +462,7 @@ msgid "Output"
 msgstr "Ruch wychodzący"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 "Przekazuje dodatkowe argumenty do iptables. Zachowaj szczególną ostrożność!"
@@ -496,7 +496,7 @@ msgstr ""
 "komputerami z sieci LAN."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protokół"
 
@@ -537,7 +537,7 @@ msgstr "Ogranicz maskaradę do wskazanych sieci źródłowych"
 
 # Wstawiłem rodzinę gdyż gdzieś wcześniej było tak opisane ale klasa pasuje mi tu bardziej.
 # Obsy - niestety ale "rodzina". W gui dotyczy to wyboru IPv4/IPv6, więc "rodzina" a nie klasa.
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Ogranicz do rodziny adresów"
@@ -546,7 +546,7 @@ msgstr "Ogranicz do rodziny adresów"
 msgid "Routing/NAT Offloading"
 msgstr "Routing/NAT Offloading"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Sobota"
 
@@ -563,41 +563,41 @@ msgid "Source IP address"
 msgstr "Źródłowy adres IP"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Źródłowy adres MAC"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Adres źródłowy"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Port źródłowy"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Strefa źródłowa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Data rozpoczęcia (rrrr-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Czas rozpoczęcia (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Data zakończenia (yyyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Czas zatrzymania (yyyyy-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Niedziela"
 
@@ -640,15 +640,15 @@ msgstr ""
 "politykę ruchu przekazywanego pomiędzy różnymi sieciami wewnątrz strefy. "
 "<em>Objęte sieci</em> określają dostępne sieci będące członkami tej strefy."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Czwartek"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Ograniczenia czasowe"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Czas w UTC"
 
@@ -668,12 +668,12 @@ msgstr "Do %s na <var>tym urządzeniu</var>"
 msgid "To %s, %s in %s"
 msgstr "Do %s, %s w %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Reguły ruchu sieciowego"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -683,7 +683,7 @@ msgstr ""
 "między strefami, na przykład aby odrzucać ruch między konkretnymi hostami "
 "albo otworzyć porty WAN routera."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Wtorek"
 
@@ -696,8 +696,8 @@ msgstr "Nie można zapisać zawartości: %s"
 msgid "Unnamed forward"
 msgstr "Bez nazwy"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Nieznana zasada"
 
@@ -729,11 +729,11 @@ msgstr "Przez %s"
 msgid "Via %s at %s"
 msgstr "Przez %s w %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Środa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Dni tygodnia"
 
@@ -745,7 +745,7 @@ msgstr "Strefa ⇒ Przekazywanie"
 msgid "Zones"
 msgstr "Strefy"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -756,12 +756,12 @@ msgstr "akceptuj"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "dowolny"
 
@@ -788,11 +788,11 @@ msgstr "dowolna strefa"
 msgid "day"
 msgstr "Dzień"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "nie śledź"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -819,7 +819,7 @@ msgstr "port"
 msgid "ports"
 msgstr "porty"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/pt-br/firewall.po
+++ b/applications/luci-app-firewall/po/pt-br/firewall.po
@@ -50,8 +50,8 @@ msgstr "Aceitar entrada"
 msgid "Accept output"
 msgstr "Aceitar saída"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Ação"
 
@@ -75,7 +75,7 @@ msgstr ""
 "apenas ao tráfego HTTPS de entrada."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Configurações Avançadas"
@@ -92,12 +92,12 @@ msgstr "Permite o encaminhamento da <em>zona de origem</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Permite o encaminhamento para a <em>zona de destino</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Qualquer"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Qualquer dia"
 
@@ -150,15 +150,15 @@ msgstr ""
 "cobertos por esta ferramenta. Os comandos serão executados após cada "
 "reinício do firewall, logo após a carga do conjunto de regras padrão."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Endereço de destino"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Porta de destino"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Zona de destino"
 
@@ -200,7 +200,7 @@ msgid "Drop invalid packets"
 msgstr "Descartar pacotes inválidos"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Ativar"
 
@@ -236,7 +236,7 @@ msgid "External port"
 msgstr "Porta Externa"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Argumentos extras"
 
@@ -264,7 +264,7 @@ msgstr "Firewall - Regras personalizadas"
 msgid "Firewall - Port Forwards"
 msgstr "Firewall - Encaminhamento de Portas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Firewall - Regras de Tráfego"
 
@@ -281,7 +281,7 @@ msgstr "Encaminhar"
 msgid "Forward to"
 msgstr "Encaminhar para"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Sexta-feira"
 
@@ -313,7 +313,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "De %s <var>neste dispositivo</var> com origem %s e %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -341,12 +341,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 e IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Somente IPv4"
@@ -355,7 +355,7 @@ msgstr "Somente IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Somente IPv6"
@@ -398,11 +398,11 @@ msgid "Masquerading"
 msgstr "Mascaramento"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Casa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Casa com ICMP tipo"
 
@@ -414,17 +414,17 @@ msgstr ""
 "Casa o tráfego entrante direcionado para uma porta ou faixa de portas de "
 "destino específica neste computador"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Segunda-Feira"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Dias do mês"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nome"
@@ -460,7 +460,7 @@ msgid "Output"
 msgstr "Saída"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "Passa argumentos adicionais para o iptables. Use com cuidado!"
 
@@ -492,7 +492,7 @@ msgstr ""
 "conectem a um computador ou serviço específico dentro da rede local privada."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocolo"
 
@@ -530,7 +530,7 @@ msgstr "Restringe o mascaramento para uma subrede de destino específica"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Restringe o mascaramento para uma subrede de origem específica"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Restringe para uma família de endereços"
@@ -539,7 +539,7 @@ msgstr "Restringe para uma família de endereços"
 msgid "Routing/NAT Offloading"
 msgstr "Aceleração de Roteamento/NAT"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Sábado"
 
@@ -556,41 +556,41 @@ msgid "Source IP address"
 msgstr "Endereço IP de origem"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Endereço MAC de origem"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Endereço de origem"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Porta de origem"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zona de origem"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Dia inicial (aaaa-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Hora de Início (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Dia final (aaaa-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Hora de Parada (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Domingo"
 
@@ -634,15 +634,15 @@ msgstr ""
 "<em>Redes Cobertas</em> especificam que redes disponíveis são membros desta "
 "zona."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Quita-feira"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Restrições de tempo"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Hora em UTC"
 
@@ -662,12 +662,12 @@ msgstr "Para %s <var>neste dispositivo</var>"
 msgid "To %s, %s in %s"
 msgstr "Para %s, %s em %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Regras de tráfego"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -677,7 +677,7 @@ msgstr ""
 "diferentes zonas. Por exemplo, rejeitar o tráfego entre certos equipamentos "
 "ou abrir portas WAN no roteador."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Terça-feira"
 
@@ -690,8 +690,8 @@ msgstr "Não foi possível salvar os conteúdos: %s"
 msgid "Unnamed forward"
 msgstr "Encaminhamento sem nome"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Regra sem nome"
 
@@ -723,11 +723,11 @@ msgstr "Via %s"
 msgid "Via %s at %s"
 msgstr "Através do %s na %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Quarta-feira"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Dias da semana"
 
@@ -739,7 +739,7 @@ msgstr "Zona ⇒ Encaminhamentos"
 msgid "Zones"
 msgstr "Zonas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -750,12 +750,12 @@ msgstr "aceitar"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "qualquer"
 
@@ -782,11 +782,11 @@ msgstr "qualquer zona"
 msgid "day"
 msgstr "dia"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "não rastrear"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -813,7 +813,7 @@ msgstr "porta"
 msgid "ports"
 msgstr "portas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/pt/firewall.po
+++ b/applications/luci-app-firewall/po/pt/firewall.po
@@ -50,8 +50,8 @@ msgstr "Aceitar a entrada"
 msgid "Accept output"
 msgstr "Aceitar a saída"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Ação"
 
@@ -75,7 +75,7 @@ msgstr ""
 "corresponder apenas ao tráfego HTTPS de entrada."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Definições Avançadas"
@@ -92,12 +92,12 @@ msgstr "Permitir encaminhamento de <em>zonas de origem</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Permitir encaminhamento para <em>zonas de destino</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Qualquer"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Qualquer dia"
 
@@ -151,15 +151,15 @@ msgstr ""
 "comandos são executados a seguir ao reinicio da firewall, logo a seguir ao "
 "conjunto de regras predefinidas serem carregadas."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Endereço de destino"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Porta de destino"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Zona de destino"
 
@@ -201,7 +201,7 @@ msgid "Drop invalid packets"
 msgstr "Cancelar pacotes inválidos"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Ativar"
 
@@ -236,7 +236,7 @@ msgid "External port"
 msgstr "Porta externa"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Argumentos adicionais"
 
@@ -264,7 +264,7 @@ msgstr "Firewall - Regras Personalizadas"
 msgid "Firewall - Port Forwards"
 msgstr "Firewall - Encaminhamento de Portas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Firewall - Regras de Tráfego"
 
@@ -281,7 +281,7 @@ msgstr "Encaminhar"
 msgid "Forward to"
 msgstr "Encaminhar para"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Sexta-feira"
 
@@ -313,7 +313,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "De %s <var>neste aparelho</var> com as fontes %s e %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -341,12 +341,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 e IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Só IPv4"
@@ -355,7 +355,7 @@ msgstr "Só IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Só IPv6"
@@ -398,11 +398,11 @@ msgid "Masquerading"
 msgstr "Mascaramento"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Corresponder"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Correspondência do tipo de ICMP"
 
@@ -414,17 +414,17 @@ msgstr ""
 "O tráfego de entrada corresponde a uma dada porta de destino ou intervalo de "
 "portas neste host"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Segunda-feira"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Dias do mês"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nome"
@@ -459,7 +459,7 @@ msgid "Output"
 msgstr "Saída"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "Passa argumentos adicionais para o iptables. Usar com cuidado!"
 
@@ -491,7 +491,7 @@ msgstr ""
 "liguem a um computador ou serviço especifico na rede privada (LAN)."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocolo"
 
@@ -531,7 +531,7 @@ msgstr "Restringir o Mascaramento às sub-redes de destino dadas"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Restringir Mascaramento a sub-redes de origem fornecidas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Restringir a família de endereços"
@@ -540,7 +540,7 @@ msgstr "Restringir a família de endereços"
 msgid "Routing/NAT Offloading"
 msgstr "Descargar Roteamento/NAT"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Sábado"
 
@@ -557,41 +557,41 @@ msgid "Source IP address"
 msgstr "Endereço IP de origem"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Endereço MAC de origem"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Endereço de origem"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Porta de origem"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zona de origem"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Data de Início (aaaaa-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Hora de início (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Data de Paragem (aaaaa-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Tempo de Parada (hh.mm.ss)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Domingo"
 
@@ -636,15 +636,15 @@ msgstr ""
 "abrangidas</em> especifica quais das redes disponíveis são membros desta "
 "zona."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Quinta-feira"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Restrições de Tempo"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Tempo em UTC"
 
@@ -664,12 +664,12 @@ msgstr "Para %s em <var>este dispositivo</var>"
 msgid "To %s, %s in %s"
 msgstr "Para %s, %s em %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Regras de Tráfego"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -679,7 +679,7 @@ msgstr ""
 "diferentes zonas, por exemplo, para rejeitar trafego entre certos hosts ou "
 "para abrir portas WAN no router."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Terça-feira"
 
@@ -692,8 +692,8 @@ msgstr "Incapaz de gravar conteúdos: %s"
 msgid "Unnamed forward"
 msgstr "Encaminhamento sem nome"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Regra sem nome"
 
@@ -725,11 +725,11 @@ msgstr "Via %s"
 msgid "Via %s at %s"
 msgstr "Via %s no %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Quarta-feira"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Dias úteis"
 
@@ -741,7 +741,7 @@ msgstr "Zona ⇒ Encaminhamentos"
 msgid "Zones"
 msgstr "Zonas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -752,12 +752,12 @@ msgstr "aceitar"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "qualquer"
 
@@ -784,11 +784,11 @@ msgstr "qualquer zona"
 msgid "day"
 msgstr "dia"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "não seguir"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -815,7 +815,7 @@ msgstr "porta"
 msgid "ports"
 msgstr "portas"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/ro/firewall.po
+++ b/applications/luci-app-firewall/po/ro/firewall.po
@@ -49,8 +49,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Actiune"
 
@@ -68,7 +68,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Setări avansate"
@@ -85,12 +85,12 @@ msgstr "Permite trecerea din <em>zonele sursa</em>."
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Permite trecerea catre <em>zonele sursa</em>."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Oricare"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Orice zi"
 
@@ -138,15 +138,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Destinaţie adresă"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Portul destinatie"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Zona destinatie"
 
@@ -185,7 +185,7 @@ msgid "Drop invalid packets"
 msgstr "Descarcă pachetele invalide"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Activează"
 
@@ -218,7 +218,7 @@ msgid "External port"
 msgstr "Port extern"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -246,7 +246,7 @@ msgstr "Firewall - Reguli particularizate"
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -263,7 +263,7 @@ msgstr "Forward"
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -323,12 +323,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 şi IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "doar IPv4"
@@ -337,7 +337,7 @@ msgstr "doar IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "doar IPv6"
@@ -380,11 +380,11 @@ msgid "Masquerading"
 msgstr "Translatare"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Potrivire"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Potriveste pe tipul de ICMP"
 
@@ -394,17 +394,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Nume"
@@ -437,7 +437,7 @@ msgid "Output"
 msgstr "Ieşire"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -508,7 +508,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -525,41 +525,41 @@ msgid "Source IP address"
 msgstr "Sursă adresă IP"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "Sursă adresă MAC"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Adresa sursa"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Port sursa"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Zona sursa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Duminică"
 
@@ -589,15 +589,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Joi"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Restricţii de timp"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -617,19 +617,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Marţi"
 
@@ -642,8 +642,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -671,11 +671,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Miercuri"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "Zones"
 msgstr "Zone"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -698,12 +698,12 @@ msgstr "accept"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "oricare"
 
@@ -730,11 +730,11 @@ msgstr "orice zona"
 msgid "day"
 msgstr "zi"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -761,7 +761,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/ru/firewall.po
+++ b/applications/luci-app-firewall/po/ru/firewall.po
@@ -52,8 +52,8 @@ msgstr "Принимать входящий трафик"
 msgid "Accept output"
 msgstr "Принимать исходящий трафик"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Действие"
 
@@ -77,7 +77,7 @@ msgstr ""
 "входящему HTTPS трафику."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
@@ -94,12 +94,12 @@ msgstr "Разрешить перенаправление из <em>'зон ис�
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Разрешить перенаправление в <em>'зоны назначения'</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Любой"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Любой день"
 
@@ -153,15 +153,15 @@ msgstr ""
 "каждой перезагрузки межсетевого экрана, сразу после загрузки набора правил "
 "по умолчанию."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Адрес назначения"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Порт назначения"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Зона назначения"
 
@@ -203,7 +203,7 @@ msgid "Drop invalid packets"
 msgstr "Отбрасывать некорректные пакеты"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Включить"
 
@@ -238,7 +238,7 @@ msgid "External port"
 msgstr "Внешний порт"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Дополнительные аргументы"
 
@@ -266,7 +266,7 @@ msgstr "Межсетевой экран - Пользовательские пр�
 msgid "Firewall - Port Forwards"
 msgstr "Межсетевой экран - Перенаправление портов"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Межсетевой экран - Правила для трафика"
 
@@ -283,7 +283,7 @@ msgstr "Перенаправление"
 msgid "Forward to"
 msgstr "Перенаправлять на"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Пятница"
 
@@ -315,7 +315,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "Из %s в <var>это устройство</var> с источниками %s and %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -343,12 +343,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 и IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Только IPv4"
@@ -357,7 +357,7 @@ msgstr "Только IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Только IPv6"
@@ -400,11 +400,11 @@ msgid "Masquerading"
 msgstr "Маскарадинг"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Входящий трафик"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Соответствовать ICMP типу"
 
@@ -416,17 +416,17 @@ msgstr ""
 "Порт или диапазон портов, входящие подключения на который будут "
 "перенаправляться на внутренний порт внутреннего IP-адреса (см. ниже)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Понедельник"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Дни месяца"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Имя"
@@ -464,7 +464,7 @@ msgid "Output"
 msgstr "Исходящий трафик"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 "Передаёт дополнительные аргументы таблице iptables. Используйте с "
@@ -498,7 +498,7 @@ msgstr ""
 "соединяться с компьютером или службой внутри частной локальной сети."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Протокол"
 
@@ -538,7 +538,7 @@ msgstr "Использовать маскарадинг только для ук
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Использовать маскарадинг только для указанных подсетей-отправителей"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Использовать протокол"
@@ -547,7 +547,7 @@ msgstr "Использовать протокол"
 msgid "Routing/NAT Offloading"
 msgstr "Маршрутизация/NAT offloading"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Суббота"
 
@@ -564,41 +564,41 @@ msgid "Source IP address"
 msgstr "IP-адрес источника"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "MAC-адрес источника"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Адрес источника"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Порт источника"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Зона источника"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Дата начала (год-мес-день)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Время начала (чч.мм.сс)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Дата окончания (год-мес-день)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Время окончания (чч.мм.сс)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Воскресенье"
 
@@ -641,15 +641,15 @@ msgstr ""
 "различными сетями внутри зоны. <em>'Использовать сети'</em> указывает, какие "
 "доступные сети являются членами этой зоны."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Четверг"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Временные ограничения"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Время UTC"
 
@@ -669,12 +669,12 @@ msgstr "К %s на <var>этом устройстве</var>"
 msgid "To %s, %s in %s"
 msgstr "К %s, %s в %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Правила для трафика"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -684,7 +684,7 @@ msgstr ""
 "зонами, например, запрет трафика между некоторыми хостами или открытие WAN-"
 "портов маршрутизатора."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Вторник"
 
@@ -697,8 +697,8 @@ msgstr "Невозможно сохранить содержимое: %s"
 msgid "Unnamed forward"
 msgstr "Перенаправление без имени"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Правило без имени"
 
@@ -730,11 +730,11 @@ msgstr "Через %s"
 msgid "Via %s at %s"
 msgstr "Через %s, %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Среда"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Дни недели"
 
@@ -746,7 +746,7 @@ msgstr "Зона ⇒ Перенаправления"
 msgid "Zones"
 msgstr "Зоны"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -757,12 +757,12 @@ msgstr "принимать"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "любой"
 
@@ -789,11 +789,11 @@ msgstr "любой зоны"
 msgid "day"
 msgstr "день"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "не отслеживать"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -820,7 +820,7 @@ msgstr "порт"
 msgid "ports"
 msgstr "порты"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/sk/firewall.po
+++ b/applications/luci-app-firewall/po/sk/firewall.po
@@ -44,8 +44,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -80,12 +80,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -133,15 +133,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -318,12 +318,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -332,7 +332,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -375,11 +375,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -389,17 +389,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -432,7 +432,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -457,7 +457,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -520,41 +520,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -584,15 +584,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -612,19 +612,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -637,8 +637,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -666,11 +666,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -693,12 +693,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -725,11 +725,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -756,7 +756,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/sv/firewall.po
+++ b/applications/luci-app-firewall/po/sv/firewall.po
@@ -48,8 +48,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Åtgärd"
 
@@ -67,7 +67,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
@@ -84,12 +84,12 @@ msgstr "Tillåt vidarebefordring från <em>källzonerna</em>:"
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Till vidarebefordring till <em>destinationszonerna:</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Något"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -137,15 +137,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Destinationens adress"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Destinationsport"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Destinationens zon"
 
@@ -184,7 +184,7 @@ msgid "Drop invalid packets"
 msgstr "Släpp ogiltiga paket"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Aktivera"
 
@@ -217,7 +217,7 @@ msgid "External port"
 msgstr "Extern port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Extra argument"
 
@@ -245,7 +245,7 @@ msgstr "Brandvägg - Anpassade regler"
 msgid "Firewall - Port Forwards"
 msgstr "Brandvägg - Vidarebefordring av port"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Brandvägg - Trafikregler"
 
@@ -262,7 +262,7 @@ msgstr "Vidarebefordra"
 msgid "Forward to"
 msgstr "Vidarebefordra till"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "Fredag"
 
@@ -294,7 +294,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -322,12 +322,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 och IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Endast IPv4"
@@ -336,7 +336,7 @@ msgstr "Endast IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Endast IPv6"
@@ -379,11 +379,11 @@ msgid "Masquerading"
 msgstr "Maskering"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Matcha"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Matchar ICMP-typ"
 
@@ -395,17 +395,17 @@ msgstr ""
 "Matcha inkommande trafik dirigerad till den angivna destinationsporten eller "
 "portens räckvidd på den här värden"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Måndag"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Dagar i månaden"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Namn"
@@ -439,7 +439,7 @@ msgid "Output"
 msgstr "Utmatning"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -501,7 +501,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Begränsa till adressfamilj"
@@ -510,7 +510,7 @@ msgstr "Begränsa till adressfamilj"
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Lördag"
 
@@ -527,41 +527,41 @@ msgid "Source IP address"
 msgstr "IP-adress för källa"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "MAC-adress för källa"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Adress för källkod"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Startdatum (åååå-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Stopptid (åååå-mm-dd)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Söndag"
 
@@ -591,15 +591,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Torsdag"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Tid enligt UTC"
 
@@ -619,19 +619,19 @@ msgstr "Till %s på <var>den här enheten</var>"
 msgid "To %s, %s in %s"
 msgstr "Till %s, %s i %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Trafikregler"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Tisdag"
 
@@ -644,8 +644,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -673,11 +673,11 @@ msgstr "Via %s"
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Onsdag"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Veckodagar"
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "Zones"
 msgstr "Zoner"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -700,12 +700,12 @@ msgstr "acceptera"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "något"
 
@@ -732,11 +732,11 @@ msgstr "alla zoner"
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "spåra inte"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -763,7 +763,7 @@ msgstr "port"
 msgid "ports"
 msgstr "portar"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/templates/firewall.pot
+++ b/applications/luci-app-firewall/po/templates/firewall.pot
@@ -37,8 +37,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr ""
 
@@ -56,7 +56,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -73,12 +73,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -126,15 +126,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -311,12 +311,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -325,7 +325,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -368,11 +368,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -382,17 +382,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -425,7 +425,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -513,41 +513,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -577,15 +577,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -605,19 +605,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -630,8 +630,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -659,11 +659,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -675,7 +675,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -686,12 +686,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -718,11 +718,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -749,7 +749,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/tr/firewall.po
+++ b/applications/luci-app-firewall/po/tr/firewall.po
@@ -48,8 +48,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Eylem"
 
@@ -67,7 +67,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -84,12 +84,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -137,15 +137,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr ""
 
@@ -184,7 +184,7 @@ msgid "Drop invalid packets"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgid "External port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -294,7 +294,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -322,12 +322,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -379,11 +379,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -393,17 +393,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -436,7 +436,7 @@ msgid "Output"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -461,7 +461,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -524,41 +524,41 @@ msgid "Source IP address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -588,15 +588,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -616,19 +616,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -641,8 +641,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -670,11 +670,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -686,7 +686,7 @@ msgstr ""
 msgid "Zones"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -697,12 +697,12 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -729,11 +729,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -760,7 +760,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/uk/firewall.po
+++ b/applications/luci-app-firewall/po/uk/firewall.po
@@ -49,8 +49,8 @@ msgstr "Приймати вхідний"
 msgid "Accept output"
 msgstr "Приймати вихідний"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Дія"
 
@@ -74,7 +74,7 @@ msgstr ""
 "вхідний трафік HTTPS."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "Додаткові параметри"
@@ -91,12 +91,12 @@ msgstr "Дозволити переспрямовування від <em>зон 
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "Дозволити переспрямовування до <em>зон призначення</em>:"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "Будь-який"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "Будь-який день"
 
@@ -155,15 +155,15 @@ msgstr ""
 "виконуються після кожного перезавантаження брандмауера, відразу після "
 "завантаження типового набору правил."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Адреса призначення"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Порт призначення"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "Зона призначення"
 
@@ -205,7 +205,7 @@ msgid "Drop invalid packets"
 msgstr "Відкидати помилкові пакети"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Увімкнути"
 
@@ -240,7 +240,7 @@ msgid "External port"
 msgstr "Зовнішній порт"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "Додаткові аргументи"
 
@@ -268,7 +268,7 @@ msgstr "Брандмауер — Настроювані правила"
 msgid "Firewall - Port Forwards"
 msgstr "Брандмауер — Переспрямовування портів"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "Брандмауер — Правила трафіка"
 
@@ -285,7 +285,7 @@ msgstr "Переспрямовування"
 msgid "Forward to"
 msgstr "переспрямовування до"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "П'ятниця"
 
@@ -317,7 +317,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "Від %s на <var>цьому пристрої</var> з джерелом %s та %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -345,12 +345,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 та IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "Лише IPv4"
@@ -359,7 +359,7 @@ msgstr "Лише IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "Лише IPv6"
@@ -402,11 +402,11 @@ msgid "Masquerading"
 msgstr "Підміна"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "Зіставляти"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "Зіставляти ICMP типу"
 
@@ -418,17 +418,17 @@ msgstr ""
 "Зіставляти вхідний трафік, спрямований на заданий порт призначення або "
 "діапазон портів цього вузла"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "Понеділок"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "Дні місяця"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "Ім'я"
@@ -463,7 +463,7 @@ msgid "Output"
 msgstr "Вихідний"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 "Передача додаткових аргументів для IPTables. Використовуйте з обережністю!"
@@ -496,7 +496,7 @@ msgstr ""
 "підключатися до певного комп'ютера або служби у приватній мережі."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Протокол"
 
@@ -534,7 +534,7 @@ msgstr "Обмежити підміну заданими підмережами 
 msgid "Restrict Masquerading to given source subnets"
 msgstr "Обмежити підміну заданими підмережами джерела"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "Обмежити сімейство протоколів"
@@ -543,7 +543,7 @@ msgstr "Обмежити сімейство протоколів"
 msgid "Routing/NAT Offloading"
 msgstr "Розвантаження маршрутизації/NAT"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "Субота"
 
@@ -560,41 +560,41 @@ msgid "Source IP address"
 msgstr "IP-адреса джерела"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "MAC-адреса джерела"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "Адреса джерела"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Порт джерела"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "Зона джерела"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "Дата початку (рррр-мм-дд)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "Час початку (гг:хх:сс)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "Дата зупинки (рррр-мм-дд)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "Час зупинки (гг:хх:сс)"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "Неділя"
 
@@ -638,15 +638,15 @@ msgstr ""
 "спрямовування трафіку між різними мережами в межах зони. Пункт <em>Покриті "
 "мережі</em> визначає, які доступні мережі є членами цієї зони."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "Четвер"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "Часові обмеження"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "Час в UTC"
 
@@ -666,12 +666,12 @@ msgstr "%s на <var>цього пристрою</var>"
 msgid "To %s, %s in %s"
 msgstr "%s, %s у %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "Правила трафіка"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -681,7 +681,7 @@ msgstr ""
 "різними зонами, наприклад, відхиляти трафік між певними вузлами або відкрити "
 "порти WAN на маршрутизаторі."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "Вівторок"
 
@@ -694,8 +694,8 @@ msgstr "Не вдалося зберегти вміст: %s"
 msgid "Unnamed forward"
 msgstr "Переспрямовування без назви"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "Правило без назви"
 
@@ -727,11 +727,11 @@ msgstr "Через %s"
 msgid "Via %s at %s"
 msgstr "Через %s на %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "Середа"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "Дні тижня"
 
@@ -743,7 +743,7 @@ msgstr "Зона ⇒ Переспрямовування"
 msgid "Zones"
 msgstr "Зони"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -754,12 +754,12 @@ msgstr "приймати"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "будь-який"
 
@@ -786,11 +786,11 @@ msgstr "будь-якій зоні"
 msgid "day"
 msgstr "день"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "не відстеж."
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -817,7 +817,7 @@ msgstr "порт"
 msgid "ports"
 msgstr "порти"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/vi/firewall.po
+++ b/applications/luci-app-firewall/po/vi/firewall.po
@@ -52,8 +52,8 @@ msgstr ""
 msgid "Accept output"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "Hành động"
 
@@ -71,7 +71,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr ""
@@ -88,12 +88,12 @@ msgstr ""
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -141,15 +141,15 @@ msgid ""
 "each firewall restart, right after the default ruleset has been loaded."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "Địa chỉ điểm đến"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "Cổng điểm đến"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 #, fuzzy
 msgid "Destination zone"
 msgstr "Điểm đến"
@@ -189,7 +189,7 @@ msgid "Drop invalid packets"
 msgstr "Bỏ qua nhưng gói không hợp lý"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "Kích hoạt"
 
@@ -223,7 +223,7 @@ msgid "External port"
 msgstr "External port"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Firewall - Port Forwards"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr ""
 
@@ -268,7 +268,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr ""
 
@@ -300,7 +300,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -328,12 +328,12 @@ msgid "IPv4"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr ""
@@ -388,11 +388,11 @@ msgid "Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr ""
 
@@ -402,17 +402,17 @@ msgid ""
 "on this host"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr ""
@@ -445,7 +445,7 @@ msgid "Output"
 msgstr "Output"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "Giao thức"
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Restrict Masquerading to given source subnets"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 msgid "Routing/NAT Offloading"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr ""
 
@@ -534,43 +534,43 @@ msgid "Source IP address"
 msgstr "Đỉa chỉ MAC nguồn"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 #, fuzzy
 msgid "Source address"
 msgstr "Đỉa chỉ MAC nguồn"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "Cổng nguồn"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 #, fuzzy
 msgid "Source zone"
 msgstr "Cổng nguồn"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr ""
 
@@ -602,15 +602,15 @@ msgid ""
 "networks</em> specifies which available networks are members of this zone."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr ""
 
@@ -630,19 +630,19 @@ msgstr ""
 msgid "To %s, %s in %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
 "the router."
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr ""
 
@@ -655,8 +655,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr ""
 
@@ -684,11 +684,11 @@ msgstr ""
 msgid "Via %s at %s"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Zones"
 msgstr "Zones"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -711,12 +711,12 @@ msgstr "chấp nhận"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr ""
 
@@ -743,11 +743,11 @@ msgstr ""
 msgid "day"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -774,7 +774,7 @@ msgstr ""
 msgid "ports"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/zh-cn/firewall.po
+++ b/applications/luci-app-firewall/po/zh-cn/firewall.po
@@ -52,8 +52,8 @@ msgstr "接受入站"
 msgid "Accept output"
 msgstr "接受出站"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "动作"
 
@@ -75,7 +75,7 @@ msgstr ""
 "code> 仅匹配入站 HTTPS 流量。"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "高级设置"
@@ -92,12 +92,12 @@ msgstr "允许来自<em>源区域</em>的转发："
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "允许转发到<em>目标区域</em>："
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "任何"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr "每天"
 
@@ -147,15 +147,15 @@ msgstr ""
 "自定义规则允许您执行不属于防火墙框架的任意 iptables 命令。每次重启防火墙时，"
 "在默认的规则运行后这些命令将立即执行。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "目标地址"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "目标端口"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "目标区域"
 
@@ -196,7 +196,7 @@ msgid "Drop invalid packets"
 msgstr "丢弃无效数据包"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "启用"
 
@@ -229,7 +229,7 @@ msgid "External port"
 msgstr "外部端口"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "额外参数"
 
@@ -257,7 +257,7 @@ msgstr "防火墙 - 自定义规则"
 msgid "Firewall - Port Forwards"
 msgstr "防火墙 - 端口转发"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "防火墙 - 通信规则"
 
@@ -274,7 +274,7 @@ msgstr "转发"
 msgid "Forward to"
 msgstr "转发到"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "星期五"
 
@@ -306,7 +306,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "来自 %s 位于<var>本设备</var>源端口 %s 源 MAC %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -334,12 +334,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 和 IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "仅 IPv4"
@@ -348,7 +348,7 @@ msgstr "仅 IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "仅 IPv6"
@@ -391,11 +391,11 @@ msgid "Masquerading"
 msgstr "IP 动态伪装"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "匹配规则"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "匹配 ICMP 类型"
 
@@ -405,17 +405,17 @@ msgid ""
 "on this host"
 msgstr "匹配指向此主机上指定目标端口或目标端口范围的入站流量"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "星期一"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "日期"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "名称"
@@ -448,7 +448,7 @@ msgid "Output"
 msgstr "出站数据"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "传递到 iptables 的额外参数。小心使用！"
 
@@ -477,7 +477,7 @@ msgstr ""
 "端口转发允许 Internet 上的远程计算机连接到内部网络中的特定计算机或服务。"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "协议"
 
@@ -514,7 +514,7 @@ msgstr "要限制 IP 动态伪装的目标子网"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "要限制 IP 动态伪装的源子网"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "限制地址"
@@ -523,7 +523,7 @@ msgstr "限制地址"
 msgid "Routing/NAT Offloading"
 msgstr "Routing/NAT 分载"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "星期六"
 
@@ -540,41 +540,41 @@ msgid "Source IP address"
 msgstr "源 IP 地址"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "源 MAC 地址"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "源地址"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "源端口"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "源区域"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "开始日期（yyyy-mm-dd）"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr "开始时间（hh.mm.ss）"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "停止日期（yyyy-mm-dd）"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr "停止时间（hh.mm.ss）"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "星期日"
 
@@ -611,15 +611,15 @@ msgstr ""
 "域入站和出站流量的默认策略，<em>转发</em>选项描述该区域内不同网络之间的流量转"
 "发策略。<em>涵盖的网络</em>指定从属于这个区域的网络。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "星期四"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr "时间限制"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "UTC 时间"
 
@@ -639,12 +639,12 @@ msgstr "到 %s 位于<var>本设备</var>"
 msgid "To %s, %s in %s"
 msgstr "到 %s, %s 位于 %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "通信规则"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -653,7 +653,7 @@ msgstr ""
 "通信规则定义了不同区域间的数据包传输策略，例如：拒绝一些主机之间的通信，开放"
 "路由器 WAN 上的端口。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "星期二"
 
@@ -666,8 +666,8 @@ msgstr "无法保存内容：%s"
 msgid "Unnamed forward"
 msgstr "未命名转发"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "未命名规则"
 
@@ -695,11 +695,11 @@ msgstr "通过 %s"
 msgid "Via %s at %s"
 msgstr "通过 %s 在 %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "星期三"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "星期"
 
@@ -711,7 +711,7 @@ msgstr "区域 ⇒ 转发"
 msgid "Zones"
 msgstr "区域"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -722,12 +722,12 @@ msgstr "接受"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "任意"
 
@@ -754,11 +754,11 @@ msgstr "所有区域"
 msgid "day"
 msgstr "日"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "不跟踪"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -785,7 +785,7 @@ msgstr "端口"
 msgid "ports"
 msgstr "端口"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-firewall/po/zh-tw/firewall.po
+++ b/applications/luci-app-firewall/po/zh-tw/firewall.po
@@ -49,8 +49,8 @@ msgstr "接受入站"
 msgid "Accept output"
 msgstr "接受出站"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:183
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:328
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:215
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:354
 msgid "Action"
 msgstr "行動"
 
@@ -68,7 +68,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:101
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:137
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:78
 msgid "Advanced Settings"
 msgstr "高階設定"
@@ -85,12 +85,12 @@ msgstr "允許從<em>源區域</em>轉發："
 msgid "Allow forward to <em>destination zones</em>:"
 msgstr "允許轉發到<em>目標區域</em>："
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:208
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:244
 msgid "Any"
 msgstr "任何"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:344
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:370
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:386
 msgid "Any day"
 msgstr ""
 
@@ -140,15 +140,15 @@ msgstr ""
 "自訂規則允許您執行不屬於防火牆框架的任意 iptables 指令。每次重啟防火牆時，在"
 "預設的規則執行後這些指令將立即執行。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:308
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:339
 msgid "Destination address"
 msgstr "目標位址"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:319
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
 msgid "Destination port"
 msgstr "目標埠"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:302
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
 msgid "Destination zone"
 msgstr "目標區域"
 
@@ -187,7 +187,7 @@ msgid "Drop invalid packets"
 msgstr "丟棄無效資料包"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:149
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:189
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:221
 msgid "Enable"
 msgstr "啟用"
 
@@ -220,7 +220,7 @@ msgid "External port"
 msgstr "外部埠"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:267
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:336
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:362
 msgid "Extra arguments"
 msgstr "附加引數"
 
@@ -248,7 +248,7 @@ msgstr "防火牆 - 自訂規則"
 msgid "Firewall - Port Forwards"
 msgstr "防火牆 - 埠轉發"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:128
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:160
 msgid "Firewall - Traffic Rules"
 msgstr "防火牆 - 通訊規則"
 
@@ -265,7 +265,7 @@ msgstr "轉發"
 msgid "Forward to"
 msgstr "轉發到"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:350
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:376
 msgid "Friday"
 msgstr "星期五"
 
@@ -297,7 +297,7 @@ msgid "From %s on <var>this device</var> with source %s and %s"
 msgstr "來自 %s 位於<var>本裝置</var>源埠 %s 源 MAC %s"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:100
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:136
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:168
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:31
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:77
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:16
@@ -325,12 +325,12 @@ msgid "IPv4"
 msgstr "IPv4"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:220
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:233
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:189
 msgid "IPv4 and IPv6"
 msgstr "IPv4 和 IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:234
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:190
 msgid "IPv4 only"
 msgstr "僅 IPv4"
@@ -339,7 +339,7 @@ msgstr "僅 IPv4"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:203
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:235
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:191
 msgid "IPv6 only"
 msgstr "僅 IPv6"
@@ -382,11 +382,11 @@ msgid "Masquerading"
 msgstr "IP 動態偽裝"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:125
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:173
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
 msgid "Match"
 msgstr "匹配規則"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:218
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:254
 msgid "Match ICMP type"
 msgstr "匹配 ICMP 型別"
 
@@ -396,17 +396,17 @@ msgid ""
 "on this host"
 msgstr "匹配指向此主機上指定目標埠或目標埠範圍的入站流量。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:346
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:372
 msgid "Monday"
 msgstr "星期一"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:353
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:382
 msgid "Month Days"
 msgstr "日期"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:121
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:169
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:195
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:201
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:227
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:93
 msgid "Name"
 msgstr "名字"
@@ -439,7 +439,7 @@ msgid "Output"
 msgstr "出站資料"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:268
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:337
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:363
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "傳遞到 iptables 的額外引數。小心使用！"
 
@@ -464,7 +464,7 @@ msgid ""
 msgstr "埠轉發允許 Internet 上的遠端計算機連線到內部網路中的特定計算機或服務。"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:154
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:205
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:241
 msgid "Protocol"
 msgstr "協議"
 
@@ -501,7 +501,7 @@ msgstr "要限制 IP 動態偽裝的目標子網"
 msgid "Restrict Masquerading to given source subnets"
 msgstr "要限制 IP 動態偽裝的源子網"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:198
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:230
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:188
 msgid "Restrict to address family"
 msgstr "限制位址"
@@ -510,7 +510,7 @@ msgstr "限制位址"
 msgid "Routing/NAT Offloading"
 msgstr "Routing/NAT 分載"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:351
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
 msgid "Saturday"
 msgstr "星期六"
 
@@ -527,41 +527,41 @@ msgid "Source IP address"
 msgstr "源 IP 位址"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:173
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:271
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:307
 msgid "Source MAC address"
 msgstr "源 MAC 位址"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:282
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:318
 msgid "Source address"
 msgstr "源位址"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:199
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:293
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:324
 msgid "Source port"
 msgstr "源埠"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:167
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:265
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:301
 msgid "Source zone"
 msgstr "源區域"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:369
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:401
 msgid "Start Date (yyyy-mm-dd)"
 msgstr "開始日期（yyyy-mm-dd）"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:361
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:393
 msgid "Start Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:405
 msgid "Stop Date (yyyy-mm-dd)"
 msgstr "停止日期（yyyy-mm-dd）"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:365
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:397
 msgid "Stop Time (hh.mm.ss)"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:345
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:371
 msgid "Sunday"
 msgstr "星期日"
 
@@ -598,15 +598,15 @@ msgstr ""
 "域入站和出站流量的預設策略，<em>轉發</em>選項描述該區域內不同網路之間的流量轉"
 "發策略。<em>覆蓋網路</em>指定從屬於這個區域的網路。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:349
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:375
 msgid "Thursday"
 msgstr "星期四"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:138
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
 msgid "Time Restrictions"
 msgstr ""
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:377
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:409
 msgid "Time in UTC"
 msgstr "UTC 時間"
 
@@ -626,12 +626,12 @@ msgstr "到 %s 位於<var>本裝置</var>"
 msgid "To %s, %s in %s"
 msgstr "到 %s, %s 位於 %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:131
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:163
 #: applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json:34
 msgid "Traffic Rules"
 msgstr "通訊規則"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:129
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:161
 msgid ""
 "Traffic rules define policies for packets traveling between different zones, "
 "for example to reject traffic between certain hosts or to open WAN ports on "
@@ -640,7 +640,7 @@ msgstr ""
 "通訊規則定義了不同區域間的資料包傳輸策略，例如：拒絕一些主機之間的通訊，開放"
 "路由器 WAN 上的埠。"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:347
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:373
 msgid "Tuesday"
 msgstr "星期二"
 
@@ -653,8 +653,8 @@ msgstr ""
 msgid "Unnamed forward"
 msgstr "未命名轉發"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:145
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:170
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:177
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:202
 msgid "Unnamed rule"
 msgstr "未命名規則"
 
@@ -682,11 +682,11 @@ msgstr "通過 %s"
 msgid "Via %s at %s"
 msgstr "通過 %s 在 %s"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:374
 msgid "Wednesday"
 msgstr "星期三"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:340
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:366
 msgid "Week Days"
 msgstr "星期"
 
@@ -698,7 +698,7 @@ msgstr "區域 ⇒ 轉發"
 msgid "Zones"
 msgstr "區域"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:332
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:358
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:47
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:123
 msgid "accept"
@@ -709,12 +709,12 @@ msgstr "接受"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:204
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:215
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:255
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:223
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:274
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:285
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:296
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:311
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:322
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:259
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:310
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:321
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:327
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:342
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:348
 msgid "any"
 msgstr "所有"
 
@@ -741,11 +741,11 @@ msgstr "所有區域"
 msgid "day"
 msgstr "日"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:334
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:360
 msgid "don't track"
 msgstr "不跟蹤"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:331
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:357
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:46
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:122
 msgid "drop"
@@ -772,7 +772,7 @@ msgstr "埠"
 msgid "ports"
 msgstr "埠"
 
-#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:333
+#: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js:359
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:45
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:121
 msgid "reject"

--- a/applications/luci-app-fwknopd/po/templates/fwknopd.pot
+++ b/applications/luci-app-fwknopd/po/templates/fwknopd.pot
@@ -12,7 +12,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -65,8 +65,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -82,7 +82,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-mjpg-streamer/po/templates/mjpg-streamer.pot
+++ b/applications/luci-app-mjpg-streamer/po/templates/mjpg-streamer.pot
@@ -46,7 +46,7 @@ msgid "Don't initialize dynctrls"
 msgstr ""
 
 #: applications/luci-app-mjpg-streamer/luasrc/model/cbi/mjpg-streamer.lua:74
-msgid "Drop frames smaller then this limit"
+msgid "Drop frames smaller than this limit"
 msgstr ""
 
 #: applications/luci-app-mjpg-streamer/luasrc/model/cbi/mjpg-streamer.lua:12
@@ -67,7 +67,7 @@ msgstr ""
 
 #: applications/luci-app-mjpg-streamer/luasrc/model/cbi/mjpg-streamer.lua:220
 msgid ""
-"Execute command after saving picture. Mjpg-streamer parse the filename as "
+"Execute command after saving picture. Mjpg-streamer parses the filename as "
 "first parameter to your script."
 msgstr ""
 

--- a/applications/luci-app-mwan3/po/bg/mwan3.po
+++ b/applications/luci-app-mwan3/po/bg/mwan3.po
@@ -4,38 +4,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -43,6 +43,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -51,22 +52,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -126,13 +126,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -213,11 +213,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -264,8 +264,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -274,17 +274,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -296,16 +296,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -396,15 +396,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -438,18 +438,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -511,24 +511,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -555,17 +555,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -612,13 +612,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -677,13 +677,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -748,8 +748,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -763,36 +763,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/ca/mwan3.po
+++ b/applications/luci-app-mwan3/po/ca/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr "Depuració"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Activat"
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr "S’està esperant que l’ordre s’acabi…"
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Sí"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/cs/mwan3.po
+++ b/applications/luci-app-mwan3/po/cs/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d hodina"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d minuta"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d minut"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d sekunda"
 
@@ -49,6 +49,7 @@ msgstr "%d sekunda"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr "%d sekunda"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d sekund"
 
@@ -80,7 +80,7 @@ msgstr "%d sekund"
 msgid "-- Please choose --"
 msgstr "-- Prosím vyberte --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 #, fuzzy
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -135,13 +135,13 @@ msgstr "Kritické"
 msgid "Debug"
 msgstr "Ladění"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Cílová adresa"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Cílový port"
 
@@ -163,7 +163,7 @@ msgstr "Diagnostika"
 msgid "Disabled"
 msgstr "Zakázáno"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -176,8 +176,8 @@ msgstr "Záchrana"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Povoleno"
 
@@ -210,7 +210,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -222,11 +222,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -273,8 +273,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -283,17 +283,17 @@ msgstr ""
 msgid "Interface"
 msgstr "Rozhraní"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -305,16 +305,16 @@ msgstr "Síťová rozhraní"
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -405,15 +405,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Metrika"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -520,24 +520,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -564,17 +564,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Politika"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -621,13 +621,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Zdrojová adresa"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Zdrojový port"
 
@@ -652,7 +652,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -686,13 +686,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -757,8 +757,8 @@ msgstr "Čekání na dokončení příkazu..."
 msgid "Warning"
 msgstr "Varování"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Váha"
 
@@ -772,36 +772,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Ano"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/de/mwan3.po
+++ b/applications/luci-app-mwan3/po/de/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d Stunde"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d Minute"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d Minuten"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d Sekunde"
 
@@ -49,6 +49,7 @@ msgstr "%d Sekunde"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr "%d Sekunde"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d Sekunden"
 
@@ -80,7 +80,7 @@ msgstr "%d Sekunden"
 msgid "-- Please choose --"
 msgstr "-- Bitte auswählen --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -112,7 +112,7 @@ msgstr "Auch diese Routing-Tabelle für verbundene Netzwerke scannen"
 msgid "Check IP rules"
 msgstr "Prüfen der IP-Regeln"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "Linkqualität prüfen"
 
@@ -134,13 +134,13 @@ msgstr "Kritisch"
 msgid "Debug"
 msgstr "Debug"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Zieladresse"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Zielport"
 
@@ -162,7 +162,7 @@ msgstr "Diagnosen"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -177,8 +177,8 @@ msgstr "Notfall"
 msgid "Enable ssl tracking"
 msgstr "Aktiviere SSL-Tracking"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -213,7 +213,7 @@ msgstr "Ausführen"
 msgid "Expect interface state on up event"
 msgstr "Erwarteter Schnittstellen status beim up event"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "Fehler-Intervall"
 
@@ -225,11 +225,11 @@ msgstr "Firewall-Protokollierungsstufe"
 msgid "Firewall mask"
 msgstr "Firewall-Maske"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "Conntrack-Tabelle leeren"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr "Leere Global-Firewall-Conntrack-Table bei Schnittstellen-Events"
 
@@ -278,8 +278,8 @@ msgid "Initial state"
 msgstr "Ausgangszustand"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -288,17 +288,17 @@ msgstr "Ausgangszustand"
 msgid "Interface"
 msgstr "Schnittstelle"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "Schnittstelle nicht aktiv"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "Schnittstelle aktiv"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 "Die Schnittstelle wird nach dieser Anzahl an fehlgeschlagenen Tracking-"
@@ -312,16 +312,16 @@ msgstr "Schnittstellen"
 msgid "Internet Protocol"
 msgstr "Internet-Protokoll"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "Fehlerintervall beibehalten"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr "Ping-Fehlerintervall während des Ausfalls beibehalten"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "Letzter Ausweg"
 
@@ -419,15 +419,15 @@ msgstr ""
 ">Schnittstellen dürfen nicht den gleichen Namen wie konfigurierte "
 "Mitglieder, Richtlinien oder Regeln verwenden"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "Maximale TTL"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "Maximale Paketlatenzzeit [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "Maximaler Paketverlust [%]"
 
@@ -467,18 +467,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "Mitglieder, zugewiesen"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Metrik"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "Minimale Paketlatenzzeit [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "Minimaler Paketverlust [%]"
 
@@ -534,7 +534,7 @@ msgstr "Online"
 msgid "Only one IP rules for interface %s found"
 msgstr "Nur eine IP-Regel für die Schnittstelle %s gefunden"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Ping-Zähler"
 
@@ -542,24 +542,24 @@ msgstr "Ping-Zähler"
 msgid "Ping default gateway"
 msgstr "Ping-Standard-Gateway"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Ping-Intervall"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "Ping-Intervall während Fehlererkennung"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "Ping-Intervall während der Wiederherstellung"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Ping-Größe"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Ping-Timeout"
 
@@ -595,17 +595,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Standardregel"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "Richtlinie, zugewiesen"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "Wiederherstellungs-Intervall"
 
@@ -664,13 +664,13 @@ msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 "Sekunden. Gültige Werte: 1-1000000. Standard bei 600 falls nicht gesetzt"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Quelladresse"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Quellport"
 
@@ -697,7 +697,7 @@ msgstr "Aufgabe"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "Es sind derzeit %d von %d unterstützten Schnittstellen konfiguriert"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -753,13 +753,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr "Name oder IP-Adresse des Tracking Hosts"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "Tracking-Methode"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "Tracking-Sicherheit"
 
@@ -837,8 +837,8 @@ msgstr "Der Befehl wird ausgeführt..."
 msgid "Warning"
 msgstr "Warnung"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Gewichtung"
 
@@ -854,36 +854,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Ja"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "blackhole (drop)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr "verbunden (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "default (Haupt-Routing-Tabelle wird benutzt)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr "getrennt (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr "ifdown (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr "ifup (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "unerreichbar (rejectet)"

--- a/applications/luci-app-mwan3/po/el/mwan3.po
+++ b/applications/luci-app-mwan3/po/el/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr "Διεπαφή"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/en/mwan3.po
+++ b/applications/luci-app-mwan3/po/en/mwan3.po
@@ -4,38 +4,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -43,6 +43,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -51,22 +52,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -126,13 +126,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -213,11 +213,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -264,8 +264,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -274,17 +274,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -296,16 +296,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -396,15 +396,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -438,18 +438,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -511,24 +511,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -555,17 +555,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -612,13 +612,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -677,13 +677,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -748,8 +748,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -763,36 +763,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/es/mwan3.po
+++ b/applications/luci-app-mwan3/po/es/mwan3.po
@@ -13,38 +13,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d hora"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d minuto"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d minutos"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d segundo"
 
@@ -52,6 +52,7 @@ msgstr "%d segundo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -60,22 +61,21 @@ msgstr "%d segundo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d segundos"
 
@@ -83,7 +83,7 @@ msgstr "%d segundos"
 msgid "-- Please choose --"
 msgstr "-- Por favor elija --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -117,7 +117,7 @@ msgstr "También escanee esta tabla de enrutamiento para redes conectadas"
 msgid "Check IP rules"
 msgstr "Comprobar reglas de IP"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "Comprobar calidad del enlace"
 
@@ -139,13 +139,13 @@ msgstr "Crítico"
 msgid "Debug"
 msgstr "Depurar"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Dirección de destino"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Puerto de destino"
 
@@ -167,7 +167,7 @@ msgstr "Diagnósticos"
 msgid "Disabled"
 msgstr "Desactivado"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -182,8 +182,8 @@ msgstr "Emergencia"
 msgid "Enable ssl tracking"
 msgstr "Activar seguimiento de SSL"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Activado"
 
@@ -218,7 +218,7 @@ msgstr "Ejecutar"
 msgid "Expect interface state on up event"
 msgstr "Esperar el estado de la interfaz en el evento"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "Intervalo de fracaso"
 
@@ -230,11 +230,11 @@ msgstr "Nivel de firewall"
 msgid "Firewall mask"
 msgstr "Mascara de Firewall"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "Purgar mesa de conexión"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 "Vaciar la tabla de conexiones de firewall global en los eventos de la "
@@ -285,8 +285,8 @@ msgid "Initial state"
 msgstr "Estado inicial"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -295,17 +295,17 @@ msgstr "Estado inicial"
 msgid "Interface"
 msgstr "Interfaz"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "Bajar interfaz"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "Levantar interfaz"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 "La interfaz se considerará inactiva después de tantas pruebas de ping "
@@ -319,16 +319,16 @@ msgstr "Interfaces"
 msgid "Internet Protocol"
 msgstr "Protocolo de Internet"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "Mantener el intervalo de falla"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr "Mantener el intervalo de falla de ping durante el estado de falla"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "Último recurso"
 
@@ -425,15 +425,15 @@ msgstr ""
 "caracteres AZ, az, 0-9, _ y sin espacios<br />Las interfaces no pueden "
 "compartir el mismo nombre que los miembros configurados, políticas o reglas"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "Máx TTL"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "Latencia máxima de paquetes [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "Pérdida máxima de paquetes [%]"
 
@@ -473,18 +473,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "Miembros asignados"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Métrica"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "Latencia mínima de paquetes [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "Pérdida mínima de paquetes [%]"
 
@@ -540,7 +540,7 @@ msgstr "Conectado"
 msgid "Only one IP rules for interface %s found"
 msgstr "Solo se encontró una regla de IP para la interfaz %s"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Recuento de ping"
 
@@ -548,24 +548,24 @@ msgstr "Recuento de ping"
 msgid "Ping default gateway"
 msgstr "Ping a puerta de enlace predeterminada"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Intervalo de ping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "Intervalo de ping durante la detección de fallos"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "Intervalo de ping durante la recuperación de fallos"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Tamaño de ping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Tiempo de espera de ping"
 
@@ -600,17 +600,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Política"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "Política asignada"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "Intervalo de recuperación"
 
@@ -670,13 +670,13 @@ msgstr ""
 "Segundos. Valores aceptables: 1-1000000. El valor predeterminado es 600 si "
 "no se establece"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Dirección de origen"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Puerto de origen"
 
@@ -702,7 +702,7 @@ msgstr "Tarea"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "Actualmente hay %d de %d interfaces compatibles configuradas"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -755,13 +755,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr "Seguimiento de nombre de host o dirección IP"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "Método de seguimiento"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "Fiabilidad de seguimiento"
 
@@ -838,8 +838,8 @@ msgstr "Esperando a que se complete el comando..."
 msgid "Warning"
 msgstr "Advertencia"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Peso"
 
@@ -855,36 +855,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Si"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "agujero negro (caída)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr "conectado (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "predeterminado (usar tabla de enrutamiento principal)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr "desconectado (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr "Interfaz abajo (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr "Interfaz arriba (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "inalcanzable (rechazar)"

--- a/applications/luci-app-mwan3/po/fr/mwan3.po
+++ b/applications/luci-app-mwan3/po/fr/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr "Débogage"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Adresse de destination"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Port de destination"
 
@@ -160,7 +160,7 @@ msgstr "Diagnostics"
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Activé"
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr "Interfaces"
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Métrique"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protocole"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Adresse source"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Port source"
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr "En attente que la commande se termine…"
 msgid "Warning"
 msgstr "Avertissement"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Oui"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/he/mwan3.po
+++ b/applications/luci-app-mwan3/po/he/mwan3.po
@@ -4,38 +4,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -43,6 +43,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -51,22 +52,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -126,13 +126,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -213,11 +213,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -264,8 +264,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -274,17 +274,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -296,16 +296,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -396,15 +396,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -438,18 +438,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -511,24 +511,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -555,17 +555,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -612,13 +612,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -677,13 +677,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -748,8 +748,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -763,36 +763,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/hi/mwan3.po
+++ b/applications/luci-app-mwan3/po/hi/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr "कृपया चुने"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/hu/mwan3.po
+++ b/applications/luci-app-mwan3/po/hu/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d óra"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d perc"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d perc"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d másodperc"
 
@@ -49,6 +49,7 @@ msgstr "%d másodperc"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr "%d másodperc"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d másodperc"
 
@@ -80,7 +80,7 @@ msgstr "%d másodperc"
 msgid "-- Please choose --"
 msgstr "-- Kérem válasszon --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -106,13 +106,14 @@ msgstr "A(z) %s csatoló összes szükséges IP-szabálya megtalálva"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:57
 msgid "Also scan this Routing table for connected networks"
-msgstr "Vizsgálja ezt az útválasztási táblázatot is a kapcsolódott hálózatoknál"
+msgstr ""
+"Vizsgálja ezt az útválasztási táblázatot is a kapcsolódott hálózatoknál"
 
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:73
 msgid "Check IP rules"
 msgstr "IP-szabályok ellenőrzése"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "Kapcsolatminőség ellenőrzése"
 
@@ -134,13 +135,13 @@ msgstr "Kritikus"
 msgid "Debug"
 msgstr "Hibakeresés"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Célcím"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Célport"
 
@@ -162,7 +163,7 @@ msgstr "Diagnosztika"
 msgid "Disabled"
 msgstr "Letiltva"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -177,8 +178,8 @@ msgstr "Vészhelyzet"
 msgid "Enable ssl tracking"
 msgstr "SSL követés engedélyezése"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Engedélyezve"
 
@@ -213,7 +214,7 @@ msgstr "Végrehajtás"
 msgid "Expect interface state on up event"
 msgstr "Elvárt csatolóállapot a felkapcsolás eseménynél"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "Sikertelenség időköze"
 
@@ -225,11 +226,11 @@ msgstr "Tűzfal naplószintje"
 msgid "Firewall mask"
 msgstr "Tűzfal maszkja"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "Kapcsolatkövető táblázat kiürítése"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 "Globális tűzfal kapcsolatkövető táblázat kiürítése a csatolóeseményeknél"
@@ -279,8 +280,8 @@ msgid "Initial state"
 msgstr "Kezdeti állapot"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -289,17 +290,17 @@ msgstr "Kezdeti állapot"
 msgid "Interface"
 msgstr "Csatoló"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "Csatoló lekapcsolása"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "Csatoló felkapcsolása"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 "A csatoló lekapcsoltnak lesz tekintve ennyi sikertelen pingelési teszt után"
@@ -312,17 +313,17 @@ msgstr "Csatolók"
 msgid "Internet Protocol"
 msgstr "Internetprotokoll"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "Sikertelenség időközének megtartása"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 "Pingelés sikertelenségi időközének megtartása a sikertelen állapot közben"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "Végső megoldás"
 
@@ -419,15 +420,15 @@ msgstr ""
 "karaktereket tartalmazhatnak, szóközt nem<br />A csatolók nem oszthatják meg "
 "ugyanazt a nevet mint a beállított tagok, házirendek vagy szabályok"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "Legnagyobb élettartam"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "Legnagyobb csomagkésleltetés [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "Legnagyobb csomagvesztés [%]"
 
@@ -467,18 +468,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "Hozzárendelt tagok"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Mérőszám"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "Legkisebb csomagkésleltetés [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "Legkisebb csomagvesztés [%]"
 
@@ -534,7 +535,7 @@ msgstr "Elérhető"
 msgid "Only one IP rules for interface %s found"
 msgstr "Csak egy IP-szabály található a(z) %s csatolónál"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Pingelés darabszáma"
 
@@ -542,24 +543,24 @@ msgstr "Pingelés darabszáma"
 msgid "Ping default gateway"
 msgstr "Alapértelmezett átjáró pingelése"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Pingelés időköze"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "Pingelés időköze a sikertelen állapot közben"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "Pingelés időköze a sikertelen visszaállítás közben"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Pingelés mérete"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Pingelés időkorlátja"
 
@@ -584,28 +585,28 @@ msgstr ""
 "A házirendek olyan profilok, amelyek egy vagy több tagot csoportosítanak azt "
 "vezérelve, hogy a MWAN hogyan osztja el a forgalmat<br />Az alacsony "
 "mérőszámokkal rendelkező tagcsatolók vannak először használva<br />Az "
-"ugyanazzal a mérőszámmal rendelkező tagcsatolók terheléselosztásra kerülnek<"
-"br />A terheléselosztott tagcsatolók több forgalmat osztanak el a magasabb "
-"súlyúak között<br />A nevek A-Z, a-z, 0-9 és _ karaktereket tartalmazhatnak, "
-"szóközt nem<br />A nevek legfeljebb 15 karakteresek lehetnek<br />A "
-"házirendek nem oszthatják meg ugyanazt a nevet mint a beállított csatolók, "
-"tagok vagy szabályok"
+"ugyanazzal a mérőszámmal rendelkező tagcsatolók terheléselosztásra "
+"kerülnek<br />A terheléselosztott tagcsatolók több forgalmat osztanak el a "
+"magasabb súlyúak között<br />A nevek A-Z, a-z, 0-9 és _ karaktereket "
+"tartalmazhatnak, szóközt nem<br />A nevek legfeljebb 15 karakteresek "
+"lehetnek<br />A házirendek nem oszthatják meg ugyanazt a nevet mint a "
+"beállított csatolók, tagok vagy szabályok"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:51
 msgid "Policy"
 msgstr "Házirend"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "Hozzárendelt házirend"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "Visszaállítás időköze"
 
@@ -665,13 +666,13 @@ msgstr ""
 "Másodpercek. Elfogadható értékek: 1-1000000. Alapértelmezetten 600, ha nincs "
 "beállítva"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Forráscím"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Forrásport"
 
@@ -697,7 +698,7 @@ msgstr "Feladat"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "Jelenleg %d / %d támogatott csatoló van beállítva"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -731,35 +732,35 @@ msgid ""
 "Physical device name which interface went up or down (e.g. \"eth0\" or "
 "\"wwan0\")<br /><br />"
 msgstr ""
-"Ez a szakasz lehetővé teszi az „/etc/mwan3.user” tartalmának módosítását.<br "
-"/>A fájl megőrzésre kerül a rendszerfrissítés közben is.<br /><br "
-"/>Megjegyzések:<br />Ez a fájl parancsértelmező parancsfájlként van "
+"Ez a szakasz lehetővé teszi az „/etc/mwan3.user” tartalmának módosítását."
+"<br />A fájl megőrzésre kerül a rendszerfrissítés közben is.<br /><br /"
+">Megjegyzések:<br />Ez a fájl parancsértelmező parancsfájlként van "
 "értelmezve.<br />A parancsfájl első sorának „#!/bin/sh” kell lennie, "
 "idézőjelek nélkül.<br />A # kezdetű sorok megjegyzések, és nincsenek "
 "végrehajtva.<br />Tegye ide az egyéni mwan3 műveletét,<br />minden netifd "
 "gyorsleválasztási csatolóeseménynél végre lesznek hajtva<br />azokon a "
 "csatolókon, amelyeknél az mwan3 engedélyezve van.<br /><br />Van három fő "
-"környezeti változó, amely átadásra kerül ennek a parancsfájlnak.<br /><br "
-"/>$ACTION: <br />* „ifup”: a netifd és mwan3track által van meghívva <br />* "
+"környezeti változó, amely átadásra kerül ennek a parancsfájlnak.<br /><br />"
+"$ACTION: <br />* „ifup”: a netifd és mwan3track által van meghívva <br />* "
 "„ifdown”: a netifd és mwan3track által van meghívva <br />* „connected”: "
 "csak az mwan3track által van meghívva, ha a követés sikeres volt <br />* "
 "„disconnected”: csak az mwan3track által van meghívva, ha a követés "
 "sikertelen volt <br />$INTERFACE: annak a csatolónak a neve, amely "
-"felkapcsolódott vagy lekapcsolódott (például „wan” vagy „wwan”)<br />$DEVICE:"
-" annak a fizikai eszköznek a neve, amely csatoló felkapcsolódott vagy "
-"lekapcsolódott (például „eth0” vagy „wwan0”)<br /><br />"
+"felkapcsolódott vagy lekapcsolódott (például „wan” vagy „wwan”)<br />"
+"$DEVICE: annak a fizikai eszköznek a neve, amely csatoló felkapcsolódott "
+"vagy lekapcsolódott (például „eth0” vagy „wwan0”)<br /><br />"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:37
 msgid "Tracking hostname or IP address"
 msgstr "Követési gépnév vagy IP-cím"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "Követési módszer"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "Követési megbízhatóság"
 
@@ -799,7 +800,8 @@ msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:45
 msgid "WARNING: Interface %s has a duplicate metric %s configured"
-msgstr "FIGYELMEZTETÉS: a(z) %s csatolónak kettőzött %s mérőszáma van beállítva"
+msgstr ""
+"FIGYELMEZTETÉS: a(z) %s csatolónak kettőzött %s mérőszáma van beállítva"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:38
 msgid ""
@@ -836,8 +838,8 @@ msgstr "Várakozás a parancs befejeződésére…"
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Súly"
 
@@ -853,36 +855,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Igen"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "fekete lyuk (eldobás)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr "kapcsolódva (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "alapértelmezett (fő útválasztási táblázat használata)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr "lecsatlakozva (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr "csatolólekapcsolás (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr "csatolófelkapcsolás (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "elérhetetlen (visszautasítás)"

--- a/applications/luci-app-mwan3/po/it/mwan3.po
+++ b/applications/luci-app-mwan3/po/it/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d ora"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d minuto"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d minuti"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d secondo"
 
@@ -49,6 +49,7 @@ msgstr "%d secondo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr "%d secondo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d secondi"
 
@@ -80,7 +80,7 @@ msgstr "%d secondi"
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Abilitato"
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/ja/mwan3.po
+++ b/applications/luci-app-mwan3/po/ja/mwan3.po
@@ -12,38 +12,38 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Language: ja\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d 時間"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d 分"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d 分"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d 秒"
 
@@ -51,6 +51,7 @@ msgstr "%d 秒"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -59,22 +60,21 @@ msgstr "%d 秒"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d 秒"
 
@@ -82,7 +82,7 @@ msgstr "%d 秒"
 msgid "-- Please choose --"
 msgstr "-- 選択してください --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr "IP ルールのチェック"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "リンク品質のチェック"
 
@@ -137,13 +137,13 @@ msgstr "重大"
 msgid "Debug"
 msgstr "デバッグ"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "宛先アドレス"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "宛先ポート"
 
@@ -165,7 +165,7 @@ msgstr "診断機能"
 msgid "Disabled"
 msgstr "無効"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -180,8 +180,8 @@ msgstr "緊急"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "有効"
 
@@ -216,7 +216,7 @@ msgstr "実行"
 msgid "Expect interface state on up event"
 msgstr "Up イベント時に予想されるインターフェースの状態です。"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "障害検出 インターバル"
 
@@ -228,11 +228,11 @@ msgstr "ファイアウォール ログレベル"
 msgid "Firewall mask"
 msgstr "ファイアウォール マスク"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "conntrack テーブルのクリア"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 "インターフェース イベント時にグローバル ファイアウォール conntrack テーブルを"
@@ -281,8 +281,8 @@ msgid "Initial state"
 msgstr "初期状態"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -291,17 +291,17 @@ msgstr "初期状態"
 msgid "Interface"
 msgstr "インターフェース"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "インターフェース Down"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "インターフェース Up"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 "インターフェースが Down 状態と判断されるまでに要する ping テストの失敗回数で"
@@ -315,16 +315,16 @@ msgstr "インターフェース"
 msgid "Internet Protocol"
 msgstr "インターネット プロトコル"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "最終手段"
 
@@ -422,15 +422,15 @@ msgstr ""
 "スは使用できません。<br />インターフェースには、設定済みのメンバーやポリ"
 "シー、ルールと同じ名前を使用することはできません。"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "最大 TTL"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "最大パケットレイテンシ [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "最大パケットロス [%]"
 
@@ -470,18 +470,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "アサイン済みメンバー"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "メトリック"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "最小パケットレイテンシ [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "最小パケットロス [%]"
 
@@ -537,7 +537,7 @@ msgstr "オンライン"
 msgid "Only one IP rules for interface %s found"
 msgstr "インターフェース %s に IP ルールが一つのみ見つかりました。"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Ping 回数"
 
@@ -545,24 +545,24 @@ msgstr "Ping 回数"
 msgid "Ping default gateway"
 msgstr "デフォルト ゲートウェイへのping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Ping インターバル"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "障害検出中の Ping 実行間隔です。"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "障害復旧中の Ping 実行間隔です。"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Ping サイズ"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Ping タイムアウト"
 
@@ -597,17 +597,17 @@ msgstr ""
 msgid "Policy"
 msgstr "ポリシー"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "アサイン済みポリシー"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "プロトコル"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "障害復旧 インターバル"
 
@@ -664,13 +664,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr "秒。利用可能な値: 1-1000000。空欄の場合のデフォルト値は600です。"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "送信元アドレス"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "送信元ポート"
 
@@ -695,7 +695,7 @@ msgstr "タスク"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "現在、%d 個中 %d 個のサポートされたインターフェースが設定済みです。"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -748,13 +748,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr "トラッキング ホスト名または IP アドレス"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "トラッキング方式"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "トラッキングの信頼性"
 
@@ -829,8 +829,8 @@ msgstr "コマンドを実行中です..."
 msgid "Warning"
 msgstr "警告"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "ウエイト"
 
@@ -846,36 +846,36 @@ msgstr ""
 msgid "Yes"
 msgstr "はい"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "blackhole (drop)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr "接続時 (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "デフォルト（メインのルーティング テーブルを使用）"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr "切断時 (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr "ifdown (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr "ifup (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "unreachable (reject)"

--- a/applications/luci-app-mwan3/po/ko/mwan3.po
+++ b/applications/luci-app-mwan3/po/ko/mwan3.po
@@ -4,38 +4,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -43,6 +43,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -51,22 +52,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -126,13 +126,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -213,11 +213,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -264,8 +264,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -274,17 +274,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -296,16 +296,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -396,15 +396,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -438,18 +438,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -511,24 +511,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -555,17 +555,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -612,13 +612,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -677,13 +677,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -748,8 +748,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -763,36 +763,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/mr/mwan3.po
+++ b/applications/luci-app-mwan3/po/mr/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "प्रोटोकॉल"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/ms/mwan3.po
+++ b/applications/luci-app-mwan3/po/ms/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/nb_NO/mwan3.po
+++ b/applications/luci-app-mwan3/po/nb_NO/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Aktivert"
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/pl/mwan3.po
+++ b/applications/luci-app-mwan3/po/pl/mwan3.po
@@ -11,38 +11,38 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d godzin"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d minut"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d minut"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d sekund"
 
@@ -50,6 +50,7 @@ msgstr "%d sekund"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -58,22 +59,21 @@ msgstr "%d sekund"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d sekund"
 
@@ -81,7 +81,7 @@ msgstr "%d sekund"
 msgid "-- Please choose --"
 msgstr "-- Proszę wybrać --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -133,13 +133,13 @@ msgstr "Krytyczny"
 msgid "Debug"
 msgstr "Debugowanie"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Adres docelowy"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Port docelowy"
 
@@ -161,7 +161,7 @@ msgstr "Diagnostyka"
 msgid "Disabled"
 msgstr "Wyłączone"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -174,8 +174,8 @@ msgstr "Ratunkowy"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Włączone"
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -220,11 +220,11 @@ msgstr "Poziom logowania firewalla"
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -271,8 +271,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -281,17 +281,17 @@ msgstr ""
 msgid "Interface"
 msgstr "Interfejs"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -303,16 +303,16 @@ msgstr "Interfejsy"
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -403,15 +403,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "Maksymalny TTL"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "Maksymalna latencja pakietów [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "Maksymalna utrata pakietów [%]"
 
@@ -445,18 +445,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Metryka"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "Minimalna latencja pakietów [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "Minimalna strata pakietów [%]"
 
@@ -510,7 +510,7 @@ msgstr "Online"
 msgid "Only one IP rules for interface %s found"
 msgstr "Znaleziono tylko jedną regułę IP dla interfejsu %s"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Liczba pingów"
 
@@ -518,24 +518,24 @@ msgstr "Liczba pingów"
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Rozmiar pinga"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -562,17 +562,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Polityka"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protokół"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -619,13 +619,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Adres źródłowy"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Port źródłowy"
 
@@ -650,7 +650,7 @@ msgstr "Zadanie"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -684,13 +684,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -755,8 +755,8 @@ msgstr "Oczekiwanie na polecenie do wykonania..."
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -770,36 +770,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Tak"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/pt/mwan3.po
+++ b/applications/luci-app-mwan3/po/pt/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d hora"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d minuto"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d minutos"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d segundo"
 
@@ -49,6 +49,7 @@ msgstr "%d segundo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr "%d segundo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d segundos"
 
@@ -80,7 +80,7 @@ msgstr "%d segundos"
 msgid "-- Please choose --"
 msgstr "-- Por favor escolha --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -112,7 +112,7 @@ msgstr "Verificar também esta tabela de roteamento para redes conectadas"
 msgid "Check IP rules"
 msgstr "Verificar regras de IP"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "Verificar a qualidade da ligação"
 
@@ -134,13 +134,13 @@ msgstr "Critico"
 msgid "Debug"
 msgstr "Depurar"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Endereço de destino"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Porta de destino"
 
@@ -162,7 +162,7 @@ msgstr "Diagnósticos"
 msgid "Disabled"
 msgstr "Desativado"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -177,8 +177,8 @@ msgstr "Emergência"
 msgid "Enable ssl tracking"
 msgstr "Ativar rastreamento de ssl"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -213,7 +213,7 @@ msgstr "Executar"
 msgid "Expect interface state on up event"
 msgstr "Esperar o estado da interface no evento up"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "Intervalo de falha"
 
@@ -225,11 +225,11 @@ msgstr "Nível de log do firewall"
 msgid "Firewall mask"
 msgstr "Máscara de firewall"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "Limpar tabela de conntrack"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr "Limpar tabela de firewall conntrack global em eventos de interface"
 
@@ -276,8 +276,8 @@ msgid "Initial state"
 msgstr "Estado inicial"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -286,17 +286,17 @@ msgstr "Estado inicial"
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "Interface down"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "Interface up"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 "A interface será considerada down após esta quantidade testes de ping "
@@ -310,16 +310,16 @@ msgstr "Interfaces"
 msgid "Internet Protocol"
 msgstr "Protocolo Internet"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "Manter intervalo de falha"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr "Manter o intervalo de falha de ping durante o estado de falha"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "Último recurso"
 
@@ -416,15 +416,15 @@ msgstr ""
 "espaço<br />As interfaces não devem compartilhar o mesmo nome dos membros "
 "configurados, políticas ou regras"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "TTL máximo"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "Latência máxima do pacote [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "Perda máxima de pacotes [%]"
 
@@ -464,18 +464,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "Membros designados"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Métrica"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "Latência mínima de pacotes [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "Perda mínima de pacotes [%]"
 
@@ -531,7 +531,7 @@ msgstr "Online"
 msgid "Only one IP rules for interface %s found"
 msgstr "Apenas uma regra de IP para a interface %s encontrada"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Contagem de ping"
 
@@ -539,24 +539,24 @@ msgstr "Contagem de ping"
 msgid "Ping default gateway"
 msgstr "Gateway padrão de ping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Intervalo de ping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "Intervalo de ping durante a deteção de falhas"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "Intervalo de ping durante a recuperação de falhas"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Tamanho do ping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Tempo limite de ping"
 
@@ -591,17 +591,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Política"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "Política atribuída"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "Intervalo de recuperação"
 
@@ -659,13 +659,13 @@ msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 "Segundos. Valores aceitáveis: 1-1000000. O padrão é 600 se não for definido"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Endereço de origem"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Porta de origem"
 
@@ -690,7 +690,7 @@ msgstr "Tarefa"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "Atualmente existem %d de %d interfaces suportadas configuradas"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr "Isso exibe a métrica atribuída a essa interface em /etc/config/network"
@@ -741,13 +741,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr "Rastreamento de nome de host ou endereço IP"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "Método de rastreamento"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "Confiabilidade de rastreamento"
 
@@ -820,8 +820,8 @@ msgstr "A aguardar que o comando termine..."
 msgid "Warning"
 msgstr "Aviso"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Peso"
 
@@ -837,36 +837,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Sim"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "blackhole (drop)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr "conectado (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "padrão (use a tabela de roteamento principal)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr "desconectado (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr "ifdown (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr "ifup (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "inacessível (rejeitar)"

--- a/applications/luci-app-mwan3/po/pt_BR/mwan3.po
+++ b/applications/luci-app-mwan3/po/pt_BR/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d hora"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d minuto"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d minutos"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d segundo"
 
@@ -49,6 +49,7 @@ msgstr "%d segundo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr "%d segundo"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d segundos"
 
@@ -80,7 +80,7 @@ msgstr "%d segundos"
 msgid "-- Please choose --"
 msgstr "-- Por favor, escolha --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -102,7 +102,8 @@ msgstr "Alerta"
 
 #: applications/luci-app-mwan3/luasrc/controller/mwan3.lua:177
 msgid "All required IP rules for interface %s found"
-msgstr "Todas as regras de IP necessárias para a interface %s foram encontradas"
+msgstr ""
+"Todas as regras de IP necessárias para a interface %s foram encontradas"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:57
 msgid "Also scan this Routing table for connected networks"
@@ -112,7 +113,7 @@ msgstr "Varrer também esta tabela de roteamento para as redes conectadas"
 msgid "Check IP rules"
 msgstr "Verificar regras de IP"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "Verifique a qualidade do link"
 
@@ -134,13 +135,13 @@ msgstr "Crítico"
 msgid "Debug"
 msgstr "Depuração"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Endereço de destino"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Porta de destino"
 
@@ -162,7 +163,7 @@ msgstr "Diagnóstico"
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -177,8 +178,8 @@ msgstr "Emergência"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -213,7 +214,7 @@ msgstr "Executar"
 msgid "Expect interface state on up event"
 msgstr "Esperar que a interface esteja no ar durante um evento"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "Intervalo de falha"
 
@@ -225,11 +226,11 @@ msgstr "Nível de registro do firewall"
 msgid "Firewall mask"
 msgstr "Máscara do firewall"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "Despejar a tabela conntrack"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr "Despejar a tabela conntrack de firewall global durante os eventos"
 
@@ -278,8 +279,8 @@ msgid "Initial state"
 msgstr "Condição inicial"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -288,17 +289,17 @@ msgstr "Condição inicial"
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "Interface inoperante"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "Interface operante"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 "A interface será considerada inoperante caso muitos testes de ping falhem"
@@ -311,16 +312,16 @@ msgstr "Interfaces"
 msgid "Internet Protocol"
 msgstr "Protocolo de Internet"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "Conservar o intervalo de falha"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr "Conservar o intervalo de falha do ping durante uma condição de falha"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "Último recurso"
 
@@ -417,15 +418,15 @@ msgstr ""
 "entre A-Z, a-z, 0-9, _ sem nenhum espaço<br />As interfaces podem não "
 "compartilhar o mesmo nome dos membros configurados, políticas ou regras"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "TTL Máximo"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "Latência máxima do pacote [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "Perda máxima de pacotes [%]"
 
@@ -435,8 +436,9 @@ msgid ""
 "May be entered as a single or multiple port(s) (eg \"22\" or \"80,443\") or "
 "as a portrange (eg \"1024:2048\") without quotes"
 msgstr ""
-"Pode ser inserido como uma ou múltiplas portas (por exemplo, \"22\" ou \"80,"
-"443\") ou como uma faixa de portas (por exemplo, \"1024:2048\") não use aspas"
+"Pode ser inserido como uma ou múltiplas portas (por exemplo, \"22\" ou "
+"\"80,443\") ou como uma faixa de portas (por exemplo, \"1024:2048\") não use "
+"aspas"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:17
 msgid "Member"
@@ -465,18 +467,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "Membros designados"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Métrica"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "Latência mínima do pacote [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "Perda mínima de pacotes [%]"
 
@@ -532,7 +534,7 @@ msgstr "Conectado"
 msgid "Only one IP rules for interface %s found"
 msgstr "Apenas uma regra de IP para a interface %s foi encontrada"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Contagem de ping"
 
@@ -540,24 +542,24 @@ msgstr "Contagem de ping"
 msgid "Ping default gateway"
 msgstr "Realizar ping no gateway padrão"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Intervalo de ping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "Intervalo de ping durante uma detecção de falha"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "Intervalo de ping durante uma recuperação de falha"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Tamanho do ping"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Tempo limite do ping"
 
@@ -593,17 +595,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Política"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "Política atribuída"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "Intervalo de recuperação"
 
@@ -645,11 +647,11 @@ msgid ""
 "z, 0-9, _ and no spaces<br />Rules may not share the same name as configured "
 "interfaces, members or policies"
 msgstr ""
-"As regras determinam qual tráfego usará uma determinada política MWAN<br />"
-"As regras são baseadas em endereços IPs, portas ou protocolos<br />As regras "
-"são lidas de cima para baixo<br />As regras abaixo que correspondam a uma "
-"anterior são ignoradas<br />O tráfego que não coincide com nenhuma regra é "
-"roteada usando a tabela de roteamento principal<br />O tráfego destinado "
+"As regras determinam qual tráfego usará uma determinada política MWAN<br /"
+">As regras são baseadas em endereços IPs, portas ou protocolos<br />As "
+"regras são lidas de cima para baixo<br />As regras abaixo que correspondam a "
+"uma anterior são ignoradas<br />O tráfego que não coincide com nenhuma regra "
+"é roteada usando a tabela de roteamento principal<br />O tráfego destinado "
 "para as redes conhecidas (outras não predefinidas) são trabalhadas pela "
 "tabela de roteamento principal<br />O tráfego que coincida com uma regra, "
 "menos para todas as interfaces WAN onde a política esteja desativada, estas "
@@ -663,13 +665,13 @@ msgstr ""
 "Segundos. Valores aceitáveis: 1-1000000. Caso não seja definido o padrão é "
 "600"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Endereço de origem"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Porta de origem"
 
@@ -694,7 +696,7 @@ msgstr "Tarefa"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "Existem atualmente %d de %d interfaces compatíveis configuradas"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -727,9 +729,9 @@ msgid ""
 "Physical device name which interface went up or down (e.g. \"eth0\" or "
 "\"wwan0\")<br /><br />"
 msgstr ""
-"Esta seção permite que você modifique o conteúdo de \"/etc/mwan3.user\".<br "
-"/>O arquivo também é preservado durante a atualização do sistema.<br /><br "
-"/>Notas:<br />Este arquivo é interpretado como um script shell.<br />A "
+"Esta seção permite que você modifique o conteúdo de \"/etc/mwan3.user\".<br /"
+">O arquivo também é preservado durante a atualização do sistema.<br /><br /"
+">Notas:<br />Este arquivo é interpretado como um script shell.<br />A "
 "primeira linha do script deve ser &#34;#!/bin/sh&#34; sem aspas.<br />Linhas "
 "começando com # são comentários e não são executadas.<br />Ponha as suas "
 "ações personalizada para o mwan3 aqui, elas serão executadas com cada evento "
@@ -740,21 +742,21 @@ msgstr ""
 "mwan3track <br />* \"connected\" Só é chamado pelo mwan3track caso o "
 "tracking seja bem sucedido <br />* \"disconnected\" Só é chamado pelo "
 "mwan3track caso o tracking falhe <br />$INTERFACE Nome da interface que "
-"mudou a sua condição para operante ou inoperante (e.g. \"wan\" ou \"wwan\")<"
-"br />$DEVICE Nome do dispositivo físico cuja interface ficou operante ou não "
-"(e.g. \"eth0\" ou \"wwan0\")<br /><br />"
+"mudou a sua condição para operante ou inoperante (e.g. \"wan\" ou \"wwan"
+"\")<br />$DEVICE Nome do dispositivo físico cuja interface ficou operante ou "
+"não (e.g. \"eth0\" ou \"wwan0\")<br /><br />"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:37
 msgid "Tracking hostname or IP address"
 msgstr "Rastreamento de hostname ou endereço IP"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "Método de rastreamento"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "Confiabilidade de rastreamento"
 
@@ -828,8 +830,8 @@ msgstr "Aguardando a conclusão do comando..."
 msgid "Warning"
 msgstr "Alerta"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Peso"
 
@@ -845,36 +847,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Sim"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "buraco negro (derruba)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr "conectado (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "padrão (usar tabela de roteamento principal)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr "desconectado (mwan3)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr "ifdown (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr "ifup (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "inacessível (rejeitar)"

--- a/applications/luci-app-mwan3/po/ro/mwan3.po
+++ b/applications/luci-app-mwan3/po/ro/mwan3.po
@@ -11,38 +11,38 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -50,6 +50,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -58,22 +59,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -133,13 +133,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -174,8 +174,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -220,11 +220,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -271,8 +271,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -281,17 +281,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -303,16 +303,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -403,15 +403,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -445,18 +445,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -518,24 +518,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -562,17 +562,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -619,13 +619,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -650,7 +650,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -684,13 +684,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -755,8 +755,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -770,36 +770,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/ru/mwan3.po
+++ b/applications/luci-app-mwan3/po/ru/mwan3.po
@@ -16,38 +16,38 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d час"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d минута"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d минут"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d секунда"
 
@@ -55,6 +55,7 @@ msgstr "%d секунда"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -63,22 +64,21 @@ msgstr "%d секунда"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d секунд"
 
@@ -86,7 +86,7 @@ msgstr "%d секунд"
 msgid "-- Please choose --"
 msgstr "-- Сделайте выбор --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -118,7 +118,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr "Проверить правила IP"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -140,13 +140,13 @@ msgstr "Критическая ситуация"
 msgid "Debug"
 msgstr "Отладка"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Адрес назначения"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Порт назначения"
 
@@ -168,7 +168,7 @@ msgstr "Диагностика"
 msgid "Disabled"
 msgstr "Отключено"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -182,8 +182,8 @@ msgstr "Чрезвычайная ситуация"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Включено"
 
@@ -216,7 +216,7 @@ msgstr "Выполнить"
 msgid "Expect interface state on up event"
 msgstr "Ожидание "
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "Интервал отказа"
 
@@ -228,11 +228,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr "Маска межсетевого экрана"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "Сбросьте conntrack таблицу"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 "Сбросьте глобальные настройки межсетевого экрана conntrack таблицы по "
@@ -281,8 +281,8 @@ msgid "Initial state"
 msgstr "Исходное состояние"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -291,17 +291,17 @@ msgstr "Исходное состояние"
 msgid "Interface"
 msgstr "Интерфейс"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "Интерфейс отключить"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "Интерфейс включить"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 "Интерфейс будут считать отключенным, после данного количества пинг-запросов."
@@ -314,16 +314,16 @@ msgstr "Интерфейсы"
 msgid "Internet Protocol"
 msgstr "Протокол интернета"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "Сохранить интервал сбоя"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr "Сохранить интервал сбоя пинг-запроса, во время состояния сбоя."
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "Последнее средство"
 
@@ -420,15 +420,15 @@ msgstr ""
 "символы A-Z, a-z, 0-9, _ и пробелы.<br />Интерфейсы не могут иметь "
 "одинаковые имена с настроенными узлами, политиками или правилами."
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -467,18 +467,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "Назначенные узлы"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Метрика"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr "Онлайн"
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Кол-во пинг-запросов"
 
@@ -542,24 +542,24 @@ msgstr "Кол-во пинг-запросов"
 msgid "Ping default gateway"
 msgstr "Пинг-запрос шлюза по умолчанию"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Интервал пинг-запроса"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "Интервал пинг-запроса во время обнаружения отказов."
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "Интервал пинг-запроса при сбое восстановления."
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Размер пинг-запроса"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Время ожидания пинг-запроса"
 
@@ -594,17 +594,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Политика"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "Назначенная политика"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "Интервал восстановления"
 
@@ -664,13 +664,13 @@ msgstr ""
 "Секунд. Допустимые значения: 1-1000000. По умолчанию 600, если значение не "
 "установлено."
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Адрес источника"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Порт источника"
 
@@ -695,7 +695,7 @@ msgstr "Задача"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "В настоящее время настроено %d из %d поддерживаемых интерфейсов."
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -734,13 +734,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr "Отслеживание имени хоста или IP-адреса"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "Метод отслеживания"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "Надежность отслеживания"
 
@@ -816,8 +816,8 @@ msgstr "Ожидание завершения выполнения команд�
 msgid "Warning"
 msgstr "Внимание"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Вес"
 
@@ -833,36 +833,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Да"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "blackhole (drop)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "по умолчанию (использовать основную таблицу маршрутизации)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "недоступен (отклонить)"

--- a/applications/luci-app-mwan3/po/sk/mwan3.po
+++ b/applications/luci-app-mwan3/po/sk/mwan3.po
@@ -4,38 +4,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -43,6 +43,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -51,22 +52,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -126,13 +126,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -213,11 +213,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -264,8 +264,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -274,17 +274,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -296,16 +296,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -396,15 +396,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -438,18 +438,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -511,24 +511,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -555,17 +555,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -612,13 +612,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -677,13 +677,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -748,8 +748,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -763,36 +763,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/sv/mwan3.po
+++ b/applications/luci-app-mwan3/po/sv/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr "-- Vänligen välj --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr "Kritisk"
 msgid "Debug"
 msgstr "Felsök"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Destinationens adress"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Destinationsport"
 
@@ -160,7 +160,7 @@ msgstr "Diagnostik"
 msgid "Disabled"
 msgstr "Inaktiverad"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr "Nödsituation"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Aktiverad"
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr "Gränssnitt"
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Metrisk"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Villkor"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Adress för källkod"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr "Väntar på att kommandot ska slutföras..."
 msgid "Warning"
 msgstr "Varning"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "Vikt"
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Ja"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/templates/mwan3.pot
+++ b/applications/luci-app-mwan3/po/templates/mwan3.pot
@@ -1,38 +1,38 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -40,6 +40,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -48,22 +49,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -71,7 +71,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -101,7 +101,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -123,13 +123,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -164,8 +164,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -198,7 +198,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -210,11 +210,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -261,8 +261,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -271,17 +271,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -293,16 +293,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -393,15 +393,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -435,18 +435,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -508,24 +508,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -552,17 +552,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -609,13 +609,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -640,7 +640,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -674,13 +674,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -745,8 +745,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -760,36 +760,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/tr/mwan3.po
+++ b/applications/luci-app-mwan3/po/tr/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr ""
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/uk/mwan3.po
+++ b/applications/luci-app-mwan3/po/uk/mwan3.po
@@ -11,38 +11,38 @@ msgstr ""
 "4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -50,6 +50,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -58,22 +59,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr "-- Оберіть --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -133,13 +133,13 @@ msgstr "Критична ситуація"
 msgid "Debug"
 msgstr "Зневаджування"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "Адреса призначення"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "Порт призначення"
 
@@ -161,7 +161,7 @@ msgstr "Діагностика"
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -174,8 +174,8 @@ msgstr "Надзвичайна ситуація"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "Увімкнено"
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -220,11 +220,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -271,8 +271,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -281,17 +281,17 @@ msgstr ""
 msgid "Interface"
 msgstr "Інтерфейс"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -303,16 +303,16 @@ msgstr "Інтерфейси"
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -403,15 +403,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -445,18 +445,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "Метрика"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -518,24 +518,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -562,17 +562,17 @@ msgstr ""
 msgid "Policy"
 msgstr "Політика"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -619,13 +619,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "Адреса джерела"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "Порт джерела"
 
@@ -650,7 +650,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -684,13 +684,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -755,8 +755,8 @@ msgstr "Очікуємо завершення виконання команди.
 msgid "Warning"
 msgstr "Застереження"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -770,36 +770,36 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/vi/mwan3.po
+++ b/applications/luci-app-mwan3/po/vi/mwan3.po
@@ -10,38 +10,38 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr ""
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -57,22 +58,21 @@ msgstr ""
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Check IP rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr ""
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Expect interface state on up event"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr ""
 
@@ -270,8 +270,8 @@ msgid "Initial state"
 msgstr ""
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -280,17 +280,17 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr ""
 
@@ -302,16 +302,16 @@ msgstr "Giao diện"
 msgid "Internet Protocol"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr ""
 
@@ -402,15 +402,15 @@ msgid ""
 "rules"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr ""
 
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Only one IP rules for interface %s found"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr ""
 
@@ -517,24 +517,24 @@ msgstr ""
 msgid "Ping default gateway"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr ""
 
@@ -561,17 +561,17 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "Giao thức"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr "Vui lòng chờ đến khi lệnh được thực thi hoàn thành..."
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr ""
 
@@ -769,36 +769,36 @@ msgstr ""
 msgid "Yes"
 msgstr "Có"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr ""

--- a/applications/luci-app-mwan3/po/zh-cn/mwan3.po
+++ b/applications/luci-app-mwan3/po/zh-cn/mwan3.po
@@ -13,38 +13,38 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d 小时"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d 分钟"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d 分钟"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d 秒"
 
@@ -52,6 +52,7 @@ msgstr "%d 秒"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -60,22 +61,21 @@ msgstr "%d 秒"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d 秒"
 
@@ -83,7 +83,7 @@ msgstr "%d 秒"
 msgid "-- Please choose --"
 msgstr "-- 请选择 --"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -114,7 +114,7 @@ msgstr "同时扫描此路由表以查找已连接的网络"
 msgid "Check IP rules"
 msgstr "检查 IP 规则"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "检查连接数量"
 
@@ -136,13 +136,13 @@ msgstr "致命错误"
 msgid "Debug"
 msgstr "调试"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "目标地址"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "目标端口"
 
@@ -164,7 +164,7 @@ msgstr "网络诊断"
 msgid "Disabled"
 msgstr "已禁用"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr "当 Ping 成功次数达到这个数值后，已经被认为离线的接口将会重新上线"
@@ -177,8 +177,8 @@ msgstr "紧急"
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "已启用"
 
@@ -211,7 +211,7 @@ msgstr "执行"
 msgid "Expect interface state on up event"
 msgstr "在 up 事件发生时的预期接口状态"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "故障检测间隔"
 
@@ -223,11 +223,11 @@ msgstr "防火墙日志级别"
 msgid "Firewall mask"
 msgstr "防火墙掩码"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "刷新连接跟踪表"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr "在接口事件触发时刷新全局防火墙连接跟踪表"
 
@@ -274,8 +274,8 @@ msgid "Initial state"
 msgstr "初始状态"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -284,17 +284,17 @@ msgstr "初始状态"
 msgid "Interface"
 msgstr "接口"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "接口离线"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "接口在线"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr "当 Ping 失败次数达到这个数值后，接口会被认为离线"
 
@@ -306,16 +306,16 @@ msgstr "接口"
 msgid "Internet Protocol"
 msgstr "互联网协议"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "保持故障检测间隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr "在故障状态期间保持的 Ping 故障检测间隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "备用成员"
 
@@ -410,15 +410,15 @@ msgstr ""
 "的接口名称匹配。<br />名称允许包括 A-Z、a-z、0-9、_ 但是不能有空格。<br />接"
 "口不应该与成员、策略、规则中的任意一个设置项使用相同的名称"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "最大 TTL"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "最大数据包延迟 [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "最大数据包丢失率 [%]"
 
@@ -457,18 +457,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "分配的成员"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "跃点数"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "最小数据包延迟 [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "最小数据包丢失率 [%]"
 
@@ -524,7 +524,7 @@ msgstr "在线"
 msgid "Only one IP rules for interface %s found"
 msgstr "只找到接口 %s 的一个 IP 规则"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Ping 计数"
 
@@ -532,24 +532,24 @@ msgstr "Ping 计数"
 msgid "Ping default gateway"
 msgstr "Ping 默认网关"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Ping 间隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "故障检测期间的 Ping 间隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "故障恢复期间的 Ping 间隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Ping 大小"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Ping 超时"
 
@@ -581,17 +581,17 @@ msgstr ""
 msgid "Policy"
 msgstr "策略"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "分配的策略"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "协议"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "故障恢复间隔"
 
@@ -643,13 +643,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr "单位为秒。接受的值：1-1000000。留空则使用默认值 600 秒"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "源地址"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "源端口"
 
@@ -674,7 +674,7 @@ msgstr "任务"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "当前已配置 %d 个接口，最大支持 %d 个"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr "这里显示了这个接口在 /etc/config/network 中配置的跃点数"
@@ -718,13 +718,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr "跟踪的主机或 IP 地址"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "跟踪方式"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "跟踪可靠性"
 
@@ -791,8 +791,8 @@ msgstr "正在等待命令完成…"
 msgid "Warning"
 msgstr "警告"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "权重"
 
@@ -806,36 +806,36 @@ msgstr "当所有策略成员都无法使用的时候，对使用该策略的流
 msgid "Yes"
 msgstr "是"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "黑洞（丢弃）"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr "已连接（mwan3）"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "默认（使用主路由表）"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr "未连接（mwan3）"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr "ifdown (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr "ifup (netifd)"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "不可达（拒绝）"

--- a/applications/luci-app-mwan3/po/zh-tw/mwan3.po
+++ b/applications/luci-app-mwan3/po/zh-tw/mwan3.po
@@ -13,38 +13,38 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:177
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:193
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:213
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d hour"
 msgstr "%d 小時"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d minute"
 msgstr "%d 分鐘"
 
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:172
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:173
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:174
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:175
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:176
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:188
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:189
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:190
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:191
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:208
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:209
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:210
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:211
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:212
 msgid "%d minutes"
 msgstr "%d 分鐘"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:48
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:152
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:165
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:201
 msgid "%d second"
 msgstr "%d 秒"
 
@@ -52,6 +52,7 @@ msgstr "%d 秒"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:50
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:51
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua:52
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:153
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:154
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:155
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:156
@@ -60,22 +61,21 @@ msgstr "%d 秒"
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:159
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:160
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:161
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:162
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:166
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:167
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:168
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:169
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:170
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:171
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:182
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:183
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:184
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:185
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:186
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:187
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:202
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:203
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:204
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:205
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:206
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:207
 msgid "%d seconds"
 msgstr "%d 秒"
 
@@ -83,7 +83,7 @@ msgstr "%d 秒"
 msgid "-- Please choose --"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:66
 msgid ""
 "Acceptable values: 1-100. This many Tracking IP addresses must respond for "
 "the link to be deemed up"
@@ -114,7 +114,7 @@ msgstr "同時掃描此路由表以查詢已連線的網路"
 msgid "Check IP rules"
 msgstr "檢查 IP 規則"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:105
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:104
 msgid "Check link quality"
 msgstr "檢查連線數量"
 
@@ -136,13 +136,13 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:81
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:29
 msgid "Destination address"
 msgstr "目標位址"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:87
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:33
 msgid "Destination port"
 msgstr "目標埠"
 
@@ -164,7 +164,7 @@ msgstr "診斷"
 msgid "Disabled"
 msgstr "已禁用"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:230
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 msgid ""
 "Downed interface will be deemed up after this many successful ping tests"
 msgstr "當 Ping 成功次數達到這個數值後，已經被認為離線的介面將會重新上線"
@@ -177,8 +177,8 @@ msgstr ""
 msgid "Enable ssl tracking"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:160
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:23
 msgid "Enabled"
 msgstr "已啟用"
 
@@ -211,7 +211,7 @@ msgstr "執行"
 msgid "Expect interface state on up event"
 msgstr "在 up 事件發生時的預期介面狀態"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:178
 msgid "Failure interval"
 msgstr "故障檢測間隔"
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Firewall mask"
 msgstr "防火牆掩碼"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "Flush conntrack table"
 msgstr "重新整理連線跟蹤表"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:243
 msgid "Flush global firewall conntrack table on interface events"
 msgstr "在介面事件觸發時重新整理全局防火牆連線跟蹤表"
 
@@ -274,8 +274,8 @@ msgid "Initial state"
 msgstr "初始狀態"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:150
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:27
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:18
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:10
 #: applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm:62
@@ -284,17 +284,17 @@ msgstr "初始狀態"
 msgid "Interface"
 msgstr "介面"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:208
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:214
 msgid "Interface down"
 msgstr "介面離線"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:229
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:219
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:228
 msgid "Interface up"
 msgstr "介面在線"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:216
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:215
 msgid "Interface will be deemed down after this many failed ping tests"
 msgstr "當 Ping 失敗次數達到這個數值後，介面會被認為離線"
 
@@ -306,16 +306,16 @@ msgstr "介面"
 msgid "Internet Protocol"
 msgstr "網際網路協議"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:194
 msgid "Keep failure interval"
 msgstr "保持故障檢測間隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:196
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:195
 msgid "Keep ping failure interval during failure state"
 msgstr "在故障狀態期間保持的 Ping 故障檢測間隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:25
 msgid "Last resort"
 msgstr "備用成員"
 
@@ -410,15 +410,15 @@ msgstr ""
 "中的介面名稱匹配。<br />名稱允許包括 A-Z、a-z、0-9、_ 但是不能有空格。<br />"
 "接口不應該與成員、策略、規則中的任意一個設定項使用相同的名稱"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:92
 msgid "Max TTL"
 msgstr "最大 TTL"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:109
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:108
 msgid "Max packet latency [ms]"
 msgstr "最大資料包延遲 [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:121
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:120
 msgid "Max packet loss [%]"
 msgstr "最大資料包丟失率 [%]"
 
@@ -457,18 +457,18 @@ msgstr ""
 msgid "Members assigned"
 msgstr "分配的成員"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
 msgid "Metric"
 msgstr "躍點數"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:130
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:129
 msgid "Min packet latency [ms]"
 msgstr "最小資料包延遲 [ms]"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:142
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:141
 msgid "Min packet loss [%]"
 msgstr "最小資料包丟失率 [%]"
 
@@ -524,7 +524,7 @@ msgstr "在線"
 msgid "Only one IP rules for interface %s found"
 msgstr "只找到介面 %s 的一個 IP 規則"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:70
 msgid "Ping count"
 msgstr "Ping 計數"
 
@@ -532,24 +532,24 @@ msgstr "Ping 計數"
 msgid "Ping default gateway"
 msgstr "Ping 預設閘道器"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:164
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:192
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:163
 msgid "Ping interval"
 msgstr "Ping 間隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:180
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:179
 msgid "Ping interval during failure detection"
 msgstr "故障檢測期間的 Ping 間隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:200
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
 msgid "Ping interval during failure recovering"
 msgstr "故障恢復期間的 Ping 間隔"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:77
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:78
 msgid "Ping size"
 msgstr "Ping 大小"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:151
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:150
 msgid "Ping timeout"
 msgstr "Ping 超時"
 
@@ -581,17 +581,17 @@ msgstr ""
 msgid "Policy"
 msgstr "策略"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:99
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:66
 msgid "Policy assigned"
 msgstr "分配的策略"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:93
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:36
 msgid "Protocol"
 msgstr "通訊協議"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:199
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:198
 msgid "Recovery interval"
 msgstr "故障恢復間隔"
 
@@ -643,13 +643,13 @@ msgstr ""
 msgid "Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"
 msgstr "單位為秒。接受的值：1-1000000。留空則使用預設值 600 秒"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:69
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:22
 msgid "Source address"
 msgstr "源位址"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua:75
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:26
 msgid "Source port"
 msgstr "源埠"
 
@@ -674,7 +674,7 @@ msgstr "任務"
 msgid "There are currently %d of %d supported interfaces configured"
 msgstr "當前已配置 %d 個介面，最大支援 %d 個"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:251
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:250
 msgid ""
 "This displays the metric assigned to this interface in /etc/config/network"
 msgstr "這裡顯示了這個介面在 /etc/config/network 中配置的躍點數"
@@ -716,13 +716,13 @@ msgstr ""
 msgid "Tracking hostname or IP address"
 msgstr "跟蹤的主機或 IP 位址"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:170
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:41
 msgid "Tracking method"
 msgstr "跟蹤方式"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:64
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:181
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:65
 msgid "Tracking reliability"
 msgstr "跟蹤可靠性"
 
@@ -789,8 +789,8 @@ msgstr "正在等待指令完成…"
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:39
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:29
 msgid "Weight"
 msgstr "比重"
 
@@ -804,36 +804,36 @@ msgstr "當所有策略成員都無法使用的時候，對使用該策略的流
 msgid "Yes"
 msgstr "是"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:80
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:29
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:73
 msgid "blackhole (drop)"
 msgstr "黑洞（丟棄）"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
 msgid "connected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:74
 msgid "default (use main routing table)"
 msgstr "預設（使用主路由表）"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:248
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:247
 msgid "disconnected (mwan3)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:246
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
 msgid "ifdown (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:245
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:244
 msgid "ifup (netifd)"
 msgstr ""
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:72
 msgid "unreachable (reject)"
 msgstr "不可達（拒絕）"

--- a/applications/luci-app-nft-qos/po/hu/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/hu/nft-qos.po
@@ -100,8 +100,8 @@ msgstr "IP-cím"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(v4 / v6)"
-msgstr "IP-cím (v4/v6)"
+msgid "IP Address (v4 / v6)"
+msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
@@ -135,12 +135,12 @@ msgstr ""
 "Hálózati csatoló a forgalom formálásához, például br-lan, eth0.1, eth0, stb."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
-msgstr "Alkalmazandó hálózat, például 192.168.1.0/24, 10.2.0.0/16, stb."
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
+msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
-msgstr "Alkalmazandó hálózat, például AAAA::BBBB/64, CCCC::1/128, stb."
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
+msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
 msgid "No information available"
@@ -239,3 +239,12 @@ msgstr "például https, 23, (vesszővel elválasztva)"
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:44
 msgid "kB"
 msgstr "kB"
+
+#~ msgid "IP Address(v4 / v6)"
+#~ msgstr "IP-cím (v4/v6)"
+
+#~ msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+#~ msgstr "Alkalmazandó hálózat, például 192.168.1.0/24, 10.2.0.0/16, stb."
+
+#~ msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+#~ msgstr "Alkalmazandó hálózat, például AAAA::BBBB/64, CCCC::1/128, stb."

--- a/applications/luci-app-nft-qos/po/templates/nft-qos.pot
+++ b/applications/luci-app-nft-qos/po/templates/nft-qos.pot
@@ -91,12 +91,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -121,15 +121,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -151,7 +151,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-noddos/po/bg/noddos.po
+++ b/applications/luci-app-noddos/po/bg/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/ca/noddos.po
+++ b/applications/luci-app-noddos/po/ca/noddos.po
@@ -23,11 +23,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/cs/noddos.po
+++ b/applications/luci-app-noddos/po/cs/noddos.po
@@ -23,11 +23,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/de/noddos.po
+++ b/applications/luci-app-noddos/po/de/noddos.po
@@ -23,11 +23,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/el/noddos.po
+++ b/applications/luci-app-noddos/po/el/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/en/noddos.po
+++ b/applications/luci-app-noddos/po/en/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/es/noddos.po
+++ b/applications/luci-app-noddos/po/es/noddos.po
@@ -26,12 +26,12 @@ msgid "Clients"
 msgstr "Clientes"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "Nombre de host de Dhcp"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "Proveedor de Dhcp"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -142,3 +142,9 @@ msgid ""
 msgstr ""
 "Cargar sus estadísticas ayuda a mejorar el reconocimiento de dispositivos y "
 "descubrir dispositivos botnets pirateados"
+
+#~ msgid "DhcpHostname"
+#~ msgstr "Nombre de host de Dhcp"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "Proveedor de Dhcp"

--- a/applications/luci-app-noddos/po/fr/noddos.po
+++ b/applications/luci-app-noddos/po/fr/noddos.po
@@ -23,11 +23,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/he/noddos.po
+++ b/applications/luci-app-noddos/po/he/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/hi/noddos.po
+++ b/applications/luci-app-noddos/po/hi/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/hu/noddos.po
+++ b/applications/luci-app-noddos/po/hu/noddos.po
@@ -23,11 +23,11 @@ msgid "Clients"
 msgstr "Ügyfelek"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/it/noddos.po
+++ b/applications/luci-app-noddos/po/it/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/ja/noddos.po
+++ b/applications/luci-app-noddos/po/ja/noddos.po
@@ -25,12 +25,12 @@ msgid "Clients"
 msgstr "クライアント"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "DHCP ホスト名"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "DHCP ベンダー"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -141,3 +141,9 @@ msgid ""
 msgstr ""
 "デバイスの識別や、ハックされたデバイスとボットネットの発見の改善に役立てるた"
 "め、統計をアップロードします。"
+
+#~ msgid "DhcpHostname"
+#~ msgstr "DHCP ホスト名"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "DHCP ベンダー"

--- a/applications/luci-app-noddos/po/ko/noddos.po
+++ b/applications/luci-app-noddos/po/ko/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/mr/noddos.po
+++ b/applications/luci-app-noddos/po/mr/noddos.po
@@ -23,11 +23,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/ms/noddos.po
+++ b/applications/luci-app-noddos/po/ms/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/nb_NO/noddos.po
+++ b/applications/luci-app-noddos/po/nb_NO/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/pl/noddos.po
+++ b/applications/luci-app-noddos/po/pl/noddos.po
@@ -24,12 +24,12 @@ msgid "Clients"
 msgstr "Klienci"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "Nazwa hosta DHCP"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "DhcpVendor"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -136,3 +136,9 @@ msgid ""
 msgstr ""
 "Przesyłanie statystyk pomaga poprawić rozpoznawanie urządzeń i odkrywanie "
 "zhakowanych urządzeń i botnetów"
+
+#~ msgid "DhcpHostname"
+#~ msgstr "Nazwa hosta DHCP"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "DhcpVendor"

--- a/applications/luci-app-noddos/po/pt/noddos.po
+++ b/applications/luci-app-noddos/po/pt/noddos.po
@@ -23,12 +23,12 @@ msgid "Clients"
 msgstr "Clientes"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "DhcpHostname"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "DhcpVendor"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -140,3 +140,9 @@ msgid ""
 msgstr ""
 "O envio das suas estatísticas ajuda a melhorar o reconhecimento de aparelhos "
 "e a descobrir aparelhos e redes de bots hackeados"
+
+#~ msgid "DhcpHostname"
+#~ msgstr "DhcpHostname"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "DhcpVendor"

--- a/applications/luci-app-noddos/po/pt_BR/noddos.po
+++ b/applications/luci-app-noddos/po/pt_BR/noddos.po
@@ -23,12 +23,12 @@ msgid "Clients"
 msgstr "Clientes"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "Nome de Host do DHCP"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "DhcpVendor"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -140,3 +140,9 @@ msgid ""
 msgstr ""
 "O envio das suas estatísticas ajuda a melhorar o reconhecimento de "
 "dispositivos e a descobrir dispositivos hackeados e botnets"
+
+#~ msgid "DhcpHostname"
+#~ msgstr "Nome de Host do DHCP"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "DhcpVendor"

--- a/applications/luci-app-noddos/po/ro/noddos.po
+++ b/applications/luci-app-noddos/po/ro/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/ru/noddos.po
+++ b/applications/luci-app-noddos/po/ru/noddos.po
@@ -29,12 +29,12 @@ msgid "Clients"
 msgstr "Клиенты"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "DHCP имя хоста"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "DHCP Vendor"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -146,3 +146,9 @@ msgid ""
 msgstr ""
 "Загрузка статистики помогает улучшить распознавание устройств и обнаружение "
 "взломанных устройств и ботнетов."
+
+#~ msgid "DhcpHostname"
+#~ msgstr "DHCP имя хоста"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "DHCP Vendor"

--- a/applications/luci-app-noddos/po/sk/noddos.po
+++ b/applications/luci-app-noddos/po/sk/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/sv/noddos.po
+++ b/applications/luci-app-noddos/po/sv/noddos.po
@@ -23,11 +23,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/templates/noddos.pot
+++ b/applications/luci-app-noddos/po/templates/noddos.pot
@@ -14,11 +14,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/tr/noddos.po
+++ b/applications/luci-app-noddos/po/tr/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/uk/noddos.po
+++ b/applications/luci-app-noddos/po/uk/noddos.po
@@ -24,11 +24,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/vi/noddos.po
+++ b/applications/luci-app-noddos/po/vi/noddos.po
@@ -17,11 +17,11 @@ msgid "Clients"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
+msgid "DHCP Hostname"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
+msgid "DHCP Vendor"
 msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25

--- a/applications/luci-app-noddos/po/zh-cn/noddos.po
+++ b/applications/luci-app-noddos/po/zh-cn/noddos.po
@@ -26,12 +26,12 @@ msgid "Clients"
 msgstr "客户端"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "DhcpHostname"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "DhcpVendor"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -137,3 +137,9 @@ msgid ""
 "Uploading your statistics helps improving device recognition and discovering "
 "hacked devices & botnets"
 msgstr "上传统计信息有助于提高设备识别率，并发现被黑客入侵的设备及僵尸网络"
+
+#~ msgid "DhcpHostname"
+#~ msgstr "DhcpHostname"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "DhcpVendor"

--- a/applications/luci-app-noddos/po/zh-tw/noddos.po
+++ b/applications/luci-app-noddos/po/zh-tw/noddos.po
@@ -24,12 +24,12 @@ msgid "Clients"
 msgstr "客戶端"
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:83
-msgid "DhcpHostname"
-msgstr "DhcpHostname"
+msgid "DHCP Hostname"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/view/noddos/clients.htm:82
-msgid "DhcpVendor"
-msgstr "DhcpVendor"
+msgid "DHCP Vendor"
+msgstr ""
 
 #: applications/luci-app-noddos/luasrc/model/cbi/noddos.lua:25
 msgid "Don't monitor these IPv4 addresses"
@@ -135,3 +135,9 @@ msgid ""
 "Uploading your statistics helps improving device recognition and discovering "
 "hacked devices & botnets"
 msgstr "上傳統計資訊有助於提高裝置識別率，並發現被駭客入侵的裝置及殭屍網路"
+
+#~ msgid "DhcpHostname"
+#~ msgstr "DhcpHostname"
+
+#~ msgid "DhcpVendor"
+#~ msgstr "DhcpVendor"

--- a/applications/luci-app-nut/po/bg/nut.po
+++ b/applications/luci-app-nut/po/bg/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/ca/nut.po
+++ b/applications/luci-app-nut/po/ca/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/cs/nut.po
+++ b/applications/luci-app-nut/po/cs/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/de/nut.po
+++ b/applications/luci-app-nut/po/de/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/el/nut.po
+++ b/applications/luci-app-nut/po/el/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/en/nut.po
+++ b/applications/luci-app-nut/po/en/nut.po
@@ -220,7 +220,12 @@ msgstr "Max USB HID Length Reported"
 msgid "Maximum Age of Data"
 msgstr "Maximum Age of Data"
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr "Maximum Retries"
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr "Maximum Start Delay"
 
@@ -235,14 +240,6 @@ msgstr "Maximum number of times to try starting a driver."
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Maximum time in seconds between refresh of UPS status"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr "Maximum Retries"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
-msgstr "Maxium Start Delay"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
 msgid "Minimum required number or power supplies"
@@ -601,3 +598,6 @@ msgstr "chroot"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon drops privileges to this user"
+
+#~ msgid "Maxium Start Delay"
+#~ msgstr "Maxium Start Delay"

--- a/applications/luci-app-nut/po/es/nut.po
+++ b/applications/luci-app-nut/po/es/nut.po
@@ -228,7 +228,12 @@ msgstr "Longitud máxima de USB HID informada"
 msgid "Maximum Age of Data"
 msgstr "Edad máxima de los datos"
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr "Reintentos máximos"
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr "Retardo de arranque máximo"
 
@@ -243,14 +248,6 @@ msgstr "Número máximo de veces para intentar iniciar un controlador."
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Tiempo máximo en segundos para la actualización del estado de UPS"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr "Reintentos máximos"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
-msgstr "Retardo de arranque máximo"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
 msgid "Minimum required number or power supplies"
@@ -566,8 +563,8 @@ msgid ""
 "Use upscmd -l to see full list which the commands your UPS supports "
 "(requires upscmd package)"
 msgstr ""
-"Use upscmd -l para ver la lista completa de las órdenes que admite su UPS ("
-"requiere el paquete upscmd)"
+"Use upscmd -l para ver la lista completa de las órdenes que admite su UPS "
+"(requiere el paquete upscmd)"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:110
 msgid ""
@@ -616,3 +613,6 @@ msgstr "chroot"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon le quita privilegios a este usuario"
+
+#~ msgid "Maxium Start Delay"
+#~ msgstr "Retardo de arranque máximo"

--- a/applications/luci-app-nut/po/fr/nut.po
+++ b/applications/luci-app-nut/po/fr/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/he/nut.po
+++ b/applications/luci-app-nut/po/he/nut.po
@@ -219,7 +219,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -233,14 +238,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/hi/nut.po
+++ b/applications/luci-app-nut/po/hi/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/hu/nut.po
+++ b/applications/luci-app-nut/po/hu/nut.po
@@ -227,7 +227,12 @@ msgstr "Legnagyobb USB HID hossz jelentve"
 msgid "Maximum Age of Data"
 msgstr "Adatok legnagyobb életkora"
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr "Legtöbb újrapróbálás"
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr "Legnagyobb indítási késleltetés"
 
@@ -242,15 +247,6 @@ msgstr "Egy illesztőprogram indítási kísérleteinek legnagyobb száma."
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Legnagyobb idő másodpercben az UPS állapot frissítése között"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr "Legtöbb újrapróbálás"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-#, fuzzy
-msgid "Maxium Start Delay"
-msgstr "Legnagyobb indítási késleltetés"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
 msgid "Minimum required number or power supplies"
@@ -617,3 +613,7 @@ msgstr "chroot"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
 msgid "upsmon drops privileges to this user"
 msgstr "Az upsmon jogosultságokat dob a felhasználónak"
+
+#, fuzzy
+#~ msgid "Maxium Start Delay"
+#~ msgstr "Legnagyobb indítási késleltetés"

--- a/applications/luci-app-nut/po/it/nut.po
+++ b/applications/luci-app-nut/po/it/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/ja/nut.po
+++ b/applications/luci-app-nut/po/ja/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/ko/nut.po
+++ b/applications/luci-app-nut/po/ko/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/mr/nut.po
+++ b/applications/luci-app-nut/po/mr/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/ms/nut.po
+++ b/applications/luci-app-nut/po/ms/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/nb_NO/nut.po
+++ b/applications/luci-app-nut/po/nb_NO/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/pl/nut.po
+++ b/applications/luci-app-nut/po/pl/nut.po
@@ -221,7 +221,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -235,14 +240,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/pt/nut.po
+++ b/applications/luci-app-nut/po/pt/nut.po
@@ -226,7 +226,12 @@ msgstr "Relatório de comprimento máximo do USB HID"
 msgid "Maximum Age of Data"
 msgstr "Idade Máxima dos Dados"
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr "Quantidade Máxima de Tentativas"
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr "Atraso Máximo de Arranque"
 
@@ -241,14 +246,6 @@ msgstr "Quantidade máxima de vezes para tentar iniciar o driver."
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Tempo máximo em segundos para atualizar a condição do estado do UPS"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr "Quantidade Máxima de Tentativas"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
-msgstr "Atraso Máximo de Arranque"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
 msgid "Minimum required number or power supplies"
@@ -613,3 +610,6 @@ msgstr "chroot"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
 msgid "upsmon drops privileges to this user"
 msgstr "O upsmon derrubou os privilégios para este utilizador"
+
+#~ msgid "Maxium Start Delay"
+#~ msgstr "Atraso Máximo de Arranque"

--- a/applications/luci-app-nut/po/pt_BR/nut.po
+++ b/applications/luci-app-nut/po/pt_BR/nut.po
@@ -226,7 +226,12 @@ msgstr "Relatório de comprimento máximo do USB HID"
 msgid "Maximum Age of Data"
 msgstr "Idade Máxima dos Dados"
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr "Quantidade Máxima de Tentativas"
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr "Atraso Máximo de Arranque"
 
@@ -240,15 +245,8 @@ msgstr "Quantidade máxima de vezes para tentar iniciar o driver."
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr "Tempo máximo em segundos para atualizar a condição do estado do Nobreak"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr "Quantidade Máxima de Tentativas"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
-msgstr "Atraso Máximo de Arranque"
+msgstr ""
+"Tempo máximo em segundos para atualizar a condição do estado do Nobreak"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
 msgid "Minimum required number or power supplies"
@@ -612,3 +610,6 @@ msgstr "chroot"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
 msgid "upsmon drops privileges to this user"
 msgstr "O upsmon derrubou os privilégios para este usuário"
+
+#~ msgid "Maxium Start Delay"
+#~ msgstr "Atraso Máximo de Arranque"

--- a/applications/luci-app-nut/po/ro/nut.po
+++ b/applications/luci-app-nut/po/ro/nut.po
@@ -219,7 +219,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -233,14 +238,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/ru/nut.po
+++ b/applications/luci-app-nut/po/ru/nut.po
@@ -221,7 +221,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -235,14 +240,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/sk/nut.po
+++ b/applications/luci-app-nut/po/sk/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/sv/nut.po
+++ b/applications/luci-app-nut/po/sv/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/templates/nut.pot
+++ b/applications/luci-app-nut/po/templates/nut.pot
@@ -209,7 +209,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -223,14 +228,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/tr/nut.po
+++ b/applications/luci-app-nut/po/tr/nut.po
@@ -218,7 +218,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -232,14 +237,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/uk/nut.po
+++ b/applications/luci-app-nut/po/uk/nut.po
@@ -221,7 +221,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -235,14 +240,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/vi/nut.po
+++ b/applications/luci-app-nut/po/vi/nut.po
@@ -220,7 +220,12 @@ msgstr ""
 msgid "Maximum Age of Data"
 msgstr ""
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr ""
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr ""
 
@@ -234,14 +239,6 @@ msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr ""
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17

--- a/applications/luci-app-nut/po/zh-cn/nut.po
+++ b/applications/luci-app-nut/po/zh-cn/nut.po
@@ -223,7 +223,12 @@ msgstr "报告的最大 USB HID 长度"
 msgid "Maximum Age of Data"
 msgstr "最大数据年龄"
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr "最大重试次数"
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr "最大启动延迟"
 
@@ -238,14 +243,6 @@ msgstr "尝试启动驱动程序的最大次数。"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "刷新 UPS 状态之间的最长时间（秒）"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr "最大重试次数"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
-msgstr "最大启动延迟"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
 msgid "Minimum required number or power supplies"
@@ -600,3 +597,6 @@ msgstr "chroot"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon 删除此用户的权限"
+
+#~ msgid "Maxium Start Delay"
+#~ msgstr "最大启动延迟"

--- a/applications/luci-app-nut/po/zh-tw/nut.po
+++ b/applications/luci-app-nut/po/zh-tw/nut.po
@@ -224,7 +224,12 @@ msgstr "報告的最大 USB HID 長度"
 msgid "Maximum Age of Data"
 msgstr "最大資料年齡"
 
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum Retries"
+msgstr "最大重試次數"
+
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maximum Start Delay"
 msgstr "最大啟動延遲"
 
@@ -239,14 +244,6 @@ msgstr "嘗試啟動驅動程式的最大次數。"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "重新整理 UPS 狀態之間的最長時間（秒）"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maximum Retries"
-msgstr "最大重試次數"
-
-#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
-msgid "Maxium Start Delay"
-msgstr "最大啟動延遲"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
 msgid "Minimum required number or power supplies"
@@ -601,3 +598,6 @@ msgstr "chroot"
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon 刪除此使用者的許可權"
+
+#~ msgid "Maxium Start Delay"
+#~ msgstr "最大啟動延遲"

--- a/applications/luci-app-ocserv/po/hu/ocserv.po
+++ b/applications/luci-app-ocserv/po/hu/ocserv.po
@@ -27,15 +27,7 @@ msgstr "Aktív OpenConnect felhasználók"
 msgid "Active users"
 msgstr "Aktív felhasználók"
 
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:23
-msgid ""
-"An alternative value to be communicated to the client to verify the server's "
-"certificate; this value only depends on the public key"
-msgstr ""
-"Az ügyféllel közlendő alternatív érték a kiszolgáló tanúsítványának "
-"ellenőrzéséhez. Ez az érték csak a nyilvános kulcstól függ"
-
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:95
+#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:74
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:64
 msgid "AnyConnect client compatibility"
 msgstr "AnyConnect ügyfél kompatibilitás"
@@ -213,7 +205,7 @@ msgstr "Útválasztási táblázat"
 msgid "Server Settings"
 msgstr "Kiszolgáló beállításai"
 
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:22
+#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:20
 msgid "Server's Public Key ID"
 msgstr "A kiszolgáló nyilvános kulcsának azonosítója"
 
@@ -360,3 +352,10 @@ msgid ""
 msgstr ""
 "A kiszolgáló által használt CA-tanúsítvány megtekintése. El kell mentenie "
 "„ca.pem” néven, és importálnia kell az ügyfeleknél."
+
+#~ msgid ""
+#~ "An alternative value to be communicated to the client to verify the "
+#~ "server's certificate; this value only depends on the public key"
+#~ msgstr ""
+#~ "Az ügyféllel közlendő alternatív érték a kiszolgáló tanúsítványának "
+#~ "ellenőrzéséhez. Ez az érték csak a nyilvános kulcstól függ"

--- a/applications/luci-app-ocserv/po/hu/ocserv.po
+++ b/applications/luci-app-ocserv/po/hu/ocserv.po
@@ -213,36 +213,15 @@ msgstr "Útválasztási táblázat"
 msgid "Server Settings"
 msgstr "Kiszolgáló beállításai"
 
-<<<<<<< HEAD
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:20
-msgid "Server's Public Key ID"
-msgstr ""
-=======
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:22
 msgid "Server's Public Key ID"
 msgstr "A kiszolgáló nyilvános kulcsának azonosítója"
-
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:20
-msgid "Server's certificate SHA1 hash"
-msgstr "A kiszolgáló tanúsítványának SHA1 kivonata"
->>>>>>> weblate/master
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua:73
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:58
 msgid "Status"
 msgstr "Állapot"
 
-<<<<<<< HEAD
-=======
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:21
-msgid ""
-"That value should be communicated to the client to verify the server's "
-"certificate"
-msgstr ""
-"Az értéket közölni kell az ügyféllel a kiszolgáló tanúsítványának "
-"ellenőrzéséhez"
-
->>>>>>> weblate/master
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:112
 msgid "The DNS servers to be provided to clients; can be either IPv6 or IPv4"
 msgstr "Az ügyfeleknek biztosított DNS-kiszolgálók. Lehet IPv6 vagy IPv4"

--- a/applications/luci-app-ocserv/po/zh-cn/ocserv.po
+++ b/applications/luci-app-ocserv/po/zh-cn/ocserv.po
@@ -15,7 +15,8 @@ msgstr ""
 msgid ""
 "<abbr title=\"Classless Inter-Domain Routing\">CIDR</abbr>-Notation: address/"
 "prefix"
-msgstr "<abbr title=\"Classless Inter-Domain Routing\">CIDR</abbr>–表示：地址/前缀"
+msgstr ""
+"<abbr title=\"Classless Inter-Domain Routing\">CIDR</abbr>–表示：地址/前缀"
 
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:48
 msgid "Active OpenConnect Users"
@@ -25,12 +26,7 @@ msgstr "活跃的 OpenConnect 用户"
 msgid "Active users"
 msgstr "活跃用户"
 
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:23
-msgid ""
-"An alternative value to be communicated to the client to verify the server's "
-"certificate; this value only depends on the public key"
-msgstr "要传送给客户端以验证服务器证书的替代值；该值仅取决于公钥"
-
+#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:74
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:64
 msgid "AnyConnect client compatibility"
 msgstr "AnyConnect 客户端兼容性"
@@ -190,8 +186,9 @@ msgid ""
 "network in LAN covering 192.168.1.0/24 use 192.168.1.192/26 to reserve the "
 "upper 62 addresses."
 msgstr ""
-"从 LAN 子网向客户端提供地址；如果启用，下面的网络必须是 LAN 的子网。请注意，指定子网的第一个地址将由 ocserv 保留，因此不应使用。"
-"如果您的 LAN 网络范围是 192.168.1.0/24，请使用 192.168.1.192/26 保留前面的 62 个地址。"
+"从 LAN 子网向客户端提供地址；如果启用，下面的网络必须是 LAN 的子网。请注意，"
+"指定子网的第一个地址将由 ocserv 保留，因此不应使用。如果您的 LAN 网络范围是 "
+"192.168.1.0/24，请使用 192.168.1.192/26 保留前面的 62 个地址。"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:143
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:122
@@ -206,20 +203,10 @@ msgstr "服务器设置"
 msgid "Server's Public Key ID"
 msgstr "服务器公钥 ID"
 
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:20
-msgid "Server's certificate SHA1 hash"
-msgstr "服务器证书 SHA1 哈希"
-
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua:73
 #: applications/luci-app-ocserv/luasrc/view/ocserv_status.htm:58
 msgid "Status"
 msgstr "状态"
-
-#: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:21
-msgid ""
-"That value should be communicated to the client to verify the server's "
-"certificate"
-msgstr "该值应传达给客户端以验证服务器的证书"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:112
 msgid "The DNS servers to be provided to clients; can be either IPv6 or IPv4"
@@ -229,14 +216,18 @@ msgstr "要提供给客户端的 DNS 服务器；可以是 IPv6 或 IPv4"
 msgid ""
 "The DNS servers to be provided to clients; can be either IPv6 or IPv4. "
 "Typically you should include the address of this device"
-msgstr "要提供给客户端的 DNS 服务器；可以是 IPv6 或 IPv4。通常，您应该包括此设备的地址"
+msgstr ""
+"要提供给客户端的 DNS 服务器；可以是 IPv6 或 IPv4。通常，您应该包括此设备的地"
+"址"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:111
 msgid ""
 "The IPv4 subnet address to provide to clients; this should be some private "
 "network different than the LAN addresses unless proxy ARP is enabled. Leave "
 "empty to attempt auto-configuration."
-msgstr "要提供给客户端的 IPv4 子网地址；除非启用代理 ARP，否则这应该是一些与 LAN 地址不同的专用网络。留空以尝试自动配置。"
+msgstr ""
+"要提供给客户端的 IPv4 子网地址；除非启用代理 ARP，否则这应该是一些与 LAN 地址"
+"不同的专用网络。留空以尝试自动配置。"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:125
 msgid ""
@@ -256,7 +247,9 @@ msgid ""
 "The authentication method for the users. The simplest is plain with a single "
 "username-password pair. Use PAM modules to authenticate using another server "
 "(e.g., LDAP, Radius)."
-msgstr "用户的身份验证方法。最简单的是单个用户名-密码对。使用 PAM 模块使用其他服务器（例如：LDAP、Radius）进行身份验证。"
+msgstr ""
+"用户的身份验证方法。最简单的是单个用户名-密码对。使用 PAM 模块使用其他服务器"
+"（例如：LDAP、Radius）进行身份验证。"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:45
 msgid "The firewall zone that the VPN clients will be set to"
@@ -272,7 +265,9 @@ msgid ""
 "The routing table to be provided to clients; you can mix IPv4 and IPv6 "
 "routes, the server will send only the appropriate. Leave empty to set a "
 "default route"
-msgstr "提供给客户端的路由表；您可以混合使用 IPv4 和 IPv6 路由，服务器将只发送适当的路由。留空以设置默认路由"
+msgstr ""
+"提供给客户端的路由表；您可以混合使用 IPv4 和 IPv6 路由，服务器将只发送适当的"
+"路由。留空以设置默认路由"
 
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua:57
 #: applications/luci-app-ocserv/luasrc/model/cbi/ocserv/user-config.lua:51
@@ -345,3 +340,16 @@ msgid ""
 "View the CA certificate used by this server. You will need to save it as 'ca."
 "pem' and import it into the clients."
 msgstr "查看该服务器使用的 CA 证书。您需要将其另存为“ca.pem”并导入客户端。"
+
+#~ msgid ""
+#~ "An alternative value to be communicated to the client to verify the "
+#~ "server's certificate; this value only depends on the public key"
+#~ msgstr "要传送给客户端以验证服务器证书的替代值；该值仅取决于公钥"
+
+#~ msgid "Server's certificate SHA1 hash"
+#~ msgstr "服务器证书 SHA1 哈希"
+
+#~ msgid ""
+#~ "That value should be communicated to the client to verify the server's "
+#~ "certificate"
+#~ msgstr "该值应传达给客户端以验证服务器的证书"

--- a/applications/luci-app-olsr/po/bg/olsr.po
+++ b/applications/luci-app-olsr/po/bg/olsr.po
@@ -24,23 +24,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -67,8 +67,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -110,31 +110,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -142,13 +142,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -158,8 +158,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -168,17 +168,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -196,8 +196,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -206,17 +206,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -224,22 +224,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -284,18 +284,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -310,26 +310,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -340,52 +340,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -394,14 +394,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -410,10 +410,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -421,15 +421,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -437,24 +437,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -468,30 +468,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -505,28 +505,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -536,18 +536,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -565,22 +565,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -588,8 +588,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -604,17 +604,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -631,8 +631,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -658,22 +658,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -697,21 +697,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -768,35 +768,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -858,8 +858,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -875,15 +875,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -907,34 +907,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -943,27 +943,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -971,10 +971,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -982,8 +982,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -998,13 +998,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1029,24 +1029,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1071,8 +1071,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ca/olsr.po
+++ b/applications/luci-app-olsr/po/ca/olsr.po
@@ -28,23 +28,23 @@ msgstr "Nodes OLSR actius"
 msgid "Active host net announcements"
 msgstr "Anuncis de xarxa de màquines actives"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Ajusts avançats"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Permet els passarel·les amb NAT "
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -71,8 +71,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr "Adreça de difusió"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -114,31 +114,31 @@ msgstr ""
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Activa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Habilita aquesta interfície."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Activat"
 
@@ -146,13 +146,13 @@ msgstr "Activat"
 msgid "Expected retransmission count"
 msgstr "Compte de retransmissió previst"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "Mètrica FIB"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -162,8 +162,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -172,17 +172,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Passarel·la"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Ajusts generals"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Ajusts generals"
 
@@ -200,8 +200,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -210,17 +210,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "Anuncis HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "Interval HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Temps de validesa HNA"
 
@@ -229,22 +229,22 @@ msgstr "Temps de validesa HNA"
 msgid "HNA6 Announcements"
 msgstr "Anuncis HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Interval Hello"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Temps de validesa Hello"
 
@@ -262,8 +262,8 @@ msgstr ""
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -289,18 +289,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Adreces IP"
 
@@ -315,26 +315,26 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "Difusió IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -345,52 +345,52 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "Difusió selectiva IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -399,14 +399,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -415,10 +415,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Interfície"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -426,15 +426,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Interfícies"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -442,24 +442,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr "Protocol d'Internet"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -473,30 +473,30 @@ msgstr "Rutes OLSR conegudes"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "Envelliment LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "Algoritme LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ fisheye"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "Nivell LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -510,28 +510,28 @@ msgstr "Últim salt"
 msgid "Legend"
 msgstr "Llegenda"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Biblioteca"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Ajusts de qualitat d'enllaç"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -541,18 +541,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "Multiplicador de qualitat d'enllaç"
 
@@ -570,22 +570,22 @@ msgid "Local interface IP"
 msgstr "IP d'interfície local"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "Interval MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "Temps de validesa MID"
 
@@ -593,8 +593,8 @@ msgstr "Temps de validesa MID"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "IP principal"
 
@@ -609,17 +609,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Mètric"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Mode"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -636,8 +636,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "Llindar NAT"
 
@@ -663,22 +663,22 @@ msgstr "Veïns"
 msgid "Netmask"
 msgstr "Màscara de xarxa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Xarxa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Adreça de xarxa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -703,21 +703,21 @@ msgstr "Anuncis OLSR - HNA"
 msgid "OLSR - HNA6-Announcements"
 msgstr "Anuncis OLSR - HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - Connectors"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "Dimoni OLSR"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "Dimoni OLSR - Interfície"
 
@@ -774,35 +774,35 @@ msgstr "Visió de conjunt d'anuncis d'interfície múltiple coneguts"
 msgid "Overview of smart gateways in this network"
 msgstr "Visió de conjunt de les passarel·les intel·ligents en aquesta xarxa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Configuració de connector"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Connectors"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Taxa de sondeig"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -864,8 +864,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -881,15 +881,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -913,34 +913,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "Interval TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "Temps de validesa TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "Valor TOS"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -949,27 +949,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -977,10 +977,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "Sincronització i validitat"
 
@@ -988,8 +988,8 @@ msgstr "Sincronització i validitat"
 msgid "Topology"
 msgstr "Topologia"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1004,13 +1004,13 @@ msgstr "No s'ha pogut connectar al dimoni OLSR"
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Utilitza histèresi"
 
@@ -1035,24 +1035,24 @@ msgstr ""
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Pes"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1077,8 +1077,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Voluntat"
 

--- a/applications/luci-app-olsr/po/cs/olsr.po
+++ b/applications/luci-app-olsr/po/cs/olsr.po
@@ -24,23 +24,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Pokročilé nastavení"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -67,8 +67,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -110,31 +110,31 @@ msgstr ""
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Povolit"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Povolit toto rozhraní."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Povoleno"
 
@@ -142,13 +142,13 @@ msgstr "Povoleno"
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -158,8 +158,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -168,17 +168,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Brána"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Obecné nastavení"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Obecné nastavení"
 
@@ -196,8 +196,8 @@ msgid "Green"
 msgstr "Zelený"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -206,17 +206,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "HNA interval"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -224,22 +224,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr "Skrýt IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -284,18 +284,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP adresy"
 
@@ -310,26 +310,26 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 broadcast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -340,52 +340,52 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 multicast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -394,14 +394,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -410,10 +410,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Rozhraní"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -421,15 +421,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Síťová rozhraní"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -437,24 +437,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr "Internet protokol"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -468,30 +468,30 @@ msgstr ""
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ algoritmus"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -505,28 +505,28 @@ msgstr "Poslední skok (hop)"
 msgid "Legend"
 msgstr "Legenda"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Knihovna"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -536,18 +536,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -565,22 +565,22 @@ msgid "Local interface IP"
 msgstr "IP lokálního rozhraní"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID interval"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -588,8 +588,8 @@ msgstr ""
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "Hlavní IP"
 
@@ -604,17 +604,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Metrika"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Mód"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -631,8 +631,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -658,22 +658,22 @@ msgstr "Sousedé"
 msgid "Netmask"
 msgstr "Maska sítě"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Síť"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -697,21 +697,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - pluginy"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -768,35 +768,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Konfigurace pluginu"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Pluginy"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -858,8 +858,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "Úroveň šumu v dB"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -875,15 +875,15 @@ msgstr ""
 msgid "Source address"
 msgstr "Zdrojová adresa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -907,34 +907,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC interval"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS hodnota"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -943,27 +943,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -971,10 +971,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -982,8 +982,8 @@ msgstr ""
 msgid "Topology"
 msgstr "Topologie"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -998,13 +998,13 @@ msgstr ""
 msgid "Uplink"
 msgstr "Uplink"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1029,24 +1029,24 @@ msgstr "Velmi dobré (SNR > 30)"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Váha"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1071,8 +1071,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/de/olsr.po
+++ b/applications/luci-app-olsr/po/de/olsr.po
@@ -26,23 +26,23 @@ msgstr "Aktive OLSR-Knoten"
 msgid "Active host net announcements"
 msgstr "Aktive HNA-Ankündigungen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Gateways mit NAT erlauben"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "Auswahl von IPv4-Gateways erlauben, die zum Internet hin NAT verwenden"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Uplink ankündigen"
 
@@ -70,8 +70,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr "Broadcast-Adresse"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -113,34 +113,34 @@ msgstr "Konfiguration herunterladen"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 "SmartGateway aktivieren. Ist diese Option deaktiviert, dann werden alle "
-"folgenden SmartGateway Einstellungen ignoriert. Die Voreinstellung ist \"no\""
-"."
+"folgenden SmartGateway Einstellungen ignoriert. Die Voreinstellung ist \"no"
+"\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Dieses Interface benutzen."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -148,13 +148,13 @@ msgstr "Aktiviert"
 msgid "Expected retransmission count"
 msgstr "Zu erwartende Sendeversuche pro Paket"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "FIB-Metrik"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -167,11 +167,11 @@ msgstr ""
 "die Metrik immer auf 2. Dies ist der bevorzugte Wert, da er dem Kernel dabei "
 "hilft, veraltete Routen zu löschen. \"correct\" verwendet den Hopcount als "
 "Metrik. \"approx\" benutzt ebenfalls den Hopcount als Metrik, updated diese "
-"aber nur, wenn sich auch der Nexthop verändert hat. Die Voreinstellung ist \""
-"flat\"."
+"aber nur, wenn sich auch der Nexthop verändert hat. Die Voreinstellung ist "
+"\"flat\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 "Fisheye Mechanismus für TC-Nachrichten (ausgewählt entspricht ein). Die "
@@ -182,17 +182,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Gateway"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -210,8 +210,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -220,17 +220,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "HNA-Ankündigungen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "HNA-Intervall"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "HNA-Gültigkeit"
 
@@ -239,22 +239,22 @@ msgstr "HNA-Gültigkeit"
 msgid "HNA6 Announcements"
 msgstr "HNA-Ankündigungen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Hallo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Hello-Intervall"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Hello-Gültigkeit"
 
@@ -272,8 +272,8 @@ msgstr ""
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -304,8 +304,8 @@ msgstr ""
 "Rechner in einem OLSR-geroutetem Netzwerk können Konnektivität zu externen "
 "Netzwerken mittels HNA-Nachrichten ankündigen."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -315,10 +315,10 @@ msgstr ""
 "Metric). Hysterese erhöht die Stabilität von berechneten Routen, verzögert "
 "aber das Registrieren von Nachbarknoten. Die Voreinstellung ist \"ja\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP-Adressen"
 
@@ -335,13 +335,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 Broadcast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -351,36 +351,36 @@ msgstr ""
 "Beispiel ist 255.255.255.255. Die Voreinstellung ist \"0.0.0.0\". Dies "
 "verwendet die Broadcastadresse des Interfaces."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 Quell-IP"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
 msgstr ""
-"IPv4 Quell-IP für ausgehende OLSR-Nachrichten. Die Voreinstellung ist \""
-"0.0.0.0\", dann wird die IP des Interfaces verwendet."
+"IPv4 Quell-IP für ausgehende OLSR-Nachrichten. Die Voreinstellung ist "
+"\"0.0.0.0\", dann wird die IP des Interfaces verwendet."
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:114
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 Multicast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -388,25 +388,25 @@ msgstr ""
 "IPv6 Multicast-Adresse. Die Voreinstellung ist \"FF02::6D\", die linklocal "
 "Multicastadresse für MANETs."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "IPv6 Netzwerk muss in 'full notation', der Prefix in CIDR Schreibweise "
 "eingegeben werden."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 Quell-IP"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -416,13 +416,13 @@ msgstr ""
 "angegebenen Prefix liegt. Die Voreinstellung ist \"0::/0\", damit wird eine "
 "IPv6-Adresse des Interfaces verwendet die nicht linklocal ist."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "IPv6-Präfix des Uplinks"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -433,20 +433,20 @@ msgstr ""
 "Wenn sich die Route zum aktuellen Gateway ändert, dann wird sein ETX-Wert "
 "zunächst mit diesem Wert multipliziert bevor er mit dem neuen ETX-Wert "
 "verglichen wird. Damit kann \"flapping\" von Routen reduziert werden. Der "
-"Wert kann zwischen 0.1 und 1.0 liegen, sollte aber nahe bei 1.0 sein.<br "
-"/><b>ACHTUNG:</b> Diese Einstellung darf nicht zusammen mit der etx_ffeth "
+"Wert kann zwischen 0.1 und 1.0 liegen, sollte aber nahe bei 1.0 sein.<br /"
+"><b>ACHTUNG:</b> Diese Einstellung darf nicht zusammen mit der etx_ffeth "
 "Metrik verwendet werden!<br />Die Voreinstellung ist \"1.0\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 "Benutzt dieser Knoten NAT für die Verbindung zum Internet? Die "
 "Voreinstellung ist \"yes\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -455,29 +455,29 @@ msgstr ""
 msgid "Interface"
 msgstr "Schnittstelle"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "Mit dieser Einstellung kann unnötiges Forwarden von Paketen auf geswitchten "
-"Ethernetschnittstellen unterbunden werden. Gültige Werte sind \"mesh\" und \""
-"ether\". Die Voreinstellung ist \"mesh\"."
+"Ethernetschnittstellen unterbunden werden. Gültige Werte sind \"mesh\" und "
+"\"ether\". Die Voreinstellung ist \"mesh\"."
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Schnittstellen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Schnittstellen-Standards"
 
@@ -485,8 +485,8 @@ msgstr "Schnittstellen-Standards"
 msgid "Internet protocol"
 msgstr "Internet Protokoll"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
@@ -494,17 +494,17 @@ msgstr ""
 "Intervall mit dem Netzwerkschnittstellen auf Änderungen in ihrer "
 "Konfiguration überprüft werden (in Sekunden). Die Voreinstellung ist \"2.5\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -518,30 +518,30 @@ msgstr "Bekannte OLSR-Routen"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ-Alterung"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ-Algorithmus"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ-Fisheye"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ-Level"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -555,20 +555,20 @@ msgstr "letzter Hop"
 msgid "Legend"
 msgstr "Legende"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Bibliothek"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Linkqualitätseinstellungen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -578,8 +578,8 @@ msgstr ""
 "etx_float und etx_fpm, kleinere Werte bedeuten langsamere Änderungen des ETX-"
 "Wertes. (zulässige Werte liegen zwischen 0,01 und 1,0)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -591,13 +591,13 @@ msgstr ""
 "Link Quality Algorithmus (nur für lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX mit exponentieller Alterung<br /><b>etx_fpm</b>: Dasselbe "
 "wie etx_float, Berechnung jedoch mit Ganzzahlen<br /><b>etx_ff</b>: ETX "
-"freifunk, eine ETX Variante die allen OLSR Traffic zur ETX Berechnung nutzt ("
-"und nicht nur Hello-Nachrichten)<br /><b>etx_ffeth</b>: Inkompatible "
+"freifunk, eine ETX Variante die allen OLSR Traffic zur ETX Berechnung nutzt "
+"(und nicht nur Hello-Nachrichten)<br /><b>etx_ffeth</b>: Inkompatible "
 "Variante von etx_ff die Ethernetlinks mit ETX 0.1 erlaubt<br />Die "
 "Voreinstellung ist \"etx_ff\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
@@ -608,10 +608,10 @@ msgstr ""
 "Linkqualität für MPR-Auswahl und Routing verwenden<br />Die Voreinstellung "
 "ist \"2\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "LQ-Multiplikator"
 
@@ -629,22 +629,22 @@ msgid "Local interface IP"
 msgstr "Lokale Interface-IP"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID-Intervall"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "MID-Gültigkeit"
 
@@ -652,8 +652,8 @@ msgstr "MID-Gültigkeit"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "Haupt-IP"
 
@@ -668,17 +668,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Metrik"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Modus"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -699,8 +699,8 @@ msgstr ""
 "zu 192.168.0.1: 192.168.0.1 0.5<br />reduziere die LQ für alle Nodes die mit "
 "diesem Interface kommunizieren um 20%: Voreinstellung 0.8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "NAT-Schwellenwert"
 
@@ -726,22 +726,22 @@ msgstr "Nachbarn"
 msgid "Netmask"
 msgstr "Netzmaske"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Netzwerk"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Netzwerk-Adresse"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Abfrageintervall für Schnittstellenänderungen"
 
@@ -766,21 +766,21 @@ msgstr "OLSR - HNA-Ankündigungen"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - HNA-Ankündigungen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - Plugins"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR-Daemon"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR Daemon - Schnittstelle"
 
@@ -837,35 +837,36 @@ msgstr "Übersicht über bekannte Mehrfachschnittstellenmeldungen"
 msgid "Overview of smart gateways in this network"
 msgstr "Übersicht über Smart Gateways in diesem Netzwerk"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Pluginkonfiguration"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Plugins"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
-msgstr "Abfragerate für OLSRd-Sockets in Sekunden. Die Voreinstellung ist 0.05."
+msgstr ""
+"Abfragerate für OLSRd-Sockets in Sekunden. Die Voreinstellung ist 0.05."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Abfragerate"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -937,8 +938,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "Smart Gateway"
 
@@ -954,8 +955,8 @@ msgstr "Smart Gateway ist auf diesem System nicht konfiguriert."
 msgid "Source address"
 msgstr "Quelladresse"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -964,8 +965,8 @@ msgstr ""
 "Der erste Wert ist die Upload-, der zweite Wert die Downloadgeschwindigkeit. "
 "Die Voreinstellung ist \"128 1024\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "Geschwindigkeit des Uplinks"
 
@@ -989,34 +990,34 @@ msgstr "Erfolgsquote vom Nachbarn empfangener Pakete"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "Erfolgsquote zum Nachbarn gesendeter Pakete"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC-Intervall"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "TC-Gültigkeit"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS-Wert"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -1028,8 +1029,8 @@ msgstr ""
 "erlaubt damit Mesh-Routing für jegliche Netzwerkgeräte. Besuche <a "
 "href='http://www.olsr.org'>olsrd.org</a> für Hilfe und Dokumentation."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1038,13 +1039,13 @@ msgstr ""
 "dann wird der Bereitschaftswert automatisch anhand von Akkukapazität und "
 "Stromversorgung berechnet. Die Voreinstellung ist \"3\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "Interface das OLSRd verwenden soll."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1052,8 +1053,8 @@ msgstr ""
 "Port, den OLSRd benutzt. Dieser sollte in der Regel auf dem Defaultwert 698 "
 "bleiben, was dem von IANA zugewiesenen Port für OLSRd entspricht."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1065,10 +1066,10 @@ msgstr ""
 "Übersetzung der IPv6-Adresse zu benutzen. Die maximale erlaubte Länge des "
 "Präfix ist 64 bit. Die Voreinstellung ist \"::/0\" (kein Präfix)."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "Taktung und Validität"
 
@@ -1076,14 +1077,14 @@ msgstr "Taktung und Validität"
 msgid "Topology"
 msgstr "Topologie"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
 msgstr ""
-"TOS-Wert für den IP-Header von OLSR-Nachrichten. Die Voreinstellung ist \""
-"16\"."
+"TOS-Wert für den IP-Header von OLSR-Nachrichten. Die Voreinstellung ist "
+"\"16\"."
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:9
 msgid "Unable to connect to the OLSR daemon!"
@@ -1094,13 +1095,13 @@ msgstr "Es konnte keine Verbindung zum OLSR-Daemon hergestellt werden!"
 msgid "Uplink"
 msgstr "Uplink"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "Der Uplink benutzt NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Hysterese aktivieren"
 
@@ -1125,8 +1126,8 @@ msgstr ""
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1134,17 +1135,17 @@ msgstr ""
 "WARNUNG: kmod-ipip ist nicht installiert. Ohne kmod-ipip wird SmartGateway "
 "nicht funktionieren, bitte installieren."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Gewichtung"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1184,8 +1185,8 @@ msgstr ""
 "2000::/3). Die Voreinstellung ist \"both\" (sowohl IPv4 als auch IPv6 Uplink "
 "ankündigen sofern verfügbar)."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Bereitschaft"
 

--- a/applications/luci-app-olsr/po/el/olsr.po
+++ b/applications/luci-app-olsr/po/el/olsr.po
@@ -26,23 +26,23 @@ msgstr "Ενεργοί κόμβοι OLSR"
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Προχωρημένες Ρυθμίσεις"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -69,8 +69,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -112,31 +112,31 @@ msgstr ""
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Ενεργοποίηση"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Ενεργοποίηση αυτής της διεπαφής."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -144,13 +144,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -160,8 +160,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -170,17 +170,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Πύλη"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Γενικές Ρυθμίσεις"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Γενικές ρυθμίσεις"
 
@@ -198,8 +198,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -208,17 +208,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -226,22 +226,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -259,8 +259,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -286,18 +286,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Διευθύνσεις IP"
 
@@ -312,26 +312,26 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -342,52 +342,52 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -396,14 +396,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -412,10 +412,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Διεπαφή"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -423,15 +423,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Διεπαφές"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -439,24 +439,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -470,30 +470,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -507,28 +507,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -538,18 +538,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -567,22 +567,22 @@ msgid "Local interface IP"
 msgstr "IP τοπικής διεπαφής"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -590,8 +590,8 @@ msgstr ""
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -606,17 +606,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -633,8 +633,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -660,22 +660,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Δίκτυο"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Διεύθυνση δικτύου"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -699,21 +699,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR Δαίμονας"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR Δαίμονας - Διεπαφή"
 
@@ -770,35 +770,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Πόρτα"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -860,8 +860,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -877,15 +877,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -909,34 +909,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -945,27 +945,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -973,10 +973,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -984,8 +984,8 @@ msgstr ""
 msgid "Topology"
 msgstr "Τοπολογία"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1000,13 +1000,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1031,24 +1031,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1073,8 +1073,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/en/olsr.po
+++ b/applications/luci-app-olsr/po/en/olsr.po
@@ -25,23 +25,23 @@ msgstr "Active OLSR nodes"
 msgid "Active host net announcements"
 msgstr "Active host net announcements"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -68,8 +68,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -111,31 +111,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -143,13 +143,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr "Expected retransmission count"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "FIB metric"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -159,8 +159,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -169,17 +169,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "General settings"
 
@@ -197,8 +197,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -207,17 +207,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "HNA interval"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "HNA validity time"
 
@@ -226,22 +226,22 @@ msgstr "HNA validity time"
 msgid "HNA6 Announcements"
 msgstr "OLSR - HNA-Announcements"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Hello interval"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Hello validity time"
 
@@ -259,8 +259,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -286,18 +286,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -312,26 +312,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 broadcast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -342,52 +342,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -396,14 +396,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -412,10 +412,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -423,15 +423,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -439,24 +439,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr "Internet protocol"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -470,30 +470,30 @@ msgstr "Known OLSR routes"
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ aging"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ algorithm"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ fisheye"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ level"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -507,28 +507,28 @@ msgstr "Last hop"
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Library"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -538,18 +538,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -567,22 +567,22 @@ msgid "Local interface IP"
 msgstr "Local interface IP"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID interval"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "MID validity time"
 
@@ -590,8 +590,8 @@ msgstr "MID validity time"
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -606,17 +606,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -633,8 +633,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -660,22 +660,22 @@ msgstr ""
 msgid "Netmask"
 msgstr "Netmask"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -700,21 +700,21 @@ msgstr "OLSR - HNA-Announcements"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - HNA-Announcements"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - Plugins"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR Daemon"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -771,35 +771,35 @@ msgstr "Overview of known multiple interface announcements"
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Plugin configuration"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Pollrate"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -861,8 +861,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -878,15 +878,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -910,34 +910,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC interval"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "TC validity time"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -946,27 +946,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -974,10 +974,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -985,8 +985,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1001,13 +1001,13 @@ msgstr "Unable to connect to the OLSR daemon!"
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Use hysteresis"
 
@@ -1032,24 +1032,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1074,8 +1074,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Willingness"
 

--- a/applications/luci-app-olsr/po/es/olsr.po
+++ b/applications/luci-app-olsr/po/es/olsr.po
@@ -26,23 +26,23 @@ msgstr "Nodos OLSR activos"
 msgid "Active host net announcements"
 msgstr "Declaraciones activas de dispositivos en la red"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Permitir puertas de enlace con NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "Permitir seleccionar una pasarela IPv4 con NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Declarar enlace de subida"
 
@@ -69,8 +69,8 @@ msgstr "Ambos valores en notación decimal con punto."
 msgid "Broadcast address"
 msgstr "Dirección de propagación"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr "Sólo puede ser una dirección IPv4 o IPv6 válidas o \"por defecto\""
 
@@ -114,19 +114,19 @@ msgstr "Configuración de descarga"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Activar"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -134,13 +134,13 @@ msgstr ""
 "Activar SmartGateway. Si se desactiva el resto de parámetros de SmartGateway "
 "se ignoran. \"No\" por defecto."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Activar esta interfaz."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Activado"
 
@@ -148,13 +148,13 @@ msgstr "Activado"
 msgid "Expected retransmission count"
 msgstr "Contador de retransmisión esperado"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "Métrica FIB"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -170,8 +170,8 @@ msgstr ""
 "también, pero solo la actualiza si cambia el siguiente salto también. Por "
 "defecto \"flat\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr "Mecanismo Fisheye para TCs (marcado = activado). Activado por defecto"
 
@@ -180,17 +180,17 @@ msgstr "Mecanismo Fisheye para TCs (marcado = activado). Activado por defecto"
 msgid "Gateway"
 msgstr "Puerta de enlace"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Configuración general"
 
@@ -208,8 +208,8 @@ msgid "Green"
 msgstr "Verde"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -218,17 +218,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "Declaraciones HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "Intervalo HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Tiempo de validez de HNA"
 
@@ -236,22 +236,22 @@ msgstr "Tiempo de validez de HNA"
 msgid "HNA6 Announcements"
 msgstr "Anuncios HNA6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Saludo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Intervalo de saludo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Tiempo de validez del saludo"
 
@@ -269,8 +269,8 @@ msgstr "Ocultar IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -300,8 +300,8 @@ msgstr ""
 "Los hosts en una red enrutada OLSR pueden anunciar la conectividad a redes "
 "externas utilizando mensajes HNA6."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -311,10 +311,10 @@ msgstr ""
 "histéresis da más robustez a la sensibilidad de enlace pero retrasa el "
 "registro de vecinos. \"Sí\" por defecto"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Direcciones IP"
 
@@ -331,13 +331,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "Difusión IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -347,13 +347,13 @@ msgstr ""
 "\"255.255.255.255\". Por defecto es \"0.0.0.0\" que hace que se use la "
 "interfaz de propagación IP."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 origen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -366,17 +366,17 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "Multidifusión IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -384,25 +384,25 @@ msgstr ""
 "Dirección IPv6 de multidifusión. Por defecto es \"FF02::6D\", la dirección "
 "de multidifusión local en routers MANET."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "La red IPv6 debe escribirse en notación completa y el prefijo debe estar en "
 "notación CIDR."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 origen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -412,13 +412,13 @@ msgstr ""
 "de este parámetro. Por defecto es \"0::/0\" que provoca el uso de un "
 "interfaz IP no local."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "Prefijo IPv6 para el enlace de subida"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -431,14 +431,14 @@ msgstr ""
 "1.0, pero debería aproximarse a 1.0 si se cambia.<br /><b>AVISO:</b> No debe "
 "usarse junto con la métrica etx_ffeth!<br />Por defecto es 1.0."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr "Este nodo usa NAT para conectar a internet. \"Sí\" por defecto."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -447,10 +447,10 @@ msgstr "Este nodo usa NAT para conectar a internet. \"Sí\" por defecto."
 msgid "Interface"
 msgstr "Interfaz"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -461,15 +461,15 @@ msgstr ""
 "Por defecto es \"mesh\"."
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Interfaces"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Valores por defecto de los interfaces"
 
@@ -477,8 +477,8 @@ msgstr "Valores por defecto de los interfaces"
 msgid "Internet protocol"
 msgstr "Protocolo de Internet"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
@@ -486,17 +486,17 @@ msgstr ""
 "Intervalo de sondeo de cambios de configuración a interfaces de red (en "
 "segundos). Por defecto es \"2.5\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr "Valor no válido para LQMult-Value. Debe ser entre 0,01 y 1,0."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -512,30 +512,30 @@ msgstr "Rutas OLSR conocidas"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ - Envejecimiento"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ - Algoritmo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ - Ojo de pez"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ - Nivel"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -551,20 +551,20 @@ msgstr "Último salto"
 msgid "Legend"
 msgstr "Leyenda"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Biblioteca"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Configuración de calidad de enlace"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -575,8 +575,8 @@ msgstr ""
 "cambios más lentos en el valor ETX. (los valores permitidos están entre 0.01 "
 "y 1.0)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -593,8 +593,8 @@ msgstr ""
 "incompatible de etx_ff que permite enlaces ethernet con ETX 0.1.<br />Por "
 "defecto \"etx_ff\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
@@ -605,10 +605,10 @@ msgstr ""
 "calidad del enlace<br /><b>2</b> = use calidad del enlace para selección de "
 "MPR y enrutado<br />Por defecto es 2"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "Multilplicador de calidad de enlace"
 
@@ -626,22 +626,22 @@ msgid "Local interface IP"
 msgstr "IP de la interfaz local"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "Intervalo de MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "Tiempo de validez de MID"
 
@@ -649,8 +649,8 @@ msgstr "Tiempo de validez de MID"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "IP principal"
 
@@ -668,17 +668,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Métrica"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Modo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -703,8 +703,8 @@ msgstr ""
 ">reduce LQ a fd91:662e:3c58::1 a la mitad: fd91:662e:3c58::1 0.5<br />reduce "
 "LQ a todos los nodos en esta interfaz en un 20%: por defecto 0,8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "Umbral NAT"
 
@@ -730,22 +730,22 @@ msgstr "Vecinos"
 msgid "Netmask"
 msgstr "Máscara de red"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Red"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Dirección de red"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Intervalo de muestreo de cambios de nic"
 
@@ -769,21 +769,21 @@ msgstr "OLSR - Declaraciones HNA"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - Anuncios HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - Complementos"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "Demonio OLSR"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "Demonio OLSR - Interfaz"
 
@@ -840,35 +840,35 @@ msgstr "Declaraciones de múltiples interfaces conocidas"
 msgid "Overview of smart gateways in this network"
 msgstr "Pasarelas inteligentes en esta red"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Configuración del plugin"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Plugins"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr "Ratio de muestreo de paquetes OLSR en segundos. Por defecto es 0.05."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Tasa de muestreo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Puerto"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -939,8 +939,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "Ratio señal / ruido en dB"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -956,8 +956,8 @@ msgstr "SmartGateway no está configurado."
 msgid "Source address"
 msgstr "Dirección de origen"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -965,8 +965,8 @@ msgstr ""
 "Especifica la velocidad del enlace en kilobits/s. El primer parámetro es la "
 "subida y el segundo la bajada. Por defecto es \"128 1024\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "Velocidad de subida"
 
@@ -990,34 +990,34 @@ msgstr "Ratio de éxito de paquetes recibidos de la vecindad"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "Ratio de éxito de paquetes enviados a la vecindad"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "Intervalo TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "Validez de TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -1031,8 +1031,8 @@ msgstr ""
 "ethernet. Puede visitar <a href='http://www.olsr.org'>olsrd.org</a> para "
 "ayuda y documentación."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1040,13 +1040,13 @@ msgstr ""
 "Willingness fija a usar. Si no se establece se calculará dinámicamente "
 "basándose en el estado de la batería y la corriente. Por defecto es 3."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "Interfaz a usar por OLSRD."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1054,8 +1054,8 @@ msgstr ""
 "Puerto a usar por OLSR. Debería ser 698 tal y como asigna IANA. Puede tener "
 "un valor entre 1 y 65535."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1067,10 +1067,10 @@ msgstr ""
 "de dirección. La longitud máxima del prefijo es 64 bits. Por defecto es "
 "\"::/0\" (sin prefijo)."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "Tiempo y validez"
 
@@ -1078,8 +1078,8 @@ msgstr "Tiempo y validez"
 msgid "Topology"
 msgstr "Topología"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1096,13 +1096,13 @@ msgstr "¡No puedo conectar con el demonio OLSR!"
 msgid "Uplink"
 msgstr "Enlace ascendente"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "El enlace saliente usa NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Usar histéresis"
 
@@ -1127,25 +1127,25 @@ msgstr "Muy bien (SNR > 30)"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 "Aviso: kmod-ipip no está instalado. Sin kmod-ipip SmartGateway no funcionará."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Peso"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1182,8 +1182,8 @@ msgstr ""
 "enlace ascendente buscando un HNA6 ::ffff:0:0/96 o 2000::/3 local. La "
 "configuración predeterminada es \"ambos\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Willingness"
 

--- a/applications/luci-app-olsr/po/fr/olsr.po
+++ b/applications/luci-app-olsr/po/fr/olsr.po
@@ -26,23 +26,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -69,8 +69,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -112,31 +112,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Activer"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Activé"
 
@@ -144,13 +144,13 @@ msgstr "Activé"
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -160,8 +160,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -170,17 +170,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -198,8 +198,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -208,17 +208,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -226,22 +226,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -259,8 +259,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -286,18 +286,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -312,26 +312,26 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -342,52 +342,52 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 multidiffusion"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -396,14 +396,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -412,10 +412,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -423,15 +423,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Interfaces"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -439,24 +439,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -470,30 +470,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -507,28 +507,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -538,18 +538,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -567,22 +567,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -590,8 +590,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -606,17 +606,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Métrique"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -633,8 +633,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -660,22 +660,22 @@ msgstr "Voisins"
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Réseau"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -699,21 +699,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -770,35 +770,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -860,8 +860,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -877,15 +877,15 @@ msgstr ""
 msgid "Source address"
 msgstr "Adresse source"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -909,34 +909,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -945,27 +945,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -973,10 +973,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -984,8 +984,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1000,13 +1000,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1031,24 +1031,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1073,8 +1073,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/he/olsr.po
+++ b/applications/luci-app-olsr/po/he/olsr.po
@@ -20,23 +20,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -63,8 +63,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -106,31 +106,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -138,13 +138,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -154,8 +154,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -164,17 +164,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -192,8 +192,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -202,17 +202,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -220,22 +220,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -253,8 +253,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -280,18 +280,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -306,26 +306,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -336,52 +336,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -390,14 +390,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -406,10 +406,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -417,15 +417,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -433,24 +433,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -464,30 +464,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -501,28 +501,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -532,18 +532,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -561,22 +561,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -584,8 +584,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -600,17 +600,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -627,8 +627,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -654,22 +654,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -693,21 +693,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -764,35 +764,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -854,8 +854,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -871,15 +871,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -903,34 +903,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -939,27 +939,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -967,10 +967,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -978,8 +978,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -994,13 +994,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1025,24 +1025,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1067,8 +1067,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/hi/olsr.po
+++ b/applications/luci-app-olsr/po/hi/olsr.po
@@ -24,23 +24,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -67,8 +67,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -110,31 +110,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -142,13 +142,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -158,8 +158,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -168,17 +168,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -196,8 +196,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -206,17 +206,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -224,22 +224,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -284,18 +284,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -310,26 +310,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -340,52 +340,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -394,14 +394,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -410,10 +410,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -421,15 +421,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -437,24 +437,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -468,30 +468,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -505,28 +505,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -536,18 +536,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -565,22 +565,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -588,8 +588,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -604,17 +604,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -631,8 +631,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -658,22 +658,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -697,21 +697,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -768,35 +768,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -858,8 +858,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -875,15 +875,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -907,34 +907,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -943,27 +943,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -971,10 +971,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -982,8 +982,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -998,13 +998,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1029,24 +1029,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1071,8 +1071,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/hu/olsr.po
+++ b/applications/luci-app-olsr/po/hu/olsr.po
@@ -24,24 +24,24 @@ msgstr "Aktív OLSR csomópontok"
 msgid "Active host net announcements"
 msgstr "Aktív gép hálózati közleményei"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Speciális beállítások"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Engedélyezett átjárók NAT-tal"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 "Egy NAT-tal rendelkező kimenő IPv4-átjáró kiválasztásának lehetővé tétele"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Kifelé menő kapcsolat bejelentése"
 
@@ -69,8 +69,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr "Üzenetszórás címe"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr "Csak egy érvényes IPv4-cím, IPv6-cím vagy „default” lehet"
 
@@ -114,19 +114,19 @@ msgstr "Beállítás letöltése"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -134,13 +134,13 @@ msgstr ""
 "SmartGateway engedélyezése. Ha ez le van tiltva, akkor az összes egyéb "
 "SmartGateway paraméter figyelmen kívül lesz hagyva. Alapértelmezetten „no”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "A csatoló engedélyezése."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Engedélyezve"
 
@@ -148,13 +148,13 @@ msgstr "Engedélyezve"
 msgid "Expected retransmission count"
 msgstr "Elvárt újraküldési darabszám"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "FIB mérőszám"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -171,8 +171,8 @@ msgstr ""
 "mérőszámértékként, de csak akkor frissíti az ugrásszámot, ha a következő "
 "ugrás is megváltozik. Alapértelmezetten „flat”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 "Halszem mechanizmus a TC-khez (a bejelölt azt jeleni, hogy be). "
@@ -183,17 +183,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Átjáró"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Általános beállítások"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Általános beállítások"
 
@@ -211,8 +211,8 @@ msgid "Green"
 msgstr "Zöld"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -221,17 +221,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "HNA közlemények"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "HNA időköz"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "HNA érvényességi idő"
 
@@ -239,22 +239,22 @@ msgstr "HNA érvényességi idő"
 msgid "HNA6 Announcements"
 msgstr "HNA6 közlemények"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Helló"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Helló időköze"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Helló érvényességi idő"
 
@@ -272,8 +272,8 @@ msgstr "IPv6 elrejtése"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -303,8 +303,8 @@ msgstr ""
 "Egy OLSR által forgalomirányított hálózatban lévő gépek bejelenthetik a "
 "külső hálózatokkal való kapcsolataikat HNA6 üzenetek használatával."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -314,10 +314,10 @@ msgstr ""
 "hiszterézis nagyobb robusztusságot ad a kapcsolat érzékeléséhez, de "
 "késlelteti a szomszéd regisztrálását. Alapértelmezetten „yes”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP-címek"
 
@@ -334,13 +334,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 üzenetszórás"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -350,13 +350,13 @@ msgstr ""
 "255.255.255.255. Alapértelmezetten „0.0.0.0”, amely a csatoló üzenetszórási "
 "IP-jének használatát aktiválja."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 forrás"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -369,17 +369,17 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 csoportcímzés"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -387,25 +387,25 @@ msgstr ""
 "IPv6 csoportcímzési cím. Alapértelmezetten „FF02::6D”, a mobil eseti hálózat "
 "útválasztójának kapcsolatszintű csoportcímzése."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "Az IPv6 hálózatot teljes jelölésben kell megadni, az előtagnak CIDR "
 "jelölésben kell lennie."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 forrás"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -416,13 +416,13 @@ msgstr ""
 "„0::/0”, amely egy nem kapcsolatszintű csatoló IP-jének használatát "
 "aktiválja."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "A kifelé menő kapcsolat IPv6-előtagja"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -433,20 +433,20 @@ msgstr ""
 "Ha a jelenlegi átjáróhoz vezető útvonalat meg kell változtatni, akkor ennek "
 "az átjárónak az ETX értéke meg lesz szorozva ezzel az értékkel, mielőtt az "
 "összehasonlításra kerül az újjal. A paraméter egy 0.1 és 1.0 közötti érték "
-"lehet, de az 1.0-hoz közelinek kell lennie, ha megváltoztatják.<br "
-"/><b>FIGYELMEZTETÉS:</b> ezt a paramétert nem szabad együtt használni az "
+"lehet, de az 1.0-hoz közelinek kell lennie, ha megváltoztatják.<br /"
+"><b>FIGYELMEZTETÉS:</b> ezt a paramétert nem szabad együtt használni az "
 "etx_ffeth mérőszámmal!<br />Alapértelmezetten „1.0”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 "Ha ez a csomópont NAT-ot használ az internethez történő kapcsolatokhoz. "
 "Alapértelmezetten „yes”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -455,10 +455,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Csatoló"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 #, fuzzy
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
@@ -470,15 +470,15 @@ msgstr ""
 "és „ether”. Alapértelmezetten „mesh”."
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Csatolók"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Csatolók alapértelmezettjei"
 
@@ -486,8 +486,8 @@ msgstr "Csatolók alapértelmezettjei"
 msgid "Internet protocol"
 msgstr "Internetprotokoll"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
@@ -495,17 +495,17 @@ msgstr ""
 "Időköz a hálózati csatolók lekérdezéséhez a beállítások változtatásaiért "
 "(másodpercben). Alapértelmezetten „2.5”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr "Érvénytelen érték az LQMult értéknél. 0.01 és 1.0 között kell lennie."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -521,30 +521,30 @@ msgstr "Ismert OLSR útvonalak"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ öregedés"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ algoritmus"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ halszem"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ szint"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -560,20 +560,20 @@ msgstr "Utolsó ugrás"
 msgid "Legend"
 msgstr "Jelmagyarázat"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Programkönyvtár"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Kapcsolat minőségének beállításai"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -584,8 +584,8 @@ msgstr ""
 "értékek az ETX érték lassabb változtatásait jelentik (az engedélyezett "
 "értékek 0.01 és 1.0 között vannak)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -594,31 +594,30 @@ msgid ""
 "calculation<br /><b>etx_ffeth</b>: incompatible variant of etx_ff that "
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
-"A kapcsolatminőség algoritmusa (csak 2-es szintű LQ-nál).<br "
-"/><b>etx_float</b>: lebegőpontos ETX exponenciális öregedéssel<br "
-"/><b>etx_fpm</b>: ugyanaz mint az etx_float, de egész számú aritmetikával<br "
-"/><b>etx_ff</b>: ETX freifunk, egy ETX-változat, amely az összes OLSR "
-"forgalmat használja (csak a hellók helyett) az ETX számításánál<br "
-"/><b>etx_ffeth</b>: az etx_ff nem kompatibilis változata, amely megengedi az "
-"ETX 0.1 értékkel rendelkező Ethernet kapcsolatokat.<br />Alapértelmezetten "
-"„etx_ff”"
+"A kapcsolatminőség algoritmusa (csak 2-es szintű LQ-nál).<br /><b>etx_float</"
+"b>: lebegőpontos ETX exponenciális öregedéssel<br /><b>etx_fpm</b>: ugyanaz "
+"mint az etx_float, de egész számú aritmetikával<br /><b>etx_ff</b>: ETX "
+"freifunk, egy ETX-változat, amely az összes OLSR forgalmat használja (csak a "
+"hellók helyett) az ETX számításánál<br /><b>etx_ffeth</b>: az etx_ff nem "
+"kompatibilis változata, amely megengedi az ETX 0.1 értékkel rendelkező "
+"Ethernet kapcsolatokat.<br />Alapértelmezetten „etx_ff”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
-"A kapcsolatminőség szintjének kapcsolója az ugrásszám és a költségalapú ("
-"főleg ETX) útválasztás között.<br /><b>0</b> = ne használjon "
+"A kapcsolatminőség szintjének kapcsolója az ugrásszám és a költségalapú "
+"(főleg ETX) útválasztás között.<br /><b>0</b> = ne használjon "
 "kapcsolatminőséget<br /><b>2</b> = kapcsolatminőség használata az MPR "
 "kiválasztáshoz és az útválasztáshoz<br />Alapértelmezetten „2”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "Kapcsolatminőség szorzója"
 
@@ -636,22 +635,22 @@ msgid "Local interface IP"
 msgstr "Helyi csatoló IP"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID időköz"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "MID érvényességi idő"
 
@@ -659,8 +658,8 @@ msgstr "MID érvényességi idő"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "Fő IP"
 
@@ -678,17 +677,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Mérőszám"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Mód"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -715,8 +714,8 @@ msgstr ""
 "fd91:662e:3c58::1 0.5<br />az LQ csökkentése az összes csomópontra ezen a "
 "csatolón 20%-kal: default 0.8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "NAT küszöbszintje"
 
@@ -742,22 +741,22 @@ msgstr "Szomszédok"
 msgid "Netmask"
 msgstr "Hálózati maszk"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Hálózat"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Hálózati cím"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Nic változtatások lekérdezési időköze"
 
@@ -781,21 +780,21 @@ msgstr "OLSR – HNA-közlemények"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR – HNA6-közlemények"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR – bővítmények"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR démon"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR démon – csatoló"
 
@@ -852,36 +851,36 @@ msgstr "Az ismert többszörös csatoló közlemények áttekintője"
 msgid "Overview of smart gateways in this network"
 msgstr "Ebben a hálózatban lévő okos átjárók áttekintője"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Bővítmény beállítása"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Bővítmények"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 "Az OLSR foglalatok lekérdezési aránya másodpercben. Alapértelmezetten „0.05”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Lekérdezési arány"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -953,8 +952,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "Jel zajaránya dB-ben"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -970,18 +969,18 @@ msgstr "A SmartGateway nincs beállítva ezen a rendszeren."
 msgid "Source address"
 msgstr "Forráscím"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 "Megadja a kifelé menő kapcsolat sebességét kilobit/másodpercben. Az első "
-"paraméter a feltöltés, a második paraméter a letöltés. Alapértelmezetten „"
-"128 1024”."
+"paraméter a feltöltés, a második paraméter a letöltés. Alapértelmezetten "
+"„128 1024”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "A kifelé menő kapcsolat sebessége"
 
@@ -1005,34 +1004,34 @@ msgstr "A szomszédtól fogadott csomagok sikerességi aránya"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "A szomszédnak küldött csomagok sikerességi aránya"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC időköz"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "TC érvényességi idő"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS érték"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -1040,15 +1039,15 @@ msgid ""
 "device. Visit <a href='http://www.olsr.org'>olsrd.org</a> for help and "
 "documentation."
 msgstr ""
-"Az OLSR démon az optimalizált kapcsolatállapot alapú forgalomirányítás ("
-"Optimized Link State Routing) protokoll megvalósítása. Mint olyan, lehetővé "
+"Az OLSR démon az optimalizált kapcsolatállapot alapú forgalomirányítás "
+"(Optimized Link State Routing) protokoll megvalósítása. Mint olyan, lehetővé "
 "teszi a háló útválasztást bármely hálózati berendezésnél. Bármilyen Wi-Fi "
 "kártyán elfut, amely támogatja az eseti módot, és természetesen bármely "
 "Ethernet eszközön. A súgóért és a dokumentációért látogassa meg az <a "
 "href='http://www.olsr.org'>olsrd.org</a> oldalt."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1057,13 +1056,13 @@ msgstr ""
 "dinamikusan lesz kiszámítva az akkumulátor vagy energia állapota alapján. "
 "Alapértelmezetten „3”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "A csatoló, amelyet az OLSRd-nek ki kell szolgálnia."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1071,8 +1070,8 @@ msgstr ""
 "Az a port, amelyet az OLSR használ. Ezt általában az IANA-hoz rendelt 698-as "
 "porton kellene tartani. 1 és 65535 között lehet az értéke."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1085,10 +1084,10 @@ msgstr ""
 "használja. A legnagyobb előtaghossz 64 bit. Alapértelmezetten „::/0” (nincs "
 "előtag)."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "Időzítés és érvényesség"
 
@@ -1096,8 +1095,8 @@ msgstr "Időzítés és érvényesség"
 msgid "Topology"
 msgstr "Topológia"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1114,13 +1113,13 @@ msgstr "Nem lehet kapcsolódni az OLSR démonhoz!"
 msgid "Uplink"
 msgstr "Kifelé menő kapcsolat"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "A kifelé menő kapcsolat NAT-ot használ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Hiszterézis használata"
 
@@ -1145,8 +1144,8 @@ msgstr "Nagyon jó (SNR > 30)"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1154,17 +1153,17 @@ msgstr ""
 "Figyelmeztetés: a kmod-ipip nincs telepítve. A kmod-ipip nélkül a "
 "SmartGateway nem fog működni, ezért telepítse azt."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Súly"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1205,8 +1204,8 @@ msgstr ""
 "helyi HNA6-jára történő keresés alapján van felismerve. Az alapértelmezett "
 "érték „both”."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Hajlandóság"
 

--- a/applications/luci-app-olsr/po/it/olsr.po
+++ b/applications/luci-app-olsr/po/it/olsr.po
@@ -26,23 +26,23 @@ msgstr "Nodi OLSR attivi"
 msgid "Active host net announcements"
 msgstr "Annunci rete host attiva"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Opzioni Avanzate"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Permetti gateway con NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "Permetti l'uso di gateway in uscita con NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Annuncia uplink"
 
@@ -69,8 +69,8 @@ msgstr "Entrambi i valori devono essere nella notazione decimale puntata"
 msgid "Broadcast address"
 msgstr "Indirizzo di broadcast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -112,19 +112,19 @@ msgstr "Configurazione Download"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Attiva"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -132,13 +132,13 @@ msgstr ""
 "Abitita SmartGateway. Se è disattivata, tutti gli altri parametri "
 "SmartGateway verrano ignorati. Predefinito è \"no\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Attiva questa interfaccia."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Abilitato"
 
@@ -146,13 +146,13 @@ msgstr "Abilitato"
 msgid "Expected retransmission count"
 msgstr "Expected retransmission count"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "Metrica FIB"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -162,8 +162,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -172,17 +172,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Gateway"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Impostazioni Generali"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Impostazioni Generali"
 
@@ -200,8 +200,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -210,17 +210,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "Annuncio di HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "Intervallo HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Durata di validità HNA"
 
@@ -229,22 +229,22 @@ msgstr "Durata di validità HNA"
 msgid "HNA6 Announcements"
 msgstr "Annuncio di HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Ciao"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Intervallo Saluto"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Durata validità Saluto"
 
@@ -262,8 +262,8 @@ msgstr ""
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -289,8 +289,8 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -300,10 +300,10 @@ msgstr ""
 "robustezza alla sensibilità del link ma rallenta la registrazione dei "
 "vicini. Default è \"si\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Indirizzi IP"
 
@@ -320,13 +320,13 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -336,13 +336,13 @@ msgstr ""
 "255.255.255.255. Default is 0.0.0.0, il che abilita l'uso dell'ip di "
 "broadcast di default."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 source"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -355,41 +355,41 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 multicast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "IPv6 network deve essere specificata in full notation, il prefisso deve "
 "essere in CIDR notation."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 source"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -399,13 +399,13 @@ msgstr ""
 "questo parametro. Predefinito è \"0::/0\", il che abilita l'uso di un IP non-"
 "linklocal."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "IPv6-Prefix dell' uplink"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -419,15 +419,15 @@ msgstr ""
 "valore vicino a 1.0. <br /><b>ATTENZIONE:</b> Questo valore non deve essere "
 "utilizzato insieme con la metrica etx_ffeth!<br />Defaults a \"1.0\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 "Se questo nodo usa un NAT per connettersi a Internet. Predefinito è \"si\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -436,10 +436,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Interfaccia"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -447,15 +447,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -463,24 +463,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -494,30 +494,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -531,28 +531,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -562,18 +562,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -591,22 +591,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -614,8 +614,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -630,17 +630,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -657,8 +657,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -684,22 +684,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -724,21 +724,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr "Annuncio di HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -795,35 +795,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -885,8 +885,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -902,15 +902,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -934,34 +934,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -970,27 +970,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -998,10 +998,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -1009,8 +1009,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1025,13 +1025,13 @@ msgstr "Impossibile connetersi al demone OLSR!"
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "L'uplink usa il NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Usa l'isteresi"
 
@@ -1056,24 +1056,24 @@ msgstr ""
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Peso"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1111,8 +1111,8 @@ msgstr ""
 "cercando un HNA del tipo 0.0.0.0/0, ::ffff:0:0/96 or 2000::/3. Default "
 "setting is \"both\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ja/olsr.po
+++ b/applications/luci-app-olsr/po/ja/olsr.po
@@ -25,23 +25,23 @@ msgstr "アクティブなOLSRノード"
 msgid "Active host net announcements"
 msgstr "アクティブなホストネットワーク通知"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "NATを使用するゲートウェイを選択可能にする"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "NATを介してパケットを送信するIPv4 ゲートウェイを選択可能にします"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "通知するアップリンク"
 
@@ -68,8 +68,8 @@ msgstr "どちらの値もドット付き十進数の形式で入力してくだ
 msgid "Broadcast address"
 msgstr "ブロードキャストアドレス"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -111,19 +111,19 @@ msgstr "設定ダウンロード"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "有効"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -131,13 +131,13 @@ msgstr ""
 "スマートゲートウェイを有効にします。無効の場合、その他全てのスマートゲート"
 "ウェイの設定値は無視されます。標準設定は\"無効\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "このインターフェースを有効にします。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "有効"
 
@@ -145,13 +145,13 @@ msgstr "有効"
 msgid "Expected retransmission count"
 msgstr "再送数の期待値"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "FIB メトリック"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -167,8 +167,8 @@ msgstr ""
 "リック値として使用しますが、次ホップが変更した場合のみ更新を行います。標準設"
 "定は\"flat\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr "TCsのfisheyeメカニズムを使用します。標準設定は\"有効\"です。"
 
@@ -177,17 +177,17 @@ msgstr "TCsのfisheyeメカニズムを使用します。標準設定は\"有効
 msgid "Gateway"
 msgstr "ゲートウェイ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "一般設定"
 
@@ -205,8 +205,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -215,17 +215,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "HNA 通知"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "HNA 送信間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "HNA 有効時間"
 
@@ -234,22 +234,22 @@ msgstr "HNA 有効時間"
 msgid "HNA6 Announcements"
 msgstr "HNA 通知"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Hello"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Hello 送信間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Hello 有効時間"
 
@@ -267,8 +267,8 @@ msgstr ""
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -294,8 +294,8 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -305,10 +305,10 @@ msgstr ""
 "効)。ヒステリシスはリンク検出に対するロバスト性を向上させますが、隣接ノードの"
 "登録が遅くなります。標準設定は\"有効\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IPアドレス"
 
@@ -325,13 +325,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 ブロードキャスト"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -341,13 +341,13 @@ msgstr ""
 "255.255.255.255が挙げられます。標準設定は\"0.0.0.0\"であり、インターフェース"
 "のブロードキャストIPを使用します。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 送信元"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -360,17 +360,17 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 マルチキャスト"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -378,25 +378,25 @@ msgstr ""
 "IPv6 マルチキャストアドレスを設定します。標準はMANETルーターが使用するリンク"
 "ローカル・マルチキャストである\"FF02::6D\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "IPv6 ネットワークアドレスは省略せずに入力してください。プレフィクスはCIDR形式"
 "で入力してください。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 送信元"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -406,13 +406,13 @@ msgstr ""
 "フィクス値に一致するものを選択します。標準設定は\"0::/0\"であり、リンクローカ"
 "ルIPでないインターフェースIPを使用します。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "アップリンクIPv6 プレフィクス"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -426,16 +426,16 @@ msgstr ""
 "<br /><b>警告:</b>このパラメータはetx_ffeth メトリックと同時に使用しないでく"
 "ださい!<br />標準設定は\"1.0\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 "このノードがNATを使用してインターネットに接続する場合、有効にしてください。標"
 "準設定は\"有効\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -444,10 +444,10 @@ msgstr ""
 msgid "Interface"
 msgstr "インターフェース"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -458,15 +458,15 @@ msgstr ""
 "\"です。標準設定は\"mesh\"です。"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "インターフェース"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "インターフェース デフォルト設定"
 
@@ -474,8 +474,8 @@ msgstr "インターフェース デフォルト設定"
 msgid "Internet protocol"
 msgstr "インターネットプロトコル"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
@@ -483,17 +483,17 @@ msgstr ""
 "ネットワーク・インターフェースの設定が変更されたかをチェックするポーリング間"
 "隔を秒単位で設定します。標準設定は\"2.5\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -507,30 +507,30 @@ msgstr "OLSR ルーティング"
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ エイジング"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ アルゴリズム"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ fisheye"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ レベル"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -544,20 +544,20 @@ msgstr "最終ホップ"
 msgid "Legend"
 msgstr "凡例"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "ライブラリ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "リンク品質 (LQ) 設定"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -567,8 +567,8 @@ msgstr ""
 "効)。etx_float及びetx_fpmの値の調整を行います。値が小さくなると、ETX値の変化"
 "が遅くなります。設定可能な値は0.01-1.0です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -585,8 +585,8 @@ msgstr ""
 "す。イーサネットのリンクにETX 0.1を設定することができます<br />標準設定は"
 "\"etx_ff\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
@@ -597,10 +597,10 @@ msgstr ""
 "<br /><b>2</b> = MPR集合及びルーティングにリンク品質を加味する<br />標準設定"
 "は\"2\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "リンク品質 (LQ) マルチプリケーター"
 
@@ -618,22 +618,22 @@ msgid "Local interface IP"
 msgstr "ローカルインターフェース IP"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID 送信間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "MID 有効時間"
 
@@ -641,8 +641,8 @@ msgstr "MID 有効時間"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "メインIP"
 
@@ -657,17 +657,17 @@ msgstr ""
 msgid "Metric"
 msgstr "メトリック"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "モード"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -689,8 +689,8 @@ msgstr ""
 "192.168.0.1 0.5<br />このインターフェースから全てのノードへ対して20%減らす場"
 "合: default 0.8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "NAT しきい値"
 
@@ -716,22 +716,22 @@ msgstr "隣接ノード"
 msgid "Netmask"
 msgstr "ネットマスク"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "ネットワーク"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "ネットワークアドレス"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "NIC変更ポーリング間隔"
 
@@ -756,21 +756,21 @@ msgstr "OLSR - HNA (Host and Network Association) 通知"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - HNA (Host and Network Association) 通知"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - プラグイン"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR デーモン"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR デーモン - インターフェース"
 
@@ -827,35 +827,35 @@ msgstr "通知されているマルチ・インターフェースの一覧"
 msgid "Overview of smart gateways in this network"
 msgstr "ネットワーク内のスマート・ゲートウェイ一覧"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "プラグイン設定"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "プラグイン"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr "OLSRソケットのポーリング間隔を秒単位で設定します。標準は0.05です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "ポーリング間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "ポート"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -928,8 +928,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -945,8 +945,8 @@ msgstr "スマート・ゲートウェイ(SmartGW)は設定されていません
 msgid "Source address"
 msgstr "送信元アドレス"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -954,8 +954,8 @@ msgstr ""
 "アップリンク速度をキロビット/秒で設定してください。1つ目のパラメータは上り、2"
 "つ目のパラメータは下りのストリームです。標準は\"128 1024\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "アップリンク速度"
 
@@ -979,34 +979,34 @@ msgstr "隣接ノードから受信したパケットの受信成功率"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "隣接ノードへ送信したパケットの送信成功率"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC 送信間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "TC 有効時間"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS値"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -1020,8 +1020,8 @@ msgstr ""
 "ん全てのイーサネットデバイスでも使用可能です。<a href='http://www.olsr."
 "org'>olsrd.org</a>にアクセスして、ヘルプ及びドキュメントを参照してください。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1029,13 +1029,13 @@ msgstr ""
 "willingnessを固定する場合に使用します。willingnessが設定されていない場合、"
 "バッテリや電源のステータスによって動的に計算されます。標準は\"3\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "OLSRdが使用するインターフェースです。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1043,8 +1043,8 @@ msgstr ""
 "OLSRが使用するポート番号です。通常、このポート番号はIANAがアサインした698番で"
 "あるべきです。1-65535の間で設定可能です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1052,10 +1052,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "送信間隔及び有効時間"
 
@@ -1063,8 +1063,8 @@ msgstr "送信間隔及び有効時間"
 msgid "Topology"
 msgstr "トポロジー"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1081,13 +1081,13 @@ msgstr "OLSRデーモンに接続できません！"
 msgid "Uplink"
 msgstr "アップリンク"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "NATを使用して上位ネットワークに接続する"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "ヒステリシスを使用する"
 
@@ -1112,8 +1112,8 @@ msgstr ""
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1121,17 +1121,17 @@ msgstr ""
 "警告: kmod-ipipがインストールされていません。スマートゲートウェイはkmod-ipip"
 "なしでは動作しません。まず初めにインストールを行なってください。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Weight"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1169,8 +1169,8 @@ msgstr ""
 "ローカルのHNAである0.0.0.0/0、::ffff:0:0/96、2000::/3を探索することで検出しま"
 "す。標準設定は、\"both\"です。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Willingness"
 

--- a/applications/luci-app-olsr/po/ko/olsr.po
+++ b/applications/luci-app-olsr/po/ko/olsr.po
@@ -24,23 +24,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -67,8 +67,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -110,31 +110,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -142,13 +142,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -158,8 +158,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -168,17 +168,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -196,8 +196,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -206,17 +206,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -224,22 +224,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -284,18 +284,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -310,26 +310,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -340,52 +340,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -394,14 +394,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -410,10 +410,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -421,15 +421,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -437,24 +437,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -468,30 +468,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -505,28 +505,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -536,18 +536,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -565,22 +565,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -588,8 +588,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -604,17 +604,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -631,8 +631,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -658,22 +658,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -697,21 +697,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -768,35 +768,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -858,8 +858,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -875,15 +875,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -907,34 +907,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -943,27 +943,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -971,10 +971,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -982,8 +982,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -998,13 +998,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1029,24 +1029,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1071,8 +1071,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/mr/olsr.po
+++ b/applications/luci-app-olsr/po/mr/olsr.po
@@ -26,23 +26,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "प्रगत सेटिंग्ज"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -69,8 +69,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -112,31 +112,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "सक्षम करा"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -144,13 +144,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -160,8 +160,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -170,17 +170,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "सामान्य सेटिंग्ज"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -198,8 +198,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -208,17 +208,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -226,22 +226,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -259,8 +259,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -286,18 +286,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -312,26 +312,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -342,52 +342,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -396,14 +396,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -412,10 +412,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -423,15 +423,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -439,24 +439,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -470,30 +470,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -507,28 +507,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -538,18 +538,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -567,22 +567,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -590,8 +590,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -606,17 +606,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -633,8 +633,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -660,22 +660,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -699,21 +699,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -770,35 +770,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "पोर्ट"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -860,8 +860,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -877,15 +877,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -909,34 +909,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -945,27 +945,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -973,10 +973,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -984,8 +984,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1000,13 +1000,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1031,24 +1031,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1073,8 +1073,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ms/olsr.po
+++ b/applications/luci-app-olsr/po/ms/olsr.po
@@ -19,23 +19,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -62,8 +62,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -105,31 +105,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -137,13 +137,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -153,8 +153,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -163,17 +163,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -191,8 +191,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -201,17 +201,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -219,22 +219,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -252,8 +252,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -279,18 +279,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -305,26 +305,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -335,52 +335,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -389,14 +389,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -405,10 +405,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -416,15 +416,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -432,24 +432,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -463,30 +463,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -500,28 +500,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -531,18 +531,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -560,22 +560,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -583,8 +583,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -599,17 +599,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -626,8 +626,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -653,22 +653,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -692,21 +692,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -763,35 +763,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -853,8 +853,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -870,15 +870,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -902,34 +902,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -938,27 +938,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -966,10 +966,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -977,8 +977,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -993,13 +993,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1024,24 +1024,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1066,8 +1066,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/no/olsr.po
+++ b/applications/luci-app-olsr/po/no/olsr.po
@@ -24,23 +24,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -67,8 +67,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -110,31 +110,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Aktivert"
 
@@ -142,13 +142,13 @@ msgstr "Aktivert"
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -158,8 +158,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -168,17 +168,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -196,8 +196,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -206,17 +206,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -224,22 +224,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -284,18 +284,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -310,26 +310,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -340,52 +340,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -394,14 +394,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -410,10 +410,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -421,15 +421,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -437,24 +437,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -468,30 +468,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -505,28 +505,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -536,18 +536,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -565,22 +565,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -588,8 +588,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -604,17 +604,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -631,8 +631,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -658,22 +658,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -697,21 +697,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -768,35 +768,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -858,8 +858,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -875,15 +875,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -907,34 +907,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -943,27 +943,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -971,10 +971,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -982,8 +982,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -998,13 +998,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1029,24 +1029,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1071,8 +1071,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/pl/olsr.po
+++ b/applications/luci-app-olsr/po/pl/olsr.po
@@ -25,23 +25,23 @@ msgstr "Aktywne węzły OLSR"
 msgid "Active host net announcements"
 msgstr "Aktywne ogłoszenia hostnet"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Zezwól na bramy z NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "Zezwól na wybieranie wychodzącej bramy IPv4 przez NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Ogłaszaj uplink"
 
@@ -70,8 +70,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr "Adres rozgłoszeniowy (broadcast)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr "Może to być tylko prawidłowy adres IPv4 lub IPv6 albo \"domyślny\""
 
@@ -115,19 +115,19 @@ msgstr "Ustawienia pobierania"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Włącz"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -135,13 +135,13 @@ msgstr ""
 "Włącz SmartGateway. Jeśli wyłączone, wszystkie inne parametry SmartGateway "
 "są ignorowane. Domyślnie jest wyłączone."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Włącz ten interfejs."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Włączone"
 
@@ -149,13 +149,13 @@ msgstr "Włączone"
 msgid "Expected retransmission count"
 msgstr "Oczekiwana wartość retransmisji"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "Metryka FIB"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -166,8 +166,8 @@ msgid ""
 msgstr ""
 
 # skorzystałem z niemieckiego tłumaczenia
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 "Mechanizm Fisheye dla TCs (zaznaczone oznacza \"włączone\"). Domyślnie jest "
@@ -178,17 +178,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Brama"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Ustawienia ogólne"
 
@@ -206,8 +206,8 @@ msgid "Green"
 msgstr "Zielony"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -216,17 +216,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "Ogłoszenia HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "Interwał HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Czas poprawności HNA"
 
@@ -235,22 +235,22 @@ msgstr "Czas poprawności HNA"
 msgid "HNA6 Announcements"
 msgstr "Ogłoszenia HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Hello"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Interwał Hello"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Czas poprawności Hello"
 
@@ -268,8 +268,8 @@ msgstr "Ukryj IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -300,18 +300,18 @@ msgstr ""
 "Hosty w sieci OLSR mogą ogłaszać połączenia z zewnętrznymi sieciami poprzez "
 "wiadomości HNA."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Adres IP"
 
@@ -328,13 +328,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "Transmisja IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -344,13 +344,13 @@ msgstr ""
 "Przydatnym przykładem byłoby 255.255.255.255. Domyślna wartość to "
 "\"0.0.0.0\" - jest wtedy używany adres rozgłoszeniowy interfejsu."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "Źródło IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -363,18 +363,18 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "Multicast IPv6"
 
 # Nie mam pojęcia, jak to lepiej przetłumaczyć, ale w moich tłumaczeniach kieruję się zasadą "release early, release often".
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -382,24 +382,24 @@ msgstr ""
 "Adres multicast IPv6. Domyślna wartość to \"FF02::6D\", multicast lokalnego "
 "routera."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "Sieć IPv6 musi być podana w pełnej notacji, prefiks musi być w notacji CIDR."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "Źródło IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -409,13 +409,13 @@ msgstr ""
 "będzie pasował do tego prefiksu. Domyślna wartość to \"0::/0\" - jest wtedy "
 "używany adres IP interfejsu."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "IPv6-Prefix łącza uplink"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -424,14 +424,15 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
-msgstr "Czy węzeł korzysta z NAT do połączenia z Internetem. Domyślnie \"Tak\"."
+msgstr ""
+"Czy węzeł korzysta z NAT do połączenia z Internetem. Domyślnie \"Tak\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -440,10 +441,10 @@ msgstr "Czy węzeł korzysta z NAT do połączenia z Internetem. Domyślnie \"Ta
 msgid "Interface"
 msgstr "Interfejs"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -454,16 +455,16 @@ msgstr ""
 "\"mesh\"."
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Interfejsy"
 
 # by Google :D po części
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Standardy interfejsów"
 
@@ -471,25 +472,25 @@ msgstr "Standardy interfejsów"
 msgid "Internet protocol"
 msgstr "Protokół internetowy"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 "Nieprawidłowa wartość dla LQMult-Value. Musi być z zakresu od 0.01 do 1.0."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -505,30 +506,30 @@ msgstr "Znane ścieżki OLSR"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "Starzenie się LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "Algorytm LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ-Fisheye"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "Poziom LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -544,29 +545,29 @@ msgstr "Ostatni skok (hop)"
 msgid "Legend"
 msgstr "Legenda"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Biblioteka"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #, fuzzy
 msgid "Link Quality Settings"
 msgstr "Ustawienia jakości linków"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -576,18 +577,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "Mnożnik LinkQuality"
 
@@ -605,22 +606,22 @@ msgid "Local interface IP"
 msgstr "IP lokalnego interfejsu"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "Interwał MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "Czas poprawności MID"
 
@@ -628,8 +629,8 @@ msgstr "Czas poprawności MID"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "Główny IP"
 
@@ -644,17 +645,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Metryka"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Tryb"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -671,8 +672,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "Próg NAT"
 
@@ -698,22 +699,22 @@ msgstr "Sąsiedzi"
 msgid "Netmask"
 msgstr "Maska sieci"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Sieć"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Adres sieci"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Zmiana interwału ankiety Nic"
 
@@ -737,21 +738,21 @@ msgstr "OLSR - Komunikaty HNA"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - Komunikaty HNA6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - pluginy"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "Demon OLSR"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "Demon OLSR - interfejs"
 
@@ -808,35 +809,35 @@ msgstr "Przegląd znanych wielointerfejsowych ogłoszeń"
 msgid "Overview of smart gateways in this network"
 msgstr "Przegląd bram SmartGateway w tej sieci"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Ustawienia pluginu"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Pluginy"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -898,8 +899,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -915,15 +916,15 @@ msgstr "SmartGateway jest nieskonfigurowane."
 msgid "Source address"
 msgstr "Adres źródłowy"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -949,34 +950,34 @@ msgstr "Wartość poprawnie otrzymanych od sąsiada pakietów"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "Wartość poprawnie wysłanych pakietów do sąsiada"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "Interwał TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "Czas poprawności TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "Wartość TOS"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -985,20 +986,20 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "Interfejs, który powinien oferować OLSRd."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1006,8 +1007,8 @@ msgstr ""
 "Port używany przez OLSR. Zwykle powinien pozostać na przydzielonym przez "
 "IANA porcie 698. Może mieć wartość pomiędzy 1 a 65535."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1015,10 +1016,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -1026,8 +1027,8 @@ msgstr ""
 msgid "Topology"
 msgstr "Topologia"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1042,13 +1043,13 @@ msgstr "Połączenie z demonem OLSR nieudane!"
 msgid "Uplink"
 msgstr "Uplink"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "Uplink używa NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Używaj histerezy"
 
@@ -1073,8 +1074,8 @@ msgstr ""
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1082,17 +1083,17 @@ msgstr ""
 "Uwaga: kmod-ipip nie jest zainstalowany. Bez kmod-ipip bramy SmartGateway "
 "nie będą działać. Proszę go zainstalować."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Waga"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1124,8 +1125,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Gotowość"
 

--- a/applications/luci-app-olsr/po/pt-br/olsr.po
+++ b/applications/luci-app-olsr/po/pt-br/olsr.po
@@ -28,23 +28,23 @@ msgstr "Nós OLSR ativos"
 msgid "Active host net announcements"
 msgstr "Anúncios ativos de equipamentos"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Configurações Avançadas"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Permitir rotadores com NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "Permitir a seleção de rotador de saída IPv4 com NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Anunciar enlace superior (uplink)"
 
@@ -74,8 +74,8 @@ msgid "Broadcast address"
 msgstr "Endereço de broadcast"
 
 # 20140621: edersg: tradução
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 "Somente pode ser um endereço IPv4 ou IPv6 válidos ou um endereço 'padrão'"
@@ -125,19 +125,19 @@ msgstr "Configuração do Recebimento de Dados"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Ativar"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -145,13 +145,13 @@ msgstr ""
 "Habilita o SmartGateway. Se isto está desabilitado, então todos os demais "
 "parâmetros do SmartGateway são ignorados. Padrão é \"não\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Habilita esta interface."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -159,13 +159,13 @@ msgstr "Ativado"
 msgid "Expected retransmission count"
 msgstr "Contagem esperada de retransmissões"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "Métrica FIB"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -182,8 +182,8 @@ msgstr ""
 "atualiza a contagem de saltos se o próximo salto também mudar. O padrão é "
 "\"flat\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 "Mecanismo Fisheye para <abbr title=\"Topology Control, Controle de Topologia"
@@ -194,17 +194,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Roteador"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Configurações gerais"
 
@@ -225,8 +225,8 @@ msgid "Green"
 msgstr "Verde"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -239,19 +239,19 @@ msgstr ""
 "Anúncios do <abbr title=\"Host and network association, Associação de "
 "equipamentos e redes\">HNA</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 "Intervalo entre <abbr title=\"Host and network association, Associação de "
 "equipamentos e redes\">HNA</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 "Validade do <abbr title=\"Host and network association, Associação de "
@@ -263,22 +263,22 @@ msgstr ""
 "Anúncios do <abbr title=\"Host and network association, Associação de "
 "equipamentos e redes\">HNA</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Saudação (Hello)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Intervalo entre Saudações (Hello)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Validade da Saudação (Hello)"
 
@@ -298,8 +298,8 @@ msgstr "Ocultar IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -330,8 +330,8 @@ msgstr ""
 "redes externas usando mensagens HNA."
 
 # Hysteresis é Histerese que significa "retardo"
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -341,10 +341,10 @@ msgstr ""
 "de saltos), Retardo incrementa a robustez da sensibilidade do enlace mas "
 "atrasa o registro dos vizinhos. O padrão é \"sim\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Endereços IP"
 
@@ -361,13 +361,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "Broadcast IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -377,13 +377,13 @@ msgstr ""
 "seria 255.255.255.255. O padrão é \"0.0.0.0\", que indica o uso do endereço "
 "IP de broadcast da interface."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "Origem IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -397,17 +397,17 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "Multicast IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -415,25 +415,25 @@ msgstr ""
 "Endereço de multicast IPv6. O padrão é \"FF02::6D\", o multicast do enlace "
 "local do roteador MANET."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "A rede IPv6 deve ser informada em notação completa. O prefixo deve ser em "
 "notação CIDR."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "Origem IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -443,13 +443,13 @@ msgstr ""
 "com o prefixo do parâmetro. O padrão é \"0::/0\", que faz com que seja usado "
 "um endereço IP não local da interface."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "Prefixo IPv6 do enlace superior (uplink)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -463,14 +463,14 @@ msgstr ""
 "1.0 se alterado..<br /><b>CUIDADO:</b> Este parâmetro não deve ser usado em "
 "conjunto com a métrica etx_ffeth!<br />O padrão é \"1.0\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr "Se este Nó usa NAT para conexões com a internet. Padrão é \"sim\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -479,10 +479,10 @@ msgstr "Se este Nó usa NAT para conexões com a internet. Padrão é \"sim\"."
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -493,15 +493,15 @@ msgstr ""
 "\"ether\". O padrão é \"mesh\"."
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Interfaces"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Padrões da Interface"
 
@@ -509,8 +509,8 @@ msgstr "Padrões da Interface"
 msgid "Internet protocol"
 msgstr "Protocolo internet"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
@@ -519,18 +519,18 @@ msgstr ""
 "configurações (em segundos). O padrão é \"2.5\"."
 
 # 20140621: edersg: tradução
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr "Valor inválido para LQMult-Value. Deve estar entre 0.01 e 1.0."
 
 # 20140621: edersg: tradução
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -546,32 +546,32 @@ msgstr "Rotas OLSR conhecidas"
 msgid "LQ"
 msgstr "<abbr title=\"Link Quality, Qualidade do Enlace\">LQ</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 "Envelhecimento do <abbr title=\"Link Quality, Qualidade do Enlace\">LQ</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "Algoritmo <abbr title=\"Link Quality, Qualidade do Enlace\">LQ</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "Fisheye <abbr title=\"Link Quality, Qualidade do Enlace\">LQ</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "Nível <abbr title=\"Link Quality, Qualidade do Enlace\">LQ</abbr>"
 
 # 20140621: edersg: tradução
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -587,20 +587,20 @@ msgstr "Último salto"
 msgid "Legend"
 msgstr "Legenda"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Biblioteca"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Configurações da Qualidade do Enlace"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -611,8 +611,8 @@ msgstr ""
 "para etx_float e etx_fpm, Valores menores significam mudanças mais lentas do "
 "valor ETX. (permitido valores entre 0.01 e 1.0)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -621,16 +621,16 @@ msgid ""
 "calculation<br /><b>etx_ffeth</b>: incompatible variant of etx_ff that "
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
-"Algoritmo de qualidade do enlace (apenas para lq level 2).<br "
-"/><b>etx_float</b>: Ponto ETX flutuante com envelhecimento exponencial<br "
-"/><b>etx_fpm</b> : o mesmo que etx_float, mas com aritmética inteira<br "
-"/><b>etx_ff</b> : ETX freifunk, uma variante do etx que usa todo o tráfego "
-"OLSE (em vez de usar saudações 'hello') para o cálculo do ETX<br "
-"/><b>etx_ffeth</b>: variante incompatível do etx_ff que permite enlaces "
+"Algoritmo de qualidade do enlace (apenas para lq level 2).<br /"
+"><b>etx_float</b>: Ponto ETX flutuante com envelhecimento exponencial<br /"
+"><b>etx_fpm</b> : o mesmo que etx_float, mas com aritmética inteira<br /"
+"><b>etx_ff</b> : ETX freifunk, uma variante do etx que usa todo o tráfego "
+"OLSE (em vez de usar saudações 'hello') para o cálculo do ETX<br /"
+"><b>etx_ffeth</b>: variante incompatível do etx_ff que permite enlaces "
 "ethernet com ETX 0.1.<br />O Padrão é \"etx_ff\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
@@ -641,10 +641,10 @@ msgstr ""
 "b> = não use a qualidade do enlace<br /><b>2</b> = use a qualidade do enlace "
 "para a seleção do MPR e roteamento<br />O padrão é \"2\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "Multiplicador da Qualidade do Enlace"
 
@@ -662,26 +662,26 @@ msgid "Local interface IP"
 msgstr "Endereço IP da interface local"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 "<abbr title=\"Multiple interface declaration,Declaração de interface múltipla"
 "\">MID</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 "Intervalo do <abbr title=\"Multiple interface declaration,Declaração de "
 "interface múltipla\">MID</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 "Validade do <abbr title=\"Multiple interface declaration,Declaração de "
@@ -691,8 +691,8 @@ msgstr ""
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "IP Principal"
 
@@ -711,18 +711,18 @@ msgstr ""
 msgid "Metric"
 msgstr "Métrica"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Modo"
 
 # 20140621: edersg: tradução
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -748,8 +748,8 @@ msgstr ""
 "Exemplos: <br />reduzir LQ para 192.168.0.1 pela metade: 192.168.0.1 0.5<br /"
 "> reduzir LQ para todos os nós nesta interface em 20%: padrão 0.8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "Limiar do NAT"
 
@@ -777,22 +777,22 @@ msgstr "Vizinhos"
 msgid "Netmask"
 msgstr "Máscara de rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Endereço de rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Intervalo de consulta de mudanças na placa de rede"
 
@@ -820,21 +820,21 @@ msgstr ""
 "OLSR - Anúncios <abbr title=\"Host and network association, Associação de "
 "equipamentos e redes\">HNA</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "Plug-ins - OLSR"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "Servidor OLSR"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "Servidor OLSR - Interface"
 
@@ -892,36 +892,36 @@ msgstr "Visão geral de anúncios de nós com múltiplas interfaces conhecidas"
 msgid "Overview of smart gateways in this network"
 msgstr "Visão geral dos SmartGateways na rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Configuração do Plugin"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Plugins"
 
 # Que socket?
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr "Taxa de consulta por conexões OLSR, em segundos. Padrão é 0.05."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Taxa de consulta"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -997,8 +997,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "Relação do ruído do sinal em dB"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -1014,8 +1014,8 @@ msgstr "SmartGateway não está configurado no seu sistema."
 msgid "Source address"
 msgstr "Endereço de origem"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -1024,8 +1024,8 @@ msgstr ""
 "primeiro parâmetro é a taxa de envio (upstream) e o segundo parâmetro é a "
 "taxa de recebimento (downstream). O padrão é \"128 1024\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "Velocidade do enlace superior"
 
@@ -1051,37 +1051,37 @@ msgstr "Taxa de sucesso de pacotes recebidos de vizinhos"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "Taxa de sucesso de pacotes enviados a vizinhos"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "<abbr title=\"Topology Control, Controle de Topologia\">TC</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 "Intervalo do <abbr title=\"Topology Control, Controle de Topologia\">TC</"
 "abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 "Validade do <abbr title=\"Topology Control, Controle de Topologia\">TC</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "Valor do TOS"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -1095,8 +1095,8 @@ msgstr ""
 "suporte o modo ad-hoc e, é claro, em qualquer dispositivo ethernet. Visite "
 "<a href='http://www.olsr.org'>olsrd.org</a> para ajuda e documentação."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1105,13 +1105,13 @@ msgstr ""
 "definida, ela será dinamicamente calculada baseada no estado da energia/"
 "bateria, O padrão é \"3\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "A interface onde o OLSRd deve servir."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1119,8 +1119,8 @@ msgstr ""
 "A porta que o OLSR usa. Isto geralmente deve ficar na porta 698, designada "
 "pela IANA. Pode ter qualquer valor entre 1 e 65535."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1132,10 +1132,10 @@ msgstr ""
 "IPv6 local para usar o roteador IPv6 sem qualquer tradução de endereços. O "
 "tamanho máximo do prefixo é 64 bits. O padrão é \"::/0\" (nenhum prefixo)."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "Temporização e Validade"
 
@@ -1143,8 +1143,8 @@ msgstr "Temporização e Validade"
 msgid "Topology"
 msgstr "Topologia"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1161,13 +1161,13 @@ msgstr "Não foi possível conectar ao servidor OLSR!"
 msgid "Uplink"
 msgstr "Velocidade de envio do enlace (uplink)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "Enlace superior (uplink) usa NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Usar retardo"
 
@@ -1195,8 +1195,8 @@ msgstr "Muito bom (SNR > 30)"
 msgid "WLAN"
 msgstr "Rede sem fio (WLAN)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1204,17 +1204,17 @@ msgstr ""
 "Atenção: o kmod-ipip não está instalado. Sem o kmod-ipip, o SmartGateway não "
 "irá funcionar. Por favor, instale-o."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Peso"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1255,8 +1255,8 @@ msgstr ""
 "and network association, Associação de equipamentos e redes\">HNA</abbr> "
 "local de 0.0.0.0/0, ::ffff:0:0/96 ou 2000::/3. O padrão é \"ambos\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Disponibilidade"
 

--- a/applications/luci-app-olsr/po/pt/olsr.po
+++ b/applications/luci-app-olsr/po/pt/olsr.po
@@ -26,23 +26,23 @@ msgstr "Nós OLSR ativos"
 msgid "Active host net announcements"
 msgstr "Anúncios ativos de redes de hosts"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Definições Avançadas"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Permitir gateways com NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "Permitir a selecção de uma gateway IPv4 para saída com NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Anunciar uplink"
 
@@ -69,8 +69,8 @@ msgstr "Os valores tem de usar a dotação decimal."
 msgid "Broadcast address"
 msgstr "Endereço de broadcast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 "Somente pode ser um endereço IPv4 ou IPv6 válidos ou um endereço 'padrão'"
@@ -117,19 +117,19 @@ msgstr "Descarregar Configuração"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Ativar"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -137,13 +137,13 @@ msgstr ""
 "Ativar SmartGateway. Se estiver desativado, então todos os outros parâmetros "
 "SmartGateway são ignorados. Predefinição é \"não\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Ativar esta interface."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -151,13 +151,13 @@ msgstr "Ativado"
 msgid "Expected retransmission count"
 msgstr "Contagem de retransmissões esperada"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "métrica FIB"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -169,33 +169,34 @@ msgstr ""
 "A métrica FIB controla o valor da métrica dos conjuntos de equipamentos-"
 "roteadores. \"flat\" significa que o valor da métrica é sempre 2. Este é o "
 "valor preferido porque ele ajuda o roteamento do kernel do Linux limpar as "
-"rotas antigas. \"correct\" usa a contagem de saltos como valor da métrica. \""
-"approx\" também usa a contagem de saltos como métrica, mas somente atualiza "
-"a contagem de saltos se o próximo salto também mudar. O padrão é \"flat\"."
+"rotas antigas. \"correct\" usa a contagem de saltos como valor da métrica. "
+"\"approx\" também usa a contagem de saltos como métrica, mas somente "
+"atualiza a contagem de saltos se o próximo salto também mudar. O padrão é "
+"\"flat\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
-"Mecanismo Fisheye para <abbr title=\"Topology Control, Controle de "
-"Topologia\">TC</abbr>s (marcado significa ligado). O padrão é \"ligado\""
+"Mecanismo Fisheye para <abbr title=\"Topology Control, Controle de Topologia"
+"\">TC</abbr>s (marcado significa ligado). O padrão é \"ligado\""
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:55
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:107
 msgid "Gateway"
 msgstr "Gateway"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Configurações gerais"
 
@@ -213,8 +214,8 @@ msgid "Green"
 msgstr "Verde"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -227,17 +228,17 @@ msgstr ""
 "Anúncios do <abbr title=\"Host and network association, Associação de "
 "equipamentos e redes\">HNA</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "Intervalo entre HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Validade de HNA"
 
@@ -245,22 +246,22 @@ msgstr "Validade de HNA"
 msgid "HNA6 Announcements"
 msgstr "Anúncios de HNA6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Saudação (Hello)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Intervalo entre Hello"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Validade de Hello"
 
@@ -278,8 +279,8 @@ msgstr "Ocultar IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -309,8 +310,8 @@ msgstr ""
 "Equipamentos em uma rede roteada por OLSR podem anunciar conectividade para "
 "redes externas usando mensagens HNA."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -320,10 +321,10 @@ msgstr ""
 "de saltos), Retardo incrementa a robustez da sensibilidade do enlace mas "
 "atrasa o registro dos vizinhos. O padrão é \"sim\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Endereços IP"
 
@@ -340,13 +341,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "Broadcast IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -356,13 +357,13 @@ msgstr ""
 "seria 255.255.255.255. O padrão é \"0.0.0.0\", que indica o uso do endereço "
 "IP de broadcast da interface."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "Origem IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -376,17 +377,17 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "Multicast IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -394,25 +395,25 @@ msgstr ""
 "Endereço de multicast IPv6. O padrão é \"FF02::6D\", o multicast do enlace "
 "local do roteador MANET."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "A rede IPv6 deve ser fornecido em dotação completa, o prefixo deve estar na "
 "notação CIDR."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "Origem IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -422,13 +423,13 @@ msgstr ""
 "com o prefixo do parâmetro. O padrão é \"0::/0\", que faz com que seja usado "
 "um endereço IP não local da interface."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "Prefixo IPv6 do enlace superior (uplink)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -442,14 +443,14 @@ msgstr ""
 "1.0 se alterado..<br /><b>CUIDADO:</b> Este parâmetro não deve ser usado em "
 "conjunto com a métrica etx_ffeth!<br />O padrão é \"1.0\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr "Se este Nó usa NAT para conexões com a internet. Padrão é \"sim\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -458,10 +459,10 @@ msgstr "Se este Nó usa NAT para conexões com a internet. Padrão é \"sim\"."
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -472,15 +473,15 @@ msgstr ""
 "são \"mesh\" e \"ether\". Por defeito é \"mesh\"."
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Interfaces"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Predefinições das Interfaces"
 
@@ -488,8 +489,8 @@ msgstr "Predefinições das Interfaces"
 msgid "Internet protocol"
 msgstr "Protocolo de Internet"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
@@ -497,17 +498,17 @@ msgstr ""
 "Intervalo para consultar as interfaces de rede por mudanças nas "
 "configurações (em segundos). O padrão é \"2.5\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr "Valor inválido para LQMult-Value. Deve estar entre 0.01 e 1.0."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -523,30 +524,30 @@ msgstr "Rotas OLSR conhecidas"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "Envelhecimento LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "Algoritmo LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "Fisheye LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "Nível LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -562,32 +563,32 @@ msgstr "Ultimo salto"
 msgid "Legend"
 msgstr "Legenda"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Biblioteca"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Definições de Qualidade do Link"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
-"O fator de envelhecimento da qualidade do enlace (somente para <abbr title=\""
-"Link Quality, Qualidade do Enlace\">LQ</abbr> nível 2). Parâmtro de ajuste "
+"O fator de envelhecimento da qualidade do enlace (somente para <abbr title="
+"\"Link Quality, Qualidade do Enlace\">LQ</abbr> nível 2). Parâmtro de ajuste "
 "para etx_float e etx_fpm, Valores menores significam mudanças mais lentas do "
 "valor ETX. (permitido valores entre 0.01 e 1.0)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -604,22 +605,22 @@ msgstr ""
 "para o cálculo do ETX<br /><b>etx_ffeth</b>: variação incompatível do etx_ff "
 "que permite enlaces ethernet com ETX 0.1.<br />O padrão é \"etx_ff\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 "O nível de qualidade do enlace escolhe entre o roteamento por contagem de "
-"saltos e o roteamento baseado em custos (na sua maioria, ETX). <br /><b>0</b>"
-" = não use a qualidade do enlace<br /><b>2</b> = use a qualidade do enlace "
+"saltos e o roteamento baseado em custos (na sua maioria, ETX). <br /><b>0</"
+"b> = não use a qualidade do enlace<br /><b>2</b> = use a qualidade do enlace "
 "para a seleção do MPR e roteamento<br />O padrão é \"2\""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "Multiplicador da Qualidade do Enlace"
 
@@ -637,24 +638,24 @@ msgid "Local interface IP"
 msgstr "Endereço IP do interface local"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
-"<abbr title=\"Multiple interface declaration,Declaração de interface "
-"múltipla\">MID</abbr>"
+"<abbr title=\"Multiple interface declaration,Declaração de interface múltipla"
+"\">MID</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "Intervalo de MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "Validade de MID"
 
@@ -662,8 +663,8 @@ msgstr "Validade de MID"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "IP Principal"
 
@@ -681,17 +682,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Métrica"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Modo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -700,8 +701,8 @@ msgid ""
 msgstr ""
 "Múltiplas rotas com o fator configurado aqui. Os valores permitidos estão "
 "entre 0.01 e 1.0. Ele somente é utilizado quando o nível-LQ é maior que 0. "
-"Exemplos: <br />reduzir LQ para 192.168.0.1 pela metade: 192.168.0.1 0.5<br "
-"/> reduzir LQ para todos os nós nesta interface em 20%: padrão 0.8"
+"Exemplos: <br />reduzir LQ para 192.168.0.1 pela metade: 192.168.0.1 0.5<br /"
+"> reduzir LQ para todos os nós nesta interface em 20%: padrão 0.8"
 
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:71
@@ -713,19 +714,19 @@ msgid ""
 msgstr ""
 "Múltiplas rotas com o fator configurado aqui. Os valores permitidos estão "
 "entre 0.01 e 1.0. Ele somente é utilizado quando o nível-LQ é maior que 0. "
-"Exemplos: <br />reduzir LQ para 192.168.0.1 pela metade: 192.168.0.1 0.5<br "
-"/> reduzir LQ para todos os nós nesta interface em 20%: padrão 0.8"
+"Exemplos: <br />reduzir LQ para 192.168.0.1 pela metade: 192.168.0.1 0.5<br /"
+"> reduzir LQ para todos os nós nesta interface em 20%: padrão 0.8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "Limiar do NAT"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/topology.htm:25
 msgid "NLQ"
 msgstr ""
-"<abbr title=\"Neighbor Link Quality, Qualidade do Enlace do Vizinho\""
-">NLQ</abbr>"
+"<abbr title=\"Neighbor Link Quality, Qualidade do Enlace do Vizinho\">NLQ</"
+"abbr>"
 
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:168
 msgid "Neighbors"
@@ -745,22 +746,22 @@ msgstr "Vizinhos"
 msgid "Netmask"
 msgstr "Máscara de rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Endereço de rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Intervalo de consulta de mudanças na placa de rede"
 
@@ -784,21 +785,21 @@ msgstr "OLSR - Anuncios HNA4"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - Anúncios de HNA6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "Plugins - OLSR"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "Servidor OLSR"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "Servidor OLSR - Interface"
 
@@ -855,35 +856,35 @@ msgstr "Resumo de anuncios de nós com multiplos interfaces activos"
 msgid "Overview of smart gateways in this network"
 msgstr "Visão geral dos SmartGateways na rede"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Configuração de Plugin"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Plugins"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr "Taxa de consulta por conexões OLSR, em segundos. Padrão é 0.05."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Taxa de requisição"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -955,8 +956,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "Relação do ruído do sinal em dB"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -972,8 +973,8 @@ msgstr "SmartGateway não está configurado no seu sistema."
 msgid "Source address"
 msgstr "Endereço de origem"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -982,8 +983,8 @@ msgstr ""
 "primeiro parâmetro é a taxa de envio (upstream) e o segundo parâmetro é a "
 "taxa de recebimento (downstream). O padrão é \"128 1024\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "Velocidade do uplink"
 
@@ -1007,34 +1008,34 @@ msgstr "Taxa de sucesso de pacotes recebidos de vizinhos"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "Taxa de sucesso de pacotes enviados a vizinhos"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "<abbr title=\"Topology Control, Controle de Topologia\">TC</abbr>"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "Intervalo de TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "Validade de TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "Valor do TOS"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -1048,8 +1049,8 @@ msgstr ""
 "suporte o modo ad-hoc e, é claro, em qualquer aparelho ethernet. Visite <a "
 "href='http://www.olsr.org'>olsrd.org</a> para ajuda e documentação."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1058,13 +1059,13 @@ msgstr ""
 "definida, ela será dinamicamente calculada baseada no estado da energia/"
 "bateria, O padrão é \"3\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "A interface onde o OLSRd deve servir."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1072,8 +1073,8 @@ msgstr ""
 "A porta que o OLSR usa. Isto geralmente deve ficar na porta 698, designada "
 "pela IANA. Pode ter qualquer valor entre 1 e 65535."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1085,10 +1086,10 @@ msgstr ""
 "IPv6 local para usar o roteador IPv6 sem qualquer tradução de endereços. O "
 "tamanho máximo do prefixo é 64 bits. O padrão é \"::/0\" (nenhum prefixo)."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "Temporização e Validade"
 
@@ -1096,8 +1097,8 @@ msgstr "Temporização e Validade"
 msgid "Topology"
 msgstr "Topologia"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1114,13 +1115,13 @@ msgstr "Não foi possivel ligar ao servidor OLSR!"
 msgid "Uplink"
 msgstr "Uplink"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "O uplink usa NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Usar histerese"
 
@@ -1145,8 +1146,8 @@ msgstr "Muito bom (SNR > 30)"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1154,17 +1155,17 @@ msgstr ""
 "Atenção: o kmod-ipip não está instalado. Sem o kmod-ipip, o SmartGateway não "
 "irá funcionar. Por favor, instale-o."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Peso"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1205,8 +1206,8 @@ msgstr ""
 "and network association, Associação de equipamentos e redes\">HNA</abbr> "
 "local de 0.0.0.0/0, ::ffff:0:0/96 ou 2000::/3. O padrão é \"ambos\"."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Disponibilidade"
 

--- a/applications/luci-app-olsr/po/ro/olsr.po
+++ b/applications/luci-app-olsr/po/ro/olsr.po
@@ -24,23 +24,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Setări avansate"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -67,8 +67,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -110,31 +110,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Activare"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Activează această interfaţă"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Activat"
 
@@ -142,13 +142,13 @@ msgstr "Activat"
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -158,8 +158,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -168,17 +168,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Setări generale"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Setări generale"
 
@@ -196,8 +196,8 @@ msgid "Green"
 msgstr "Verde"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -206,17 +206,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -224,22 +224,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgstr "Ascunde IPv6"
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -284,18 +284,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "Adrese IP"
 
@@ -310,26 +310,26 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -340,52 +340,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -394,14 +394,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -410,10 +410,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Interfaţă"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -421,15 +421,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Interfeţe"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Interfeţe implicite"
 
@@ -437,24 +437,24 @@ msgstr "Interfeţe implicite"
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -468,30 +468,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "Algoritm LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "Nivel LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -505,28 +505,28 @@ msgstr ""
 msgid "Legend"
 msgstr "Legendă"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -536,18 +536,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -565,22 +565,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -588,8 +588,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -604,17 +604,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -631,8 +631,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -658,22 +658,22 @@ msgstr "Vecini"
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -697,21 +697,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -768,35 +768,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Pluginuri"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -858,8 +858,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "Raport zgomot semnal în dB"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -875,15 +875,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -907,34 +907,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -943,27 +943,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -971,10 +971,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -982,8 +982,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -998,13 +998,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1029,24 +1029,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Greutate"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1071,8 +1071,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ru/olsr.po
+++ b/applications/luci-app-olsr/po/ru/olsr.po
@@ -28,23 +28,23 @@ msgstr "Активные OLSR узлы"
 msgid "Active host net announcements"
 msgstr "Активные объявления хост-сети (HNA)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "Разрешить шлюзы с NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "Разрешить выбор исходящего IPv4 шлюза с NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Объявить внешнее соединение"
 
@@ -73,8 +73,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr "Широковещательный адрес"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr "Допускается только IPv4 или IPv6 адрес или 'по умолчанию'"
 
@@ -118,19 +118,19 @@ msgstr "Загрузить config файл"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Включить"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -138,13 +138,13 @@ msgstr ""
 "Включить SmartGW (смарт-шлюз).<br />Если выключено, все остальные параметры "
 "SmartGW игнорируются. По умолчанию 'нет'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Использовать этот интерфейс."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Включено"
 
@@ -152,13 +152,13 @@ msgstr "Включено"
 msgid "Expected retransmission count"
 msgstr "Ожидаемое количество повторных передач"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "Метрика FIB"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -175,8 +175,8 @@ msgstr ""
 "происходит только при изменении следующего перехода.<br />По умолчанию "
 "используется 'flat'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 "Механизм 'fisheye' для TC-ов (средство проверки). По умолчанию 'включено'."
@@ -186,17 +186,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Шлюз"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Основные настройки"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Основные настройки"
 
@@ -214,8 +214,8 @@ msgid "Green"
 msgstr "Зеленый"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -224,17 +224,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "Объявления HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "Интервал HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Время действия HNA"
 
@@ -242,22 +242,22 @@ msgstr "Время действия HNA"
 msgid "HNA6 Announcements"
 msgstr "Объявления HNA6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Приветствие"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Интервал приветствия"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Время действия приветствия"
 
@@ -275,8 +275,8 @@ msgstr "Скрыть IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -306,8 +306,8 @@ msgstr ""
 "Хосты в маршрутизируемой сети OLSR могут извещать о подключении к внешним "
 "сетям с помощью сообщений HNA6."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -317,10 +317,10 @@ msgstr ""
 "переходов). Гистерезис увеличивает надёжность канала, но вносит задержку в "
 "регистрацию соседних устройств. По умолчанию 'да'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP-Адреса"
 
@@ -337,13 +337,13 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "Широковещательный IPv4-адрес"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -353,13 +353,13 @@ msgstr ""
 "255.255.255.255. По умолчанию используется значение \"0.0.0.0\", которое "
 "запускает использование широковещательного IP-адреса интерфейса."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 источник"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -372,17 +372,17 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 мультивещание"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
@@ -390,25 +390,25 @@ msgstr ""
 "IPv6-адрес мультивещания. По умолчанию 'FF02::6D', MANET маршрутизатор "
 "локальной сети мультивещания."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 "IPv6 сеть должна быть указана в полной нотации, префикс должен быть в "
 "нотации CIDR."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 источник"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -419,13 +419,13 @@ msgstr ""
 "'0::/0', которое запускает использование IP интерфейса не локального "
 "соединения."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "IPv6 Префикс внешнего соединения"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -439,15 +439,15 @@ msgstr ""
 "изменении должно быть ближе к '1.0'.<br /><b>Внимание:</b> Не используйте "
 "данный параметр вместе с метрикой etx_ffeth!<br />По умолчанию '1.0'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 "Использует ли данный узел NAT для подключения к Интернету. По умолчанию 'да'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -456,10 +456,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Интерфейс"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -470,15 +470,15 @@ msgstr ""
 "'ether'. По умолчанию 'mesh'."
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Интерфейсы"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Значения по умолчанию для интерфейсов"
 
@@ -486,8 +486,8 @@ msgstr "Значения по умолчанию для интерфейсов"
 msgid "Internet protocol"
 msgstr "Интернет протокол"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
@@ -495,18 +495,18 @@ msgstr ""
 "Интервал опроса сетевых интерфейсов на наличие изменений в config файле "
 "(сек.). По умолчанию '2.5'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 "Недопустимое значение для LQMult-Value. Должно быть между '0,01' и '1,0'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -522,30 +522,30 @@ msgstr "Известные маршруты OLSR"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ старение"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ алгоритм"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ fisheye"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ частота"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -561,20 +561,20 @@ msgstr "Последний переход"
 msgid "Legend"
 msgstr "События"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Библиотека"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Настройки качества соединений (LQ)"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -584,8 +584,8 @@ msgstr ""
 "подстройки для etx_float и etx_fpm.<br />Чем меньше значение, тем меньше "
 "изменения значения ETX.<br />Диапазон допустимых значений от '0.0' до '1.0'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -601,8 +601,8 @@ msgstr ""
 "b>: несовместимый вариант etx_ff, разрешающий Ethernet-соединения с ETX 0.1."
 "<br />По умолчанию 'etx_ff'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
@@ -612,10 +612,10 @@ msgstr ""
 "><b>0</b> = не использовать LQ<br /><b>2</b> = использовать LQ для выбора "
 "MPR и маршрутизации<br />По умолчанию '2'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "Мультипликатор качества соединения (LQ)"
 
@@ -633,22 +633,22 @@ msgid "Local interface IP"
 msgstr "IP-адрес локального интерфейса"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "Интервал MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "Время действия MID"
 
@@ -656,8 +656,8 @@ msgstr "Время действия MID"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "Основной IP-адрес"
 
@@ -674,17 +674,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Метрика"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Режим"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -710,8 +710,8 @@ msgstr ""
 "fd91:662e:3c58::1 '0.5'.<br />уменьшить LQ для всех узлов на данном "
 "интерфейсе на 20%: default '0.8'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "Порог NAT"
 
@@ -737,22 +737,22 @@ msgstr "Соседние узлы"
 msgid "Netmask"
 msgstr "Маска сети"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Сеть"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Сетевой адрес"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Сетевой адаптер изменяет интервал опроса"
 
@@ -776,21 +776,21 @@ msgstr "OLSR - HNA-объявления"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - HNA6-объявления"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - Плагины"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR демон"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR демон - Интерфейс"
 
@@ -847,35 +847,35 @@ msgstr "Обзор известных объявлений с нескольки
 msgid "Overview of smart gateways in this network"
 msgstr "Обзор смарт шлюзов в этой сети"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Настройка плагинов"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Плагины"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr "Частота опроса для сокетов OLSR в секундах. По умолчанию '0,05'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Частота опроса"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -948,8 +948,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "Коэффициент шума сигнала в дБ"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -965,8 +965,8 @@ msgstr "SmartGW (смарт-шлюз) не настроен на этой сис
 msgid "Source address"
 msgstr "Адрес источника"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -975,8 +975,8 @@ msgstr ""
 "внешняя сеть, второй параметр - внутренняя сеть. Значение по умолчанию '128 "
 "1024'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "Скорость внешнего соединения"
 
@@ -1001,34 +1001,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr "Показатель успешности прохождения пакетов, отправляемых соседнему узлу"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "Интервал TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "Время действия TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "Значение TOS"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -1042,8 +1042,8 @@ msgstr ""
 "Ethernet с поддержкой режима ad-hoc.<br />Более подробную информацию можно "
 "найти на <a href='http://www.olsr.org'>olsrd.org</a>."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1052,13 +1052,13 @@ msgstr ""
 "рассчитываться динамически на основе состояния батареи/питания. По умолчанию "
 "'3'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "Интерфейс, обслуживаемый OLSRd."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1066,8 +1066,8 @@ msgstr ""
 "Порт, используемый для OLSR. Рекомендуется использовать присвоенный IANA "
 "порт 698.<br />Допустимо любое значение в диапазоне от 1 до 65535."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1079,10 +1079,10 @@ msgstr ""
 "для использования IPv6-шлюза без какой-либо трансляции адресов. Максимальная "
 "длина префикса - 64 бита. По умолчанию '::/0' (без префикса)."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "Время и срок действия"
 
@@ -1090,8 +1090,8 @@ msgstr "Время и срок действия"
 msgid "Topology"
 msgstr "Топология"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1108,13 +1108,13 @@ msgstr "Не удалось подключиться к демону OLSR!"
 msgid "Uplink"
 msgstr "Внешнее соединение"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "Внешнее соединение использует NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Использовать гистерезис"
 
@@ -1139,8 +1139,8 @@ msgstr "Очень хорошо (SNR > 30)"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1148,17 +1148,17 @@ msgstr ""
 "<b>Внимание:</b> 'kmod-ipip' не установлен. Без пакета модуля ядра kmod-"
 "ipip, SmartGW (смарт-шлюз) не будет работать, установите его."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Вес"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1196,8 +1196,8 @@ msgstr ""
 "Определение внешнего соединения происходит при наличии в локальном HNA6 ::"
 "ffff:0:0/96 или 2000::/3. Значение по умолчанию 'оба'."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Готовность"
 

--- a/applications/luci-app-olsr/po/sk/olsr.po
+++ b/applications/luci-app-olsr/po/sk/olsr.po
@@ -20,23 +20,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -63,8 +63,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -106,31 +106,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -138,13 +138,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -154,8 +154,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -164,17 +164,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -192,8 +192,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -202,17 +202,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -220,22 +220,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -253,8 +253,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -280,18 +280,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -306,26 +306,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -336,52 +336,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -390,14 +390,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -406,10 +406,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -417,15 +417,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -433,24 +433,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -464,30 +464,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -501,28 +501,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -532,18 +532,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -561,22 +561,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -584,8 +584,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -600,17 +600,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -627,8 +627,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -654,22 +654,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -693,21 +693,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -764,35 +764,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -854,8 +854,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -871,15 +871,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -903,34 +903,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -939,27 +939,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -967,10 +967,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -978,8 +978,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -994,13 +994,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1025,24 +1025,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1067,8 +1067,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/sv/olsr.po
+++ b/applications/luci-app-olsr/po/sv/olsr.po
@@ -24,23 +24,23 @@ msgstr "Aktiva OLSR-noder"
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "Tillkännage upplänk"
 
@@ -67,8 +67,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr "Sändningsadress"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr "Kan endast vara en giltig IPv4 eller IPv6-adress eller 'standard'"
 
@@ -112,31 +112,31 @@ msgstr ""
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Aktivera"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "Aktivera det här gränssnittet."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Aktiverad"
 
@@ -144,13 +144,13 @@ msgstr "Aktiverad"
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -160,8 +160,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -170,17 +170,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Gateway"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Generella inställningar"
 
@@ -198,8 +198,8 @@ msgid "Green"
 msgstr "Grön"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -208,17 +208,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Giltighetstid för HNA"
 
@@ -226,22 +226,22 @@ msgstr "Giltighetstid för HNA"
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Hallå"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Hallå-intervall"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Giltighetstid för Hallå"
 
@@ -259,8 +259,8 @@ msgstr "Göm IPv6"
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -286,18 +286,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP-adresser"
 
@@ -312,26 +312,26 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4-källa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -342,52 +342,52 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6-källa"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -396,14 +396,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -412,10 +412,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -423,15 +423,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Gränssnitt"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "Standard-gränssnitten"
 
@@ -439,24 +439,24 @@ msgstr "Standard-gränssnitten"
 msgid "Internet protocol"
 msgstr "Internet-protokoll"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -470,30 +470,30 @@ msgstr "Kända OLSR-rutter"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ-algoritm"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ-nivå"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -507,28 +507,28 @@ msgstr "Senaste hopp"
 msgid "Legend"
 msgstr "Legend"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Bibliotek"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "Inställningar för länkkvalité"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -538,18 +538,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -567,22 +567,22 @@ msgid "Local interface IP"
 msgstr "IP-adress för lokalt gränssnitt"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID-intervall"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -590,8 +590,8 @@ msgstr ""
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "Huvudsaklig IP-adress"
 
@@ -606,17 +606,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Metrisk"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Läge"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -633,8 +633,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -660,22 +660,22 @@ msgstr "Grannar"
 msgid "Netmask"
 msgstr "Nätmask"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Nätverk"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "Nätverksadress"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -699,21 +699,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - Insticksprogram"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR-demon"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR-demon - Gränssnitt"
 
@@ -770,35 +770,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Konfiguration av insticksprogram"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "Insticksprogram"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -860,8 +860,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -877,15 +877,15 @@ msgstr ""
 msgid "Source address"
 msgstr "Adress för källkod"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -909,34 +909,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC-intervall"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "Giltighetstid för TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS-värde"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -945,27 +945,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -973,10 +973,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -984,8 +984,8 @@ msgstr ""
 msgid "Topology"
 msgstr "Topologi"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1000,13 +1000,13 @@ msgstr "Kunde inte ansluta till OLSR-demonen!"
 msgid "Uplink"
 msgstr "Upplänk"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "Upplänken använder NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1031,8 +1031,8 @@ msgstr "Jättebra (SNR > 30)"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1040,17 +1040,17 @@ msgstr ""
 "Varning: kmod-ipip är inte installerat. SmartGateway kommer inte att "
 "fungerautan kmod-ipip, vänligen installera det."
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "Vikt"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1075,8 +1075,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Frivillighet"
 

--- a/applications/luci-app-olsr/po/templates/olsr.pot
+++ b/applications/luci-app-olsr/po/templates/olsr.pot
@@ -13,23 +13,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -56,8 +56,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -99,31 +99,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -131,13 +131,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -147,8 +147,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -157,17 +157,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -185,8 +185,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -195,17 +195,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -213,22 +213,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -246,8 +246,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -273,18 +273,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -299,26 +299,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -329,52 +329,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -383,14 +383,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -399,10 +399,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -410,15 +410,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -426,24 +426,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -457,30 +457,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -494,28 +494,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -525,18 +525,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -554,22 +554,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -577,8 +577,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -593,17 +593,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -620,8 +620,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -647,22 +647,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -686,21 +686,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -757,35 +757,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -847,8 +847,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -864,15 +864,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -896,34 +896,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -932,27 +932,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -960,10 +960,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -971,8 +971,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -987,13 +987,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1018,24 +1018,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1060,8 +1060,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/tr/olsr.po
+++ b/applications/luci-app-olsr/po/tr/olsr.po
@@ -20,23 +20,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -63,8 +63,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -106,31 +106,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -138,13 +138,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -154,8 +154,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -164,17 +164,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -192,8 +192,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -202,17 +202,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -220,22 +220,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -253,8 +253,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -280,18 +280,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -306,26 +306,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -336,52 +336,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -390,14 +390,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -406,10 +406,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -417,15 +417,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -433,24 +433,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -464,30 +464,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -501,28 +501,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -532,18 +532,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -561,22 +561,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -584,8 +584,8 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -600,17 +600,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -627,8 +627,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -654,22 +654,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -693,21 +693,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -764,35 +764,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -854,8 +854,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -871,15 +871,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -903,34 +903,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -939,27 +939,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -967,10 +967,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -978,8 +978,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -994,13 +994,13 @@ msgstr ""
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1025,24 +1025,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1067,8 +1067,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/uk/olsr.po
+++ b/applications/luci-app-olsr/po/uk/olsr.po
@@ -25,23 +25,23 @@ msgstr ""
 msgid "Active host net announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "Додаткові параметри"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -68,8 +68,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -111,31 +111,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Увімкнути"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "Увімкнено"
 
@@ -143,13 +143,13 @@ msgstr "Увімкнено"
 msgid "Expected retransmission count"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -159,8 +159,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -169,17 +169,17 @@ msgstr ""
 msgid "Gateway"
 msgstr "Шлюз"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "Загальні параметри"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr ""
 
@@ -197,8 +197,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -207,17 +207,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr ""
 
@@ -225,22 +225,22 @@ msgstr ""
 msgid "HNA6 Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr ""
 
@@ -258,8 +258,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -285,18 +285,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP-адреси"
 
@@ -311,26 +311,26 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "Широкомовний IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -341,52 +341,52 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -395,14 +395,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -411,10 +411,10 @@ msgstr ""
 msgid "Interface"
 msgstr "Інтерфейс"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -422,15 +422,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Інтерфейси"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -438,24 +438,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -469,30 +469,30 @@ msgstr ""
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -506,28 +506,28 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -537,18 +537,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -566,22 +566,22 @@ msgid "Local interface IP"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr ""
 
@@ -589,8 +589,8 @@ msgstr ""
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -605,17 +605,17 @@ msgstr ""
 msgid "Metric"
 msgstr "Метрика"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "Режим"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -632,8 +632,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -659,22 +659,22 @@ msgstr ""
 msgid "Netmask"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "Мережа"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -698,21 +698,21 @@ msgstr ""
 msgid "OLSR - HNA6-Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -769,35 +769,35 @@ msgstr ""
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -859,8 +859,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -876,15 +876,15 @@ msgstr ""
 msgid "Source address"
 msgstr "Адреса джерела"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -908,34 +908,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -944,27 +944,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -972,10 +972,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -983,8 +983,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -999,13 +999,13 @@ msgstr ""
 msgid "Uplink"
 msgstr "Висхідне з'єднання"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr ""
 
@@ -1030,24 +1030,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1072,8 +1072,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr ""
 

--- a/applications/luci-app-olsr/po/vi/olsr.po
+++ b/applications/luci-app-olsr/po/vi/olsr.po
@@ -28,23 +28,23 @@ msgstr "Những OLSR nodes đang hoạt động"
 msgid "Active host net announcements"
 msgstr "Thông báo của mạng host đang hoạt động"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr ""
 
@@ -71,8 +71,8 @@ msgstr ""
 msgid "Broadcast address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr ""
 
@@ -114,31 +114,31 @@ msgstr ""
 msgid "ETX"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "Kích hoạt"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr ""
 
@@ -146,13 +146,13 @@ msgstr ""
 msgid "Expected retransmission count"
 msgstr "Expected retransmission count"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "FIB metric"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -162,8 +162,8 @@ msgid ""
 "Default is \"flat\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr ""
 
@@ -172,17 +172,17 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "Cài đặt tổng quát"
 
@@ -200,8 +200,8 @@ msgid "Green"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr ""
@@ -210,17 +210,17 @@ msgstr ""
 msgid "HNA Announcements"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "Khoảng HNA"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "Thời gian hợp lệ hóa HNA "
 
@@ -229,22 +229,22 @@ msgstr "Thời gian hợp lệ hóa HNA "
 msgid "HNA6 Announcements"
 msgstr "OLSR - HNA - Thông báo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Vùng xin chào"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Thời gian hợp lệ hóa lời chào"
 
@@ -262,8 +262,8 @@ msgstr ""
 msgid "Hna4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr ""
 
@@ -289,18 +289,18 @@ msgid ""
 "networks using HNA6 messages."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
 "\"yes\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr ""
 
@@ -315,26 +315,26 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 broadcast"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
 "interface broadcast IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -345,52 +345,52 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
 "of a not-linklocal interface IP."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -399,14 +399,14 @@ msgid ""
 "with the etx_ffeth metric!<br />Defaults to \"1.0\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -415,10 +415,10 @@ msgstr ""
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -426,15 +426,15 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "Giao diện"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr ""
 
@@ -442,24 +442,24 @@ msgstr ""
 msgid "Internet protocol"
 msgstr "Internet protocol"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -473,30 +473,30 @@ msgstr "Tuyến OLRS đã biết"
 msgid "LQ"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ aging"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ algorithm"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ fisheye"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ level"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -510,28 +510,28 @@ msgstr "Hop cuối "
 msgid "Legend"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "Thư viện "
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
 "(allowed values are between 0.01 and 1.0)"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -541,18 +541,18 @@ msgid ""
 "allows ethernet links with ETX 0.1.<br />Defaults to \"etx_ff\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
 "quality for MPR selection and routing<br />Default is \"2\""
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr ""
 
@@ -570,22 +570,22 @@ msgid "Local interface IP"
 msgstr "Giao diện địa phương IP"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "Khoảng MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "Thời gian hợp lệ hóa MID"
 
@@ -593,8 +593,8 @@ msgstr "Thời gian hợp lệ hóa MID"
 msgid "MTU"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr ""
 
@@ -609,17 +609,17 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -636,8 +636,8 @@ msgid ""
 "LQ to all nodes on this interface by 20%: default 0.8"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr ""
 
@@ -663,22 +663,22 @@ msgstr ""
 msgid "Netmask"
 msgstr "Netmask"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr ""
 
@@ -703,21 +703,21 @@ msgstr "OLSR - HNA - Thông báo"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - HNA - Thông báo"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - Plugins"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR Daemon"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr ""
 
@@ -774,35 +774,35 @@ msgstr "Tổng quát về thông báo của nhiều giao diện đã biết"
 msgid "Overview of smart gateways in this network"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "Cấu hình Plugin"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "Pollrate"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -864,8 +864,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr ""
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr ""
 
@@ -881,15 +881,15 @@ msgstr ""
 msgid "Source address"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr ""
 
@@ -913,34 +913,34 @@ msgstr ""
 msgid "Success rate of packages sent to the neighbour"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "Khoảng TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "Thời gian hợp lệ hóa TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -949,27 +949,27 @@ msgid ""
 "documentation."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -977,10 +977,10 @@ msgid ""
 "length is 64 bits. Default is \"::/0\" (no prefix)."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr ""
 
@@ -988,8 +988,8 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1004,13 +1004,13 @@ msgstr "Không thể kết nối với OLSR daemon!"
 msgid "Uplink"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "Dùng hysteresis"
 
@@ -1035,24 +1035,24 @@ msgstr ""
 msgid "WLAN"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1077,8 +1077,8 @@ msgid ""
 "setting is \"both\"."
 msgstr ""
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "Sẵn sàng"
 

--- a/applications/luci-app-olsr/po/zh-cn/olsr.po
+++ b/applications/luci-app-olsr/po/zh-cn/olsr.po
@@ -27,23 +27,23 @@ msgstr "活动的 OLSR 节点"
 msgid "Active host net announcements"
 msgstr "活动的主机网络通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "允许带 NAT 的网关"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "允许选择有 NAT 的 IPv4 网关"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "通告上行链接"
 
@@ -70,8 +70,8 @@ msgstr "两个值必须使用点分十进制表示法。"
 msgid "Broadcast address"
 msgstr "广播地址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr "必须是有效的 IPv4 或 IPv6 地址，或“默认”"
 
@@ -114,19 +114,19 @@ msgstr "下载配置"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "启用"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -134,13 +134,13 @@ msgstr ""
 "启用 SmartGateway。如果禁用，则将忽略 SmartGateway 的其他所有参数。缺省"
 "值：“no”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "启用这个接口"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "已启用"
 
@@ -148,13 +148,13 @@ msgstr "已启用"
 msgid "Expected retransmission count"
 msgstr "预期重发数"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "FIB 度量"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -168,8 +168,8 @@ msgstr ""
 "值。“approx”也使用 hopcount 作为度量值，但只有在下一次更改时才更新 hopcount。"
 "默认为“flat”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr "TC 的鱼眼机制（校验和开启）。默认为“开启”"
 
@@ -178,17 +178,17 @@ msgstr "TC 的鱼眼机制（校验和开启）。默认为“开启”"
 msgid "Gateway"
 msgstr "网关"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "基本设置"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "一般设置"
 
@@ -206,8 +206,8 @@ msgid "Green"
 msgstr "绿"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -216,17 +216,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "HNA 通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "HNA 间隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "HNA 有效时长"
 
@@ -234,22 +234,22 @@ msgstr "HNA 有效时长"
 msgid "HNA6 Announcements"
 msgstr "HNA 通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Hello"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Hello 间隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Hello 有效时长"
 
@@ -267,8 +267,8 @@ msgstr "隐藏 IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -294,8 +294,8 @@ msgid ""
 "networks using HNA6 messages."
 msgstr "OLSR 路由网络中的主机可以使用 HNA6 消息通告与外部网络的连接。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -304,10 +304,10 @@ msgstr ""
 "滞后链路检测（仅适用于 hopcount 度量）。滞后增加了链路感测的健壮性，但延迟了"
 "邻居注册过程。默认值为“是”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP 地址"
 
@@ -322,13 +322,13 @@ msgstr "要使用的 IP 版本。如果选择 6and4，则为每个协议启动�
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 广播地址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -337,13 +337,13 @@ msgstr ""
 "传出 OLSR 数据包的 IPv4 广播地址。一个有用的例子是 255.255.255.255。默认"
 "为“0.0.0.0”，将触发使用接口的 IP 广播地址。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 源地址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -354,39 +354,39 @@ msgstr "传出 OLSR 包的 IPv4 源地址。默认为“0.0.0.0”，将触发�
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 组播地址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr "IPv6 组播地址。默认为“FF02::6D”，即 manet-router 链路本地组播地址。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr "IPv6 网络必须完整表出，前缀必须是 CIDR 表示法。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 源地址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -395,13 +395,13 @@ msgstr ""
 "IPv6 源前缀。OLSRd 将选择一个与此参数前缀匹配的接口 IP。默认为“0::/0”，触发使"
 "用接口的非链路本地 IP。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "IPv6 上行链路前缀"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -413,14 +413,14 @@ msgstr ""
 "乘以该值。参数可以是介于 0.1 和 1.0 之间的值，但如果更改则应接近 1.0。<br /"
 "><b>警告：</b>此参数不应与 etx_ffeth 指标一起使用！<br />默认值到“1.0”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr "如果此节点使用 NAT 连接到互联网。默认为“是”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -429,10 +429,10 @@ msgstr "如果此节点使用 NAT 连接到互联网。默认为“是”。"
 msgid "Interface"
 msgstr "接口"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -442,15 +442,15 @@ msgstr ""
 "是“mesh”和“ether”。默认为“mesh”。"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "接口"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "接口默认值"
 
@@ -458,24 +458,24 @@ msgstr "接口默认值"
 msgid "Internet protocol"
 msgstr "互联网协议"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr "轮询网络接口以进行配置更改的间隔（秒）。默认值为“2.5”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr "LQMult-Value 的值无效。必须介于 0.01 和 1.0 之间。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -490,30 +490,30 @@ msgstr "已知的 OLSR 路由"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ 老化"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ 算法"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ 鱼眼"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ 级别"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -527,20 +527,20 @@ msgstr "最后一跳"
 msgid "Legend"
 msgstr "Legend"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "库"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "链接质量设置"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -549,8 +549,8 @@ msgstr ""
 "链路质量老化因子（仅适用于 lq 级别 2）。调整 etx_float 和 etx_fpm 的参数，值"
 "越小意味着 ETX 值的变化越慢。（允许值介于 0.01 和 1.0 之间）"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -565,8 +565,8 @@ msgstr ""
 "ETX 计算的 etx 变体<br /><b>etx_ffeth</b>：不兼容的变体 etx_ff，允许以太网链"
 "接使用 ETX 0.1。<br />默认为“etx_ff”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
@@ -576,10 +576,10 @@ msgstr ""
 "= 不使用链接质量<br /><b>2</b> = 使用链接质量进行 MPR 选择和路由<br />默认"
 "为“2”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "LinkQuality 乘数"
 
@@ -597,22 +597,22 @@ msgid "Local interface IP"
 msgstr "本地接口 IP"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID 间隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "MID 有效期"
 
@@ -620,8 +620,8 @@ msgstr "MID 有效期"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "主要 IP"
 
@@ -638,17 +638,17 @@ msgstr ""
 msgid "Metric"
 msgstr "度量"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "模式"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -671,8 +671,8 @@ msgstr ""
 "大于 0 时使用。示例：<br />将到 fd91:662e:3c58::1 的 LQ 减半："
 "fd91:662e:3c58::1 0.5<br />将此接口到所有节点的 LQ 减少 20%：默认 0.8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "NAT 阈值"
 
@@ -698,22 +698,22 @@ msgstr "邻居"
 msgid "Netmask"
 msgstr "子网掩码"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "网络"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "网络地址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Nic 更改轮询间隔"
 
@@ -737,21 +737,21 @@ msgstr "OLSR - HNA-通告"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - HNA6-通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - 插件"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR 守护进程"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR 守护进程 - 接口"
 
@@ -808,35 +808,35 @@ msgstr "已知的多接口通告概览"
 msgid "Overview of smart gateways in this network"
 msgstr "此网络中的智能网关概览"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "插件配置"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "插件"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr "OLSR 套接字的轮询速率，以秒为单位。默认值为 0.05。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "轮询速率"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "端口"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -904,8 +904,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "信噪比（dB）"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -921,8 +921,8 @@ msgstr "此系统上未配置 SmartGateway。"
 msgid "Source address"
 msgstr "源地址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -930,8 +930,8 @@ msgstr ""
 "以千比特/秒为单位指定上行链路的速度。第一个参数是上传，第二个参数是下载。默认"
 "值为“128 1024”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "上行链路的速度"
 
@@ -955,34 +955,34 @@ msgstr "从邻居收包的成功率"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "向邻居发包的成功率"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC 间隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "TC 有效时间"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS 值"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -995,8 +995,8 @@ msgstr ""
 "卡上运行，当然也可以在任何以太网设备上运行。访问 <a href='http://www.olsr."
 "org'>olsrd.org</a> 获取帮助和文档。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1004,13 +1004,13 @@ msgstr ""
 "固定的使用意愿值。如果未设置，则将根据电池/电源状态动态计算意愿值。默认值"
 "为“3”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "OLSRd 应该服务的接口。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
@@ -1018,8 +1018,8 @@ msgstr ""
 "OLSR 使用的端口。通常应使用 IANA 分配的保留端口 698。它的值可以在 1 到 65535 "
 "之间。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1030,10 +1030,10 @@ msgstr ""
 "IPv6 地址，以使用 IPv6 网关，而无需任何类型的地址转换。前缀长度最大为 64 位。"
 "默认为“::/0”（无前缀）。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "时间和有效性"
 
@@ -1041,8 +1041,8 @@ msgstr "时间和有效性"
 msgid "Topology"
 msgstr "拓扑"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1057,13 +1057,13 @@ msgstr "无法连接到 OLSR 守护程序！"
 msgid "Uplink"
 msgstr "上行链接"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "上行链接使用 NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "使用滞后"
 
@@ -1088,8 +1088,8 @@ msgstr "非常好（SNR > 30）"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1097,17 +1097,17 @@ msgstr ""
 "警告：未安装 kmod-ipip。没有 kmod-ipip，SmartGateway 将无法正常工作，请安装"
 "它。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "权重"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1140,8 +1140,8 @@ msgstr ""
 "将导出哪种上行链路到其他网状节点。通过查找本地 HNA6 ::ffff:0:0/96 或 "
 "2000::/3 来检测上行链路。默认设置为“两者”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "意愿值"
 

--- a/applications/luci-app-olsr/po/zh-tw/olsr.po
+++ b/applications/luci-app-olsr/po/zh-tw/olsr.po
@@ -26,23 +26,23 @@ msgstr "活動的 OLSR 節點"
 msgid "Active host net announcements"
 msgstr "活動的主機網路通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:45
 msgid "Advanced Settings"
 msgstr "進階設定"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow gateways with NAT"
 msgstr "允許帶 NAT 的閘道器"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:141
 msgid "Allow the selection of an outgoing ipv4 gateway with NAT"
 msgstr "允許選擇有 NAT 的 IPv4 閘道器"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:155
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:149
 msgid "Announce uplink"
 msgstr "通告上行連結"
 
@@ -69,8 +69,8 @@ msgstr "兩個值必須使用點分十進位制表示法。"
 msgid "Broadcast address"
 msgstr "廣播位址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:90
 msgid "Can only be a valid IPv4 or IPv6 address or 'default'"
 msgstr "必須是有效的 IPv4 或 IPv6 位址，或“預設”"
 
@@ -113,19 +113,19 @@ msgstr "下載配置"
 msgid "ETX"
 msgstr "ETX"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:365
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:346
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:35
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:35
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:15
 msgid "Enable"
 msgstr "啟用"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:140
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:134
 msgid ""
 "Enable SmartGateway. If it is disabled, then all other SmartGateway "
 "parameters are ignored. Default is \"no\"."
@@ -133,13 +133,13 @@ msgstr ""
 "啟用 SmartGateway。如果禁用，則將忽略 SmartGateway 的其他所有引數。預設"
 "值：“no”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:36
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:36
 msgid "Enable this interface."
 msgstr "啟用這個埠"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:249
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:249
 msgid "Enabled"
 msgstr "已啟用"
 
@@ -147,13 +147,13 @@ msgstr "已啟用"
 msgid "Expected retransmission count"
 msgstr "預期重發數"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:71
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:65
 msgid "FIB metric"
 msgstr "FIB 度量"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:72
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:66
 msgid ""
 "FIBMetric controls the metric value of the host-routes OLSRd sets. \"flat\" "
 "means that the metric value is always 2. This is the preferred value because "
@@ -167,8 +167,8 @@ msgstr ""
 "值。“approx”也使用 hopcount 作為度量值，但只有在下一次更改時才更新 hopcount。"
 "預設為“flat”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:112
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:106
 msgid "Fisheye mechanism for TCs (checked means on). Default is \"on\""
 msgstr "TC 的魚眼機制（校驗和開啟）。預設為“開啟”"
 
@@ -177,17 +177,17 @@ msgstr "TC 的魚眼機制（校驗和開啟）。預設為“開啟”"
 msgid "Gateway"
 msgstr "閘道器"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:42
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:222
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:42
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:31
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:31
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:39
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:39
 msgid "General settings"
 msgstr "一般設定"
 
@@ -205,8 +205,8 @@ msgid "Green"
 msgstr "綠"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:53
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:402
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:383
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:178
 msgid "HNA"
 msgstr "HNA"
@@ -215,17 +215,17 @@ msgstr "HNA"
 msgid "HNA Announcements"
 msgstr "HNA 通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:341
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:322
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:165
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:152
 msgid "HNA interval"
 msgstr "HNA 間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:347
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:328
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:171
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:158
 msgid "HNA validity time"
 msgstr "HNA 有效時長"
 
@@ -233,22 +233,22 @@ msgstr "HNA 有效時長"
 msgid "HNA6 Announcements"
 msgstr "HNA 通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:381
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:362
 msgid "Hello"
 msgstr "Hello"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:305
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:129
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:116
 msgid "Hello interval"
 msgstr "Hello 間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:311
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:135
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:122
 msgid "Hello validity time"
 msgstr "Hello 有效時長"
 
@@ -266,8 +266,8 @@ msgstr "隱藏 IPv6"
 msgid "Hna4"
 msgstr "Hna4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid "Hna6"
 msgstr "Hna6"
 
@@ -293,8 +293,8 @@ msgid ""
 "networks using HNA6 messages."
 msgstr "OLSR 路由網路中的主機可以使用 HNA6 訊息通告與外部網路的連線。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:117
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:111
 msgid ""
 "Hysteresis for link sensing (only for hopcount metric). Hysteresis adds more "
 "robustness to the link sensing but delays neighbor registration. Defaults is "
@@ -303,10 +303,10 @@ msgstr ""
 "滯後鏈路檢測（僅適用於 hopcount 度量）。滯後增加了鏈路感測的健壯性，但延遲了"
 "鄰居註冊過程。預設值為“是”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:223
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:217
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:32
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:32
 msgid "IP Addresses"
 msgstr "IP 位址"
 
@@ -321,13 +321,13 @@ msgstr "要使用的 IP 版本。如果選擇 6and4，則為每個協議啟動�
 msgid "IPv4"
 msgstr "IPv4"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:103
 msgid "IPv4 broadcast"
 msgstr "IPv4 廣播位址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:104
 msgid ""
 "IPv4 broadcast address for outgoing OLSR packets. One useful example would "
 "be 255.255.255.255. Default is \"0.0.0.0\", which triggers the usage of the "
@@ -336,13 +336,13 @@ msgstr ""
 "傳出 OLSR 資料包的 IPv4 廣播位址。一個有用的例子是 255.255.255.255。預設"
 "為“0.0.0.0”，將觸發使用介面的 IP 廣播位址。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:291
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:116
 msgid "IPv4 source"
 msgstr "IPv4 源位址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:292
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:117
 msgid ""
 "IPv4 src address for outgoing OLSR packages. Default is \"0.0.0.0\", which "
 "triggers usage of the interface IP."
@@ -353,39 +353,39 @@ msgstr "傳出 OLSR 包的 IPv4 源位址。預設為“0.0.0.0”，將觸發�
 msgid "IPv6"
 msgstr "IPv6"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:285
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:272
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:110
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:103
 msgid "IPv6 multicast"
 msgstr "IPv6 組播位址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:286
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:273
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:104
 msgid ""
 "IPv6 multicast address. Default is \"FF02::6D\", the manet-router linklocal "
 "multicast."
 msgstr "IPv6 組播位址。預設為“FF02::6D”，即 manet-router 鏈路本地組播位址。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:28
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:10
 msgid ""
 "IPv6 network must be given in full notation, prefix must be in CIDR notation."
 msgstr "IPv6 網路必須完整表出，字首必須是 CIDR 表示法。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:297
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:278
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:122
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:109
 msgid "IPv6 source"
 msgstr "IPv6 源位址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:279
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:123
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:110
 msgid ""
 "IPv6 src prefix. OLSRd will choose one of the interface IPs which matches "
 "the prefix of this parameter. Default is \"0::/0\", which triggers the usage "
@@ -394,13 +394,13 @@ msgstr ""
 "IPv6 源字首。OLSRd 將選擇一個與此引數字首匹配的介面 IP。預設為“0::/0”，觸發使"
 "用介面的非鏈路本地 IP。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid "IPv6-Prefix of the uplink"
 msgstr "IPv6 上行鏈路字首"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:202
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:196
 msgid ""
 "If the route to the current gateway is to be changed, the ETX value of this "
 "gateway is multiplied with this value before it is compared to the new one. "
@@ -412,14 +412,14 @@ msgstr ""
 "器的ETX值乘以該值。引數可以是介於0.1和1.0之間的值，但如果更改則應接近1.0。"
 "<br /><b>警告：</b>此引數不應與etx_ffeth指標一起使用！<br />預設值到“1.0”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid ""
 "If this Node uses NAT for connections to the internet. Default is \"yes\"."
 msgstr "如果此節點使用 NAT 連線到網際網路。預設為“是”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:27
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:27
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:23
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:62
 #: applications/luci-app-olsr/luasrc/view/status-olsr/neighbors.htm:128
@@ -428,10 +428,10 @@ msgstr "如果此節點使用 NAT 連線到網際網路。預設為“是”。"
 msgid "Interface"
 msgstr "介面"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:227
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:221
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
 "Interface Mode is used to prevent unnecessary packet forwarding on switched "
 "ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
@@ -441,15 +441,15 @@ msgstr ""
 "是“mesh”和“ether”。預設為“mesh”。"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:335
 #: applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm:14
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:163
 msgid "Interfaces"
 msgstr "介面"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:212
 msgid "Interfaces Defaults"
 msgstr "介面預設值"
 
@@ -457,24 +457,24 @@ msgstr "介面預設值"
 msgid "Internet protocol"
 msgstr "網際網路協議"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:54
 msgid ""
 "Interval to poll network interfaces for configuration changes (in seconds). "
 "Default is \"2.5\"."
 msgstr "輪詢網路介面以進行配置更改的間隔（秒）。預設值為“2.5”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:268
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:93
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:93
 msgid "Invalid Value for LQMult-Value. Must be between 0.01 and 1.0."
 msgstr "LQMult-Value 的值無效。必須介於0.01和1.0之間。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:271
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:265
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:96
 msgid ""
 "Invalid Value for LQMult-Value. You must use a decimal number between 0.01 "
 "and 1.0 here."
@@ -488,30 +488,30 @@ msgstr "已知的 OLSR 路由"
 msgid "LQ"
 msgstr "LQ"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:90
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:84
 msgid "LQ aging"
 msgstr "LQ 老化"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:96
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:90
 msgid "LQ algorithm"
 msgstr "LQ 演算法"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:111
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:105
 msgid "LQ fisheye"
 msgstr "LQ 魚眼"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:82
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:76
 msgid "LQ level"
 msgstr "LQ 級別"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:262
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:256
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:87
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:87
 msgid ""
 "LQMult requires two values (IP address or 'default' and multiplicator) "
 "separated by space."
@@ -525,20 +525,20 @@ msgstr "最後一跳"
 msgid "Legend"
 msgstr "Legend"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:23
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:257
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:23
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:257
 msgid "Library"
 msgstr "庫"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:43
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:43
 msgid "Link Quality Settings"
 msgstr "連結質量設定"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:91
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:85
 msgid ""
 "Link quality aging factor (only for lq level 2). Tuning parameter for "
 "etx_float and etx_fpm, smaller values mean slower changes of ETX value. "
@@ -547,8 +547,8 @@ msgstr ""
 "鏈路質量老化因子（僅適用於 lq 級別2）。調整 etx_float 和 etx_fpm 的引數，值越"
 "小意味著 ETX 值的變化越慢。（允許值介於0.01和1.0之間）"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:97
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:91
 msgid ""
 "Link quality algorithm (only for lq level 2).<br /><b>etx_float</b>: "
 "floating point ETX with exponential aging<br /><b>etx_fpm</b> : same as "
@@ -563,8 +563,8 @@ msgstr ""
 "ETX 計算的 etx 變體<br /><b>etx_ffeth</b>：不相容的變體 etx_ff，允許乙太網連"
 "結使用 ETX 0.1。<br />預設為“etx_ff”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:83
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:77
 msgid ""
 "Link quality level switch between hopcount and cost-based (mostly ETX) "
 "routing.<br /><b>0</b> = do not use link quality<br /><b>2</b> = use link "
@@ -574,10 +574,10 @@ msgstr ""
 "= 不使用連結質量<br /><b>2</b> = 使用連結質量進行 MPR 選擇和路由<br />預設"
 "為“2”"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:245
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:239
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:70
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:70
 msgid "LinkQuality Multiplicator"
 msgstr "LinkQuality 乘數"
 
@@ -595,22 +595,22 @@ msgid "Local interface IP"
 msgstr "本地介面 IP"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:58
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:395
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:376
 msgid "MID"
 msgstr "MID"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:329
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:310
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:153
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:140
 msgid "MID interval"
 msgstr "MID 間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:335
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:316
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:159
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:146
 msgid "MID validity time"
 msgstr "MID 有效期"
 
@@ -618,8 +618,8 @@ msgstr "MID 有效期"
 msgid "MTU"
 msgstr "MTU"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:132
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:126
 msgid "Main IP"
 msgstr "主要 IP"
 
@@ -636,17 +636,17 @@ msgstr ""
 msgid "Metric"
 msgstr "度量"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:226
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:376
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:220
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:357
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:51
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:51
 msgid "Mode"
 msgstr "模式"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:246
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:71
 msgid ""
 "Multiply routes with the factor given here. Allowed values are between 0.01 "
 "and 1.0. It is only used when LQ-Level is greater than 0. Examples:<br /"
@@ -669,8 +669,8 @@ msgstr ""
 "時使用。示例：<br />將到 fd91:662e:3c58::1 的 LQ 減半：fd91:662e:3c58::1 "
 "0.5<br />將此介面到所有節點的 LQ 減少20％：default 0.8"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:201
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:195
 msgid "NAT threshold"
 msgstr "NAT 閾值"
 
@@ -696,22 +696,22 @@ msgstr "鄰居"
 msgid "Netmask"
 msgstr "子網掩碼"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:373
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:354
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:44
 #: applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm:160
 msgid "Network"
 msgstr "網路"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:17
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:34
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:16
 msgid "Network address"
 msgstr "網路位址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:59
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:53
 msgid "Nic changes poll interval"
 msgstr "Nic 更改輪詢間隔"
 
@@ -735,21 +735,21 @@ msgstr "OLSR - HNA-通告"
 msgid "OLSR - HNA6-Announcements"
 msgstr "OLSR - HNA6-通告"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:9
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:216
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:9
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:216
 msgid "OLSR - Plugins"
 msgstr "OLSR - 外掛"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:12
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:12
 #: applications/luci-app-olsr/luasrc/view/status-olsr/error_olsr.htm:8
 msgid "OLSR Daemon"
 msgstr "OLSR 守護程序"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:14
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:14
 msgid "OLSR Daemon - Interface"
 msgstr "OLSR 守護程序 - 介面"
 
@@ -806,35 +806,35 @@ msgstr "已知的多介面通告概覽"
 msgid "Overview of smart gateways in this network"
 msgstr "此網路中的智慧閘道器概覽"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:11
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:11
 msgid "Plugin configuration"
 msgstr "外掛配置"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr4.lua:29
 #: applications/luci-app-olsr/luasrc/controller/olsr6.lua:29
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua:240
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua:240
 msgid "Plugins"
 msgstr "外掛"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:54
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:48
 msgid "Polling rate for OLSR sockets in seconds. Default is 0.05."
 msgstr "OLSR 套接字的輪詢速率，以秒為單位。預設值為0.05。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:53
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:47
 msgid "Pollrate"
 msgstr "輪詢速率"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:126
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:120
 msgid "Port"
 msgstr "埠"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna.lua:38
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdhna6.lua:20
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:63
 #: applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm:115
 msgid "Prefix"
@@ -902,8 +902,8 @@ msgid "Signal Noise Ratio in dB"
 msgstr "信噪比（dB）"
 
 #: applications/luci-app-olsr/luasrc/controller/olsr.lua:64
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid "SmartGW"
 msgstr "SmartGW"
 
@@ -919,8 +919,8 @@ msgstr "此係統上未配置 SmartGateway。"
 msgid "Source address"
 msgstr "源位址"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid ""
 "Specifies the speed of the uplink in kilobits/s. First parameter is "
 "upstream, second parameter is downstream. Default is \"128 1024\"."
@@ -928,8 +928,8 @@ msgstr ""
 "以千位元/秒為單位指定上行鏈路的速度。第一個引數是上傳，第二個引數是下載。預設"
 "值為“128 1024”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:176
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:170
 msgid "Speed of the uplink"
 msgstr "上行鏈路的速度"
 
@@ -953,34 +953,34 @@ msgstr "從鄰居收包的成功率"
 msgid "Success rate of packages sent to the neighbour"
 msgstr "向鄰居發包的成功率"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:388
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:369
 msgid "TC"
 msgstr "TC"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:317
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:298
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:141
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:128
 msgid "TC interval"
 msgstr "TC 間隔"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:323
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:304
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:147
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:134
 msgid "TC validity time"
 msgstr "TC 有效時間"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:65
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:59
 msgid "TOS value"
 msgstr "TOS 值"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:13
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:15
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:15
 msgid ""
 "The OLSR daemon is an implementation of the Optimized Link State Routing "
 "protocol. As such it allows mesh routing for any network equipment. It runs "
@@ -993,8 +993,8 @@ msgstr ""
 "卡上執行，當然也可以在任何乙太網裝置上執行。訪問 <a href='http://www.olsr."
 "org'>olsrd.org</a> 獲取幫助和文件。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:194
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:188
 msgid ""
 "The fixed willingness to use. If not set willingness will be calculated "
 "dynamically based on battery/power status. Default is \"3\"."
@@ -1002,21 +1002,21 @@ msgstr ""
 "固定的使用意願值。如果未設定，則將根據電池/電源狀態動態計算意願值。預設值"
 "為“3”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:45
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:45
 msgid "The interface OLSRd should serve."
 msgstr "OLSRd 應該服務的介面。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:127
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:121
 msgid ""
 "The port OLSR uses. This should usually stay at the IANA assigned port 698. "
 "It can have a value between 1 and 65535."
 msgstr ""
 "OLSR 使用的埠。通常應使用 IANA 分配的保留埠698。它的值可以在1到65535之間。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:184
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:178
 msgid ""
 "This can be used to signal the external IPv6 prefix of the uplink to the "
 "clients. This might allow a client to change it's local IPv6 address to use "
@@ -1027,10 +1027,10 @@ msgstr ""
 "IPv6 位址，以使用 IPv6 閘道器，而無需任何型別的位址轉換。字首長度最大為64位。"
 "默認為“::/0”（無字首）。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:224
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:218
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:33
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:33
 msgid "Timing and Validity"
 msgstr "時間和有效性"
 
@@ -1038,8 +1038,8 @@ msgstr "時間和有效性"
 msgid "Topology"
 msgstr "拓撲"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:66
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:60
 msgid ""
 "Type of service value for the IP header of control traffic. Default is "
 "\"16\"."
@@ -1054,13 +1054,13 @@ msgstr "無法連線到 OLSR 守護程式！"
 msgid "Uplink"
 msgstr "上行連結"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:166
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:160
 msgid "Uplink uses NAT"
 msgstr "上行連結使用 NAT"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:116
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:110
 msgid "Use hysteresis"
 msgstr "使用滯後"
 
@@ -1085,8 +1085,8 @@ msgstr "非常好（SNR > 30）"
 msgid "WLAN"
 msgstr "WLAN"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:44
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:44
 msgid ""
 "Warning: kmod-ipip is not installed. Without kmod-ipip SmartGateway will not "
 "work, please install it."
@@ -1094,17 +1094,17 @@ msgstr ""
 "警告：未安裝 kmod-ipip。沒有 kmod-ipip，SmartGateway 將無法正常工作，請安裝"
 "它。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:235
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:229
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:60
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:60
 msgid "Weight"
 msgstr "體重"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:236
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:230
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:61
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:61
 msgid ""
 "When multiple links exist between hosts the weight of interface is used to "
 "determine the link to use. Normally the weight is automatically calculated "
@@ -1137,8 +1137,8 @@ msgstr ""
 "將匯出哪種上行鏈路到其他網狀節點。通過查詢本地 HNA6 ::ffff:0:0/96 或 "
 "2000::/3 來檢測上行鏈路。預設設定為“兩者”。"
 
-#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua:193
+#: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua:187
 msgid "Willingness"
 msgstr "意願值"
 

--- a/applications/luci-app-statistics/po/bg/statistics.po
+++ b/applications/luci-app-statistics/po/bg/statistics.po
@@ -214,8 +214,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/ca/statistics.po
+++ b/applications/luci-app-statistics/po/ca/statistics.po
@@ -223,8 +223,8 @@ msgstr "Activa"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/cs/statistics.po
+++ b/applications/luci-app-statistics/po/cs/statistics.po
@@ -218,8 +218,8 @@ msgstr "Povolit"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/de/statistics.po
+++ b/applications/luci-app-statistics/po/de/statistics.po
@@ -219,8 +219,8 @@ msgstr "Aktivieren"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/el/statistics.po
+++ b/applications/luci-app-statistics/po/el/statistics.po
@@ -221,8 +221,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/en/statistics.po
+++ b/applications/luci-app-statistics/po/en/statistics.po
@@ -218,8 +218,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/es/statistics.po
+++ b/applications/luci-app-statistics/po/es/statistics.po
@@ -221,8 +221,8 @@ msgstr "Activar"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/fr/statistics.po
+++ b/applications/luci-app-statistics/po/fr/statistics.po
@@ -219,8 +219,8 @@ msgstr "Activer"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/he/statistics.po
+++ b/applications/luci-app-statistics/po/he/statistics.po
@@ -215,8 +215,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/hi/statistics.po
+++ b/applications/luci-app-statistics/po/hi/statistics.po
@@ -214,8 +214,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/hu/statistics.po
+++ b/applications/luci-app-statistics/po/hu/statistics.po
@@ -217,8 +217,8 @@ msgstr "Engedélyezés"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/it/statistics.po
+++ b/applications/luci-app-statistics/po/it/statistics.po
@@ -219,8 +219,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/ja/statistics.po
+++ b/applications/luci-app-statistics/po/ja/statistics.po
@@ -218,8 +218,8 @@ msgstr "有効"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/ko/statistics.po
+++ b/applications/luci-app-statistics/po/ko/statistics.po
@@ -214,8 +214,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/mr/statistics.po
+++ b/applications/luci-app-statistics/po/mr/statistics.po
@@ -216,8 +216,8 @@ msgstr "सक्षम करा"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/ms/statistics.po
+++ b/applications/luci-app-statistics/po/ms/statistics.po
@@ -212,8 +212,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/no/statistics.po
+++ b/applications/luci-app-statistics/po/no/statistics.po
@@ -209,8 +209,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/pl/statistics.po
+++ b/applications/luci-app-statistics/po/pl/statistics.po
@@ -221,8 +221,8 @@ msgstr "Włącz"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/pt-br/statistics.po
+++ b/applications/luci-app-statistics/po/pt-br/statistics.po
@@ -220,8 +220,8 @@ msgstr "Ativar"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15
@@ -1146,7 +1146,8 @@ msgstr "Quando definido como verdadeiro, serão requeridos valores absolutos"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:32
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/memory.lua:24
 msgid "When set to true, we request percentage values"
-msgstr "Quando definido como verdadeiro, serão requeridos valores em percentual"
+msgstr ""
+"Quando definido como verdadeiro, serão requeridos valores em percentual"
 
 #: applications/luci-app-statistics/luasrc/statistics/plugins/iwinfo.lua:7
 #: applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/iwinfo.lua:7

--- a/applications/luci-app-statistics/po/pt/statistics.po
+++ b/applications/luci-app-statistics/po/pt/statistics.po
@@ -66,7 +66,8 @@ msgstr "Monitoramento básico"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:18
 msgid "By setting this, CPU is not aggregate of all processors on the system"
-msgstr "Ao ativar isto, CPU não é agregada de todos os processadores no sistema"
+msgstr ""
+"Ao ativar isto, CPU não é agregada de todos os processadores no sistema"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:4
 msgid "CPU Context Switches Plugin Configuration"
@@ -219,8 +220,8 @@ msgstr "Ativar"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15
@@ -339,7 +340,8 @@ msgstr ""
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/sensors.lua:86
 msgid "Hold Ctrl to select multiple items or to deselect entries."
-msgstr "Segure o Ctrl para selecionar múltiplos itens ou para retirar entradas."
+msgstr ""
+"Segure o Ctrl para selecionar múltiplos itens ou para retirar entradas."
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/olsrd.lua:13
 msgid "Host"
@@ -819,7 +821,8 @@ msgstr ""
 msgid ""
 "The OpenVPN plugin gathers information about the current vpn connection "
 "status."
-msgstr "O plugin OpenVPN reúne informações sobre o status atual da conexão VPN."
+msgstr ""
+"O plugin OpenVPN reúne informações sobre o status atual da conexão VPN."
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:6
 msgid ""

--- a/applications/luci-app-statistics/po/ro/statistics.po
+++ b/applications/luci-app-statistics/po/ro/statistics.po
@@ -219,8 +219,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/ru/statistics.po
+++ b/applications/luci-app-statistics/po/ru/statistics.po
@@ -219,8 +219,8 @@ msgstr "Включить"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/sk/statistics.po
+++ b/applications/luci-app-statistics/po/sk/statistics.po
@@ -210,8 +210,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/sv/statistics.po
+++ b/applications/luci-app-statistics/po/sv/statistics.po
@@ -217,8 +217,8 @@ msgstr "Aktivera"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/templates/statistics.pot
+++ b/applications/luci-app-statistics/po/templates/statistics.pot
@@ -203,8 +203,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/tr/statistics.po
+++ b/applications/luci-app-statistics/po/tr/statistics.po
@@ -211,8 +211,8 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/uk/statistics.po
+++ b/applications/luci-app-statistics/po/uk/statistics.po
@@ -217,8 +217,8 @@ msgstr "Увімкнути"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/vi/statistics.po
+++ b/applications/luci-app-statistics/po/vi/statistics.po
@@ -221,8 +221,8 @@ msgstr "Kích hoạt"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/zh-cn/statistics.po
+++ b/applications/luci-app-statistics/po/zh-cn/statistics.po
@@ -222,8 +222,8 @@ msgstr "启用"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-statistics/po/zh-tw/statistics.po
+++ b/applications/luci-app-statistics/po/zh-tw/statistics.po
@@ -220,8 +220,8 @@ msgstr "啟用"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:14
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua:10
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:11
-#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:12
+#: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:11
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/csv.lua:15
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:8
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/df.lua:15

--- a/applications/luci-app-vpn-policy-routing/po/es/vpn-policy-routing.po
+++ b/applications/luci-app-vpn-policy-routing/po/es/vpn-policy-routing.po
@@ -12,11 +12,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:51
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:51
 msgid "(strict mode)"
 msgstr "(modo estricto)"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
 msgid ""
 "Add an ip rule, not an iptables entry for policies with just the local "
 "address. Use with caution to manipulte policies priorities."
@@ -25,11 +25,11 @@ msgstr ""
 "la dirección local. Úselo con precaución para manipular las prioridades de "
 "las políticas."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:187
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:187
 msgid "Advanced Configuration"
 msgstr "Configuración avanzada"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be "
 "explicitly supported by the service. Can be useful if your OpenVPN tunnels "
@@ -39,7 +39,7 @@ msgstr ""
 "servicio debe admitir explícitamente. Puede ser útil si sus túneles OpenVPN "
 "tienen una opción de desarrollo que no sea tun* o tap*."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be ignored "
 "by the service. Can be useful if running both VPN server and VPN client on "
@@ -49,35 +49,35 @@ msgstr ""
 "servicio debe ignorar. Puede ser útil si ejecuta tanto el servidor VPN como "
 "el cliente VPN en el enrutador."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:203
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:203
 msgid "Append"
 msgstr "Adjuntar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
 msgid "Append local IP Tables rules"
 msgstr "Adjuntar reglas locales de IPTables"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
 msgid "Append remote IP Tables rules"
 msgstr "Adjuntar reglas remotas de IPTables"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:150
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:150
 msgid "Basic Configuration"
 msgstr "Configuración básica"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
 msgid "Boot Time-out"
 msgstr "Tiempo de arranque"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:331
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:331
 msgid "Chain"
 msgstr "Cadena"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:282
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:282
 msgid "Comment"
 msgstr "Comentario"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
 msgid ""
 "Comment, interface and at least one other field are required. Multiple local "
 "and remote addresses/devices/domains and ports can be space separated. "
@@ -90,74 +90,74 @@ msgstr ""
 "representan solo el formato/sintaxis y no se utilizarán si los campos se "
 "dejan en blanco."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:154
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:154
 msgid "Condensed output"
 msgstr "Salida condensada"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:145
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:145
 msgid "Configuration"
 msgstr "Configuración"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
 msgid "Controls both system log and console output verbosity."
 msgstr ""
 "Controla el registro del sistema y la verbosidad de salida de la consola."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
 msgid "Custom User File Includes"
 msgstr "El archivo de usuario personalizado incluye"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:359
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:359
 msgid "DSCP Tag"
 msgstr "Etiqueta DSCP"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
 msgid "DSCP Tagging"
 msgstr "Etiquetado DSCP"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
 msgid "Default ICMP Interface"
 msgstr "Interfaz ICMP predeterminada"
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:52
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:52
 msgid "Disable"
 msgstr "Desactivar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:169
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:179
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:183
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:208
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:244
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:248
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:255
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:259
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:169
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:179
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:183
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:208
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:244
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:248
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:255
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:259
 msgid "Disabled"
 msgstr "Desactivado"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
 msgid "Display these protocols in protocol column in Web UI."
 msgstr "Mostrar estos protocolos en la columna de protocolo en la Web UI."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:161
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:161
 msgid "Do not enforce policies when their gateway is down"
 msgstr "No aplique políticas cuando su puerta de enlace esté inactiva"
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:50
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:50
 msgid "Enable"
 msgstr "Activar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:184
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:209
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:245
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:249
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:256
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:260
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:276
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:374
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:184
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:209
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:245
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:249
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:256
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:260
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:276
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:374
 msgid "Enabled"
 msgstr "Activado"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid ""
 "FW Mask used by the service. High mask is used to avoid conflict with SQM/"
 "QoS. Change with caution together with"
@@ -165,101 +165,101 @@ msgstr ""
 "FW Mask utilizada por el servicio. La máscara alta se usa para evitar "
 "conflictos con SQM/QoS. Cambiar con precaución junto con"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
 msgid "Force the ICMP protocol interface."
 msgstr "Forzar la interfaz del protocolo ICMP."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
 msgid "IP Rules Support"
 msgstr "Soporte de reglas de IP"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
 msgid "IPTables rule option"
 msgstr "Opción de regla de IPTables"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:182
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:182
 msgid "IPv6 Support"
 msgstr "Soporte IPv6"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
 msgid "Ignored Interfaces"
 msgstr "Interfaces ignoradas"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:204
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:204
 msgid "Insert"
 msgstr "Insertar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:340
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:340
 msgid "Interface"
 msgstr "Interfaz"
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/js.htm:51
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/js.htm:51
 msgid "Loading"
 msgstr "Cargando"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:287
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:287
 msgid "Local addresses / devices"
 msgstr "Direcciones/Dispositivos locales"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:294
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:294
 msgid "Local ports"
 msgstr "Puertos locales"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:284
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:284
 msgid "Name"
 msgstr "Nombre"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:212
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:212
 msgid "No Change"
 msgstr "Ningún cambio"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
 msgid "Output verbosity"
 msgstr "Verbosidad de salida"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:377
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:377
 msgid "Path"
 msgstr "Ruta"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:166
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:176
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:166
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:176
 msgid "Please check the"
 msgstr "Por favor, verifique el"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
 msgid "Please make sure to check the"
 msgstr "Por favor, asegúrese de verificar el"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
 msgid "Policies"
 msgstr "Políticas"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:311
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:311
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:189
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:189
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
 msgid "README"
 msgstr "LÉEME"
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:42
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:42
 msgid "Reload"
 msgstr "Recargar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:299
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:299
 msgid "Remote addresses / domains"
 msgstr "Direcciones/Dominios remotos"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:304
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:304
 msgid "Remote ports"
 msgstr "Puertos remotos"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
 msgid ""
 "Run the following user files after setting up but before restarting DNSMASQ. "
 "See the"
@@ -267,65 +267,65 @@ msgstr ""
 "Ejecute los siguientes archivos de usuario después de la configuración pero "
 "antes de reiniciar DNSMASQ. Ver el"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:49
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:13
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:49
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:13
 msgid "Running"
 msgstr "Corriendo"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
 msgid "See the"
 msgstr "Ver el"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
 msgid "Select Append for -A and Insert for -I."
 msgstr "Seleccione Agregar para -A e Insertar para -I."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:132
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:132
 msgid "Service Errors"
 msgstr "Errores del servicio"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid "Service FW Mask"
 msgstr "Servicio FW Mask"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:127
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:127
 msgid "Service Gateways"
 msgstr "Puertas de enlace del servicio"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:122
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:123
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:122
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:123
 msgid "Service Status"
 msgstr "Estado del servicio"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:137
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:137
 msgid "Service Warnings"
 msgstr "Advertencias del servicio"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
 msgid ""
 "Set DSCP tags (in range between 1 and 63) for specific interfaces. See the"
 msgstr ""
 "Establezca etiquetas DSCP (en el rango entre 1 y 63) para interfaces "
 "específicas. Ver el"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
 msgid "Show Chain Column"
 msgstr "Mostrar columna de cadena"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
 msgid "Show Enable Column"
 msgstr "Mostrar columna de Activar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
 msgid "Show Protocol Column"
 msgstr "Mostrar columna de protocolo"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
 msgid "Show Up/Down Buttons"
 msgstr "Mostrar botones Subir/Bajar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
 msgid ""
 "Shows the Up/Down buttons for policies, allowing you to move a policy up or "
 "down in the list."
@@ -333,7 +333,7 @@ msgstr ""
 "Muestra los botones Subir/Bajar para políticas, lo que le permite mover una "
 "política hacia arriba o hacia abajo en la lista."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
 msgid ""
 "Shows the chain column for policies, allowing you to assign a PREROUTING, "
 "FORWARD, INPUT or OUTPUT chain to a policy."
@@ -341,7 +341,7 @@ msgstr ""
 "Muestra la columna de cadena para políticas, permitiéndole asignar una "
 "cadena PREROUTING, FORWARD, INPUT o OUTPUT a una política."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
 msgid ""
 "Shows the enable checkbox column for policies, allowing you to quickly "
 "enable/disable specific policy without deleting it."
@@ -350,7 +350,7 @@ msgstr ""
 "le permite Activar/Desactivar rápidamente políticas específicas sin "
 "eliminarlas."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
 msgid ""
 "Shows the protocol column for policies, allowing you to assign a specific "
 "protocol to a policy."
@@ -358,24 +358,24 @@ msgstr ""
 "Muestra la columna de protocolo para políticas, lo que le permite asignar un "
 "protocolo específico a una política."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
 msgid ""
 "Special instructions to append iptables rules for local IPs/netmasks/devices."
 msgstr ""
 "Instrucciones especiales para agregar reglas de iptables para IPs/máscaras "
 "de red/dispositivos locales."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
 msgid "Special instructions to append iptables rules for remote IPs/netmasks."
 msgstr ""
 "Instrucciones especiales para agregar reglas de iptables para IP remotas/"
 "máscaras de red."
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:40
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:40
 msgid "Start"
 msgstr "Iniciar"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
 msgid ""
 "Starting (WAN) FW Mark for marks used by the service. High starting mark is "
 "used to avoid conflict with SQM/QoS. Change with caution together with"
@@ -384,103 +384,103 @@ msgstr ""
 "marca de inicio alta se usa para evitar conflictos con SQM/QoS. Cambiar con "
 "precaución junto con"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
 msgid "Starting (WAN) Table ID number for tables created by the service."
 msgstr ""
 "Número de ID de tabla de inicio (WAN) para tablas creadas por el servicio."
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:44
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:44
 msgid "Stop"
 msgstr "Detener"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:47
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:11
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:47
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:11
 msgid "Stopped"
 msgstr "Detenido"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
 msgid "Strict enforcement"
 msgstr "Aplicación estricta"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:162
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:162
 msgid "Strictly enforce policies when their gateway is down"
 msgstr ""
 "Cumplir estrictamente las políticas cuando su puerta de enlace esté inactiva"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
 msgid "Supported Interfaces"
 msgstr "Interfaces soportadas"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
 msgid "Supported Protocols"
 msgstr "Protocolos soportados"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:153
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:153
 msgid "Suppress/No output"
 msgstr "Suprimir/Sin salida"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:175
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:175
 msgid "The ipset option for local policies"
 msgstr "La opción ipset para políticas locales"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:165
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:165
 msgid "The ipset option for remote policies"
 msgstr "La opción ipset para políticas remotas"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
 msgid ""
 "Time (in seconds) for service to wait for WAN gateway discovery on boot."
 msgstr ""
 "Tiempo (en segundos) para que el servicio espere el descubrimiento de la "
 "puerta de enlace WAN en el arranque."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:171
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:171
 msgid "Use DNSMASQ ipset"
 msgstr "Usar DNSMASQ ipset"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:170
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:180
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:170
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:180
 msgid "Use ipset command"
 msgstr "Usar el comando ipset"
 
-#: luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:4
+#: applications/luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:4
 msgid "VPN"
 msgstr "VPN"
 
-#: luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:5
+#: applications/luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:5
 msgid "VPN Policy Routing"
 msgstr "Enrutamiento de políticas de VPN"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:120
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:120
 msgid "VPN and WAN Policy-Based Routing"
 msgstr "Enrutamiento basado en políticas VPN y WAN"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:155
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:155
 msgid "Verbose output"
 msgstr "Salida detallada"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:213
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:213
 msgid "WAN"
 msgstr "WAN"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid "WAN Table FW Mark"
 msgstr "Tabla WAN Marca FW"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
 msgid "WAN Table ID"
 msgstr "ID de tabla WAN"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
 msgid "WARNING:"
 msgstr "ADVERTENCIA:"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:241
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:241
 msgid "Web UI Configuration"
 msgstr "Configuración de Web UI"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:190
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:190
 msgid ""
 "before changing anything in this section! Change any of the settings below "
 "with extreme caution!"
@@ -488,17 +488,17 @@ msgstr ""
 "antes de cambiar cualquier cosa en esta sección, ¡Cambie cualquiera de las "
 "configuraciones a continuación con extrema precaución!"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
 msgid "before changing this option."
 msgstr "antes de cambiar esta opción."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
 msgid "for details."
 msgstr "para detalles."
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:43
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:43
 msgid "is not installed or not found"
 msgstr "no está instalado o no se encuentra"

--- a/applications/luci-app-vpn-policy-routing/po/templates/vpn-policy-routing.pot
+++ b/applications/luci-app-vpn-policy-routing/po/templates/vpn-policy-routing.pot
@@ -1,63 +1,63 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:51
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:51
 msgid "(strict mode)"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
 msgid ""
 "Add an ip rule, not an iptables entry for policies with just the local "
 "address. Use with caution to manipulte policies priorities."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:187
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:187
 msgid "Advanced Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be "
 "explicitly supported by the service. Can be useful if your OpenVPN tunnels "
 "have dev option other than tun* or tap*."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be ignored "
 "by the service. Can be useful if running both VPN server and VPN client on "
 "the router."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:203
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:203
 msgid "Append"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
 msgid "Append local IP Tables rules"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
 msgid "Append remote IP Tables rules"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:150
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:150
 msgid "Basic Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
 msgid "Boot Time-out"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:331
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:331
 msgid "Chain"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:282
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:282
 msgid "Comment"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
 msgid ""
 "Comment, interface and at least one other field are required. Multiple local "
 "and remote addresses/devices/domains and ports can be space separated. "
@@ -65,386 +65,386 @@ msgid ""
 "fields are left blank."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:154
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:154
 msgid "Condensed output"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:145
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:145
 msgid "Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
 msgid "Controls both system log and console output verbosity."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
 msgid "Custom User File Includes"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:359
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:359
 msgid "DSCP Tag"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
 msgid "DSCP Tagging"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
 msgid "Default ICMP Interface"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:52
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:52
 msgid "Disable"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:169
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:179
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:183
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:208
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:244
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:248
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:255
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:259
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:169
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:179
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:183
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:208
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:244
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:248
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:255
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:259
 msgid "Disabled"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
 msgid "Display these protocols in protocol column in Web UI."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:161
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:161
 msgid "Do not enforce policies when their gateway is down"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:50
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:50
 msgid "Enable"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:184
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:209
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:245
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:249
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:256
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:260
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:276
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:374
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:184
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:209
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:245
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:249
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:256
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:260
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:276
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:374
 msgid "Enabled"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid ""
 "FW Mask used by the service. High mask is used to avoid conflict with SQM/"
 "QoS. Change with caution together with"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
 msgid "Force the ICMP protocol interface."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
 msgid "IP Rules Support"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
 msgid "IPTables rule option"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:182
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:182
 msgid "IPv6 Support"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
 msgid "Ignored Interfaces"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:204
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:204
 msgid "Insert"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:340
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:340
 msgid "Interface"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/js.htm:51
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/js.htm:51
 msgid "Loading"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:287
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:287
 msgid "Local addresses / devices"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:294
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:294
 msgid "Local ports"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:284
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:284
 msgid "Name"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:212
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:212
 msgid "No Change"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
 msgid "Output verbosity"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:377
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:377
 msgid "Path"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:166
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:176
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:166
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:176
 msgid "Please check the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
 msgid "Please make sure to check the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
 msgid "Policies"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:311
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:311
 msgid "Protocol"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:189
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:189
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
 msgid "README"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:42
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:42
 msgid "Reload"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:299
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:299
 msgid "Remote addresses / domains"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:304
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:304
 msgid "Remote ports"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
 msgid ""
 "Run the following user files after setting up but before restarting DNSMASQ. "
 "See the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:49
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:13
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:49
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:13
 msgid "Running"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
 msgid "See the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
 msgid "Select Append for -A and Insert for -I."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:132
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:132
 msgid "Service Errors"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid "Service FW Mask"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:127
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:127
 msgid "Service Gateways"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:122
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:123
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:122
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:123
 msgid "Service Status"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:137
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:137
 msgid "Service Warnings"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
 msgid ""
 "Set DSCP tags (in range between 1 and 63) for specific interfaces. See the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
 msgid "Show Chain Column"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
 msgid "Show Enable Column"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
 msgid "Show Protocol Column"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
 msgid "Show Up/Down Buttons"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
 msgid ""
 "Shows the Up/Down buttons for policies, allowing you to move a policy up or "
 "down in the list."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
 msgid ""
 "Shows the chain column for policies, allowing you to assign a PREROUTING, "
 "FORWARD, INPUT or OUTPUT chain to a policy."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
 msgid ""
 "Shows the enable checkbox column for policies, allowing you to quickly "
 "enable/disable specific policy without deleting it."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
 msgid ""
 "Shows the protocol column for policies, allowing you to assign a specific "
 "protocol to a policy."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
 msgid ""
 "Special instructions to append iptables rules for local IPs/netmasks/devices."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
 msgid "Special instructions to append iptables rules for remote IPs/netmasks."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:40
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:40
 msgid "Start"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
 msgid ""
 "Starting (WAN) FW Mark for marks used by the service. High starting mark is "
 "used to avoid conflict with SQM/QoS. Change with caution together with"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
 msgid "Starting (WAN) Table ID number for tables created by the service."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:44
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:44
 msgid "Stop"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:47
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:11
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:47
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:11
 msgid "Stopped"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
 msgid "Strict enforcement"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:162
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:162
 msgid "Strictly enforce policies when their gateway is down"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
 msgid "Supported Interfaces"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
 msgid "Supported Protocols"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:153
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:153
 msgid "Suppress/No output"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:175
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:175
 msgid "The ipset option for local policies"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:165
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:165
 msgid "The ipset option for remote policies"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
 msgid ""
 "Time (in seconds) for service to wait for WAN gateway discovery on boot."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:171
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:171
 msgid "Use DNSMASQ ipset"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:170
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:180
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:170
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:180
 msgid "Use ipset command"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:4
+#: applications/luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:4
 msgid "VPN"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:5
+#: applications/luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:5
 msgid "VPN Policy Routing"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:120
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:120
 msgid "VPN and WAN Policy-Based Routing"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:155
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:155
 msgid "Verbose output"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:213
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:213
 msgid "WAN"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid "WAN Table FW Mark"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
 msgid "WAN Table ID"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
 msgid "WARNING:"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:241
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:241
 msgid "Web UI Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:190
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:190
 msgid ""
 "before changing anything in this section! Change any of the settings below "
 "with extreme caution!"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
 msgid "before changing this option."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
 msgid "for details."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:43
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:43
 msgid "is not installed or not found"
 msgstr ""

--- a/applications/luci-app-vpn-policy-routing/po/tr/vpn-policy-routing.po
+++ b/applications/luci-app-vpn-policy-routing/po/tr/vpn-policy-routing.po
@@ -4,63 +4,63 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:51
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:51
 msgid "(strict mode)"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
 msgid ""
 "Add an ip rule, not an iptables entry for policies with just the local "
 "address. Use with caution to manipulte policies priorities."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:187
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:187
 msgid "Advanced Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be "
 "explicitly supported by the service. Can be useful if your OpenVPN tunnels "
 "have dev option other than tun* or tap*."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be ignored "
 "by the service. Can be useful if running both VPN server and VPN client on "
 "the router."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:203
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:203
 msgid "Append"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
 msgid "Append local IP Tables rules"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
 msgid "Append remote IP Tables rules"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:150
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:150
 msgid "Basic Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
 msgid "Boot Time-out"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:331
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:331
 msgid "Chain"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:282
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:282
 msgid "Comment"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
 msgid ""
 "Comment, interface and at least one other field are required. Multiple local "
 "and remote addresses/devices/domains and ports can be space separated. "
@@ -68,386 +68,386 @@ msgid ""
 "fields are left blank."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:154
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:154
 msgid "Condensed output"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:145
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:145
 msgid "Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
 msgid "Controls both system log and console output verbosity."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
 msgid "Custom User File Includes"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:359
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:359
 msgid "DSCP Tag"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
 msgid "DSCP Tagging"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
 msgid "Default ICMP Interface"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:52
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:52
 msgid "Disable"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:169
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:179
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:183
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:208
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:244
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:248
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:255
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:259
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:169
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:179
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:183
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:208
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:244
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:248
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:255
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:259
 msgid "Disabled"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
 msgid "Display these protocols in protocol column in Web UI."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:161
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:161
 msgid "Do not enforce policies when their gateway is down"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:50
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:50
 msgid "Enable"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:184
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:209
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:245
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:249
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:256
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:260
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:276
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:374
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:184
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:209
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:245
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:249
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:256
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:260
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:276
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:374
 msgid "Enabled"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid ""
 "FW Mask used by the service. High mask is used to avoid conflict with SQM/"
 "QoS. Change with caution together with"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:211
 msgid "Force the ICMP protocol interface."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:207
 msgid "IP Rules Support"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
 msgid "IPTables rule option"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:182
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:182
 msgid "IPv6 Support"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:195
 msgid "Ignored Interfaces"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:204
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:204
 msgid "Insert"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:340
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:340
 msgid "Interface"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/js.htm:51
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/js.htm:51
 msgid "Loading"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:287
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:287
 msgid "Local addresses / devices"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:294
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:294
 msgid "Local ports"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:284
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:284
 msgid "Name"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:212
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:212
 msgid "No Change"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:152
 msgid "Output verbosity"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:377
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:377
 msgid "Path"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:166
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:176
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:166
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:176
 msgid "Please check the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
 msgid "Please make sure to check the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:265
 msgid "Policies"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:311
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:311
 msgid "Protocol"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:189
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:189
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
 msgid "README"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:42
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:42
 msgid "Reload"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:299
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:299
 msgid "Remote addresses / domains"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:304
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:304
 msgid "Remote ports"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:366
 msgid ""
 "Run the following user files after setting up but before restarting DNSMASQ. "
 "See the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:49
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:13
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:49
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:13
 msgid "Running"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
 msgid "See the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:202
 msgid "Select Append for -A and Insert for -I."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:132
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:132
 msgid "Service Errors"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid "Service FW Mask"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:127
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:127
 msgid "Service Gateways"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:122
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:123
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:122
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:123
 msgid "Service Status"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:137
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:137
 msgid "Service Warnings"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
 msgid ""
 "Set DSCP tags (in range between 1 and 63) for specific interfaces. See the"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
 msgid "Show Chain Column"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
 msgid "Show Enable Column"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
 msgid "Show Protocol Column"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
 msgid "Show Up/Down Buttons"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:258
 msgid ""
 "Shows the Up/Down buttons for policies, allowing you to move a policy up or "
 "down in the list."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:254
 msgid ""
 "Shows the chain column for policies, allowing you to assign a PREROUTING, "
 "FORWARD, INPUT or OUTPUT chain to a policy."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:243
 msgid ""
 "Shows the enable checkbox column for policies, allowing you to quickly "
 "enable/disable specific policy without deleting it."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:247
 msgid ""
 "Shows the protocol column for policies, allowing you to assign a specific "
 "protocol to a policy."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:220
 msgid ""
 "Special instructions to append iptables rules for local IPs/netmasks/devices."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:223
 msgid "Special instructions to append iptables rules for remote IPs/netmasks."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:40
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:40
 msgid "Start"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
 msgid ""
 "Starting (WAN) FW Mark for marks used by the service. High starting mark is "
 "used to avoid conflict with SQM/QoS. Change with caution together with"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
 msgid "Starting (WAN) Table ID number for tables created by the service."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:44
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:44
 msgid "Stop"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:47
-#: luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:11
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:47
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/buttons.htm:11
 msgid "Stopped"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:158
 msgid "Strict enforcement"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:162
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:162
 msgid "Strictly enforce policies when their gateway is down"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:192
 msgid "Supported Interfaces"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:251
 msgid "Supported Protocols"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:153
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:153
 msgid "Suppress/No output"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:175
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:175
 msgid "The ipset option for local policies"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:165
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:165
 msgid "The ipset option for remote policies"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:198
 msgid ""
 "Time (in seconds) for service to wait for WAN gateway discovery on boot."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:171
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:171
 msgid "Use DNSMASQ ipset"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:170
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:180
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:170
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:180
 msgid "Use ipset command"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:4
+#: applications/luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:4
 msgid "VPN"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:5
+#: applications/luci-app-vpn-policy-routing/luasrc/controller/vpn-policy-routing.lua:5
 msgid "VPN Policy Routing"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:120
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:120
 msgid "VPN and WAN Policy-Based Routing"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:155
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:155
 msgid "Verbose output"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:213
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:213
 msgid "WAN"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:231
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:236
 msgid "WAN Table FW Mark"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:226
 msgid "WAN Table ID"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:188
 msgid "WARNING:"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:241
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:241
 msgid "Web UI Configuration"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:190
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:190
 msgid ""
 "before changing anything in this section! Change any of the settings below "
 "with extreme caution!"
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:168
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:178
 msgid "before changing this option."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:160
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:355
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:368
 msgid "for details."
 msgstr ""
 
-#: luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:43
+#: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:43
 msgid "is not installed or not found"
 msgstr ""

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -13,7 +13,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -49,11 +49,11 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -61,7 +61,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -158,12 +158,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 
@@ -196,7 +194,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 
@@ -226,7 +223,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -255,6 +252,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -315,11 +316,11 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
@@ -343,11 +344,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -451,7 +452,7 @@ msgid "Alert"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -625,16 +626,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -837,7 +838,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr ""
 
@@ -854,8 +855,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -886,8 +887,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -903,17 +904,17 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1021,7 +1022,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr ""
@@ -1038,7 +1040,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1050,16 +1052,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1090,7 +1092,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr ""
 
@@ -1106,7 +1108,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1190,7 +1192,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1314,11 +1316,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1330,7 +1332,7 @@ msgstr ""
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1346,7 +1348,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1355,7 +1357,7 @@ msgid "Design"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr ""
 
@@ -1391,7 +1393,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1408,7 +1410,7 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1473,10 +1475,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1510,7 +1512,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1522,7 +1524,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1560,7 +1562,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1601,9 +1603,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1790,12 +1792,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1875,7 +1877,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1883,15 +1885,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1943,7 +1945,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr ""
 
@@ -2129,8 +2131,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2170,8 +2172,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2261,7 +2263,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2312,7 +2314,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2340,11 +2347,11 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2407,7 +2414,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2513,7 +2520,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2566,8 +2573,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
@@ -2696,8 +2703,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr ""
 
@@ -2779,17 +2786,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2805,7 +2809,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2894,7 +2898,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgstr ""
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3013,7 +3017,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3153,8 +3158,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3225,7 +3230,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3314,8 +3319,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3336,8 +3341,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr ""
@@ -3363,7 +3368,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3384,7 +3389,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3424,7 +3429,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3585,11 +3590,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3650,7 +3655,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3658,7 +3663,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3728,7 +3733,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3829,7 +3834,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -3963,7 +3968,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -3971,11 +3976,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4043,7 +4048,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr ""
 
@@ -4051,7 +4056,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4177,7 +4182,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4217,7 +4222,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4356,7 +4361,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr ""
 
@@ -4383,7 +4388,7 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr ""
 
@@ -4404,19 +4409,19 @@ msgstr ""
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4450,8 +4455,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr ""
 
@@ -4461,7 +4466,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4518,7 +4523,7 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4529,7 +4534,7 @@ msgid "Save"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4551,11 +4556,11 @@ msgstr ""
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4570,9 +4575,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4656,7 +4661,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4686,7 +4691,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr ""
@@ -4713,7 +4718,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4737,8 +4742,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr ""
 
@@ -4799,7 +4804,7 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4830,7 +4835,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4906,7 +4911,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4920,7 +4925,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4939,8 +4944,8 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr ""
 
@@ -4973,16 +4978,16 @@ msgstr ""
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr ""
 
@@ -5025,7 +5030,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5056,7 +5061,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5185,7 +5190,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5273,8 +5278,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5317,9 +5322,9 @@ msgstr ""
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr ""
 
@@ -5344,7 +5349,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5411,6 +5416,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5422,6 +5432,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5430,6 +5448,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5447,12 +5469,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5462,7 +5484,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5476,7 +5498,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5502,7 +5524,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5517,21 +5539,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5821,19 +5843,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr ""
 
@@ -5877,7 +5899,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6091,7 +6113,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr ""
 
@@ -6199,7 +6221,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- Camp addicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- Escolliu, si us plau --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalitzat --"
@@ -170,12 +170,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Adreça <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "Passarel·la <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
@@ -210,7 +208,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Nom <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Adreça <abbr title=\"Media Access Control\">MAC</abbr>"
 
@@ -246,7 +243,7 @@ msgstr ""
 "Avís: cal reiniciar manualment el servei cron si el fitxer crontab estava "
 "buit abans d'editar-lo."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -276,6 +273,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -338,11 +339,11 @@ msgstr "Punt d'accés"
 msgid "Actions"
 msgstr "Accions"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Rutes <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> actives"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Rutes <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> actives"
 
@@ -366,11 +367,11 @@ msgstr "Arrendaments DHCPv6 actius"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -475,7 +476,7 @@ msgid "Alert"
 msgstr "Alerta"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -653,16 +654,16 @@ msgstr "Qualsevol zona"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -868,7 +869,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Substitució dels dominis NX falsos"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Pont"
 
@@ -885,8 +886,8 @@ msgstr "Número d'unitat de pont"
 msgid "Bring up on boot"
 msgstr "Aixecar a l'engegada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -917,8 +918,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -934,17 +935,17 @@ msgstr "Cancel·la"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Cadena"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Canvis"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1060,7 +1061,8 @@ msgstr "Tanca la llista..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "S’estan recollint dades…"
@@ -1077,7 +1079,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1089,16 +1091,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configuració"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1129,7 +1131,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Connexions"
 
@@ -1145,7 +1147,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1231,7 +1233,7 @@ msgstr "DHCP i DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Client DHCP"
 
@@ -1355,11 +1357,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1371,7 +1373,7 @@ msgstr "Suprimeix"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1387,7 +1389,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descripció"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1396,7 +1398,7 @@ msgid "Design"
 msgstr "Disseny"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destí"
 
@@ -1432,7 +1434,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1449,7 +1451,7 @@ msgstr "Diagnòstics"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Directori"
 
@@ -1516,10 +1518,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1557,7 +1559,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1569,7 +1571,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1609,7 +1611,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1653,9 +1655,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Mètode EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1842,12 +1844,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Commutador Ethernet"
 
@@ -1927,7 +1929,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1935,15 +1937,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Fitxer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "No hi ha accés al fitxer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Nom de fitxer"
 
@@ -1995,7 +1997,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "Ajusts de tallafocs"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Estat de tallafocs"
 
@@ -2183,8 +2185,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Vés a la configuració de contrasenya"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2227,8 +2229,8 @@ msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "No mostris l'<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2318,7 +2320,7 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Tallafocs IPv4"
 
@@ -2369,8 +2371,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Adreça IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2397,11 +2404,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Tallafocs IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "Veïns IPv6"
 
@@ -2464,7 +2471,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Adreça IPv6"
 
@@ -2576,7 +2583,7 @@ msgstr "Ignora el fitxer de resolució"
 msgid "Image"
 msgstr "Fitxer d'imatge"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Entr."
 
@@ -2629,8 +2636,8 @@ msgstr "Instal·la extensions de protocol"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfície"
@@ -2762,8 +2769,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Registre del nucli"
 
@@ -2845,18 +2852,15 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Temps d'arrendament restant"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Fitxer d'arrendament"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2871,7 +2875,7 @@ msgstr "Deixeu-ho en blanc per autodetectar"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deixeu-ho en blanc per utilitzar l'adreça WAN actual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Llegenda:"
 
@@ -2962,7 +2966,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Càrrega"
 
@@ -2970,7 +2974,7 @@ msgstr "Càrrega"
 msgid "Load Average"
 msgstr "Càrrega mitjana"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3081,7 +3085,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "Adreça MAC"
 
@@ -3221,8 +3226,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Mètrica"
@@ -3293,7 +3298,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3384,8 +3389,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Candidats de servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3406,8 +3411,8 @@ msgstr "Navegació"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Xarxa"
@@ -3433,7 +3438,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Següent"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "No"
@@ -3454,7 +3459,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3494,7 +3499,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "No hi ha regles en aquesta cadena"
 
@@ -3655,11 +3660,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Opció canviada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Opció treta"
 
@@ -3720,7 +3725,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Opcions"
 
@@ -3728,7 +3733,7 @@ msgstr "Opcions"
 msgid "Other:"
 msgstr "Altres:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Sort."
 
@@ -3798,7 +3803,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3899,7 +3904,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Paquets"
 
@@ -4033,7 +4038,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Paquets"
 
@@ -4041,11 +4046,11 @@ msgstr "Paquets"
 msgid "Please enter your username and password."
 msgstr "Si us plau entra el teu nom d'usuari i contrasenya."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Política"
 
@@ -4113,7 +4118,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Processos"
 
@@ -4121,7 +4126,7 @@ msgstr "Processos"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4249,7 +4254,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Gràfiques en temps real"
 
@@ -4289,7 +4294,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "Reconnex aquesta interfície"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referències"
 
@@ -4428,7 +4433,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Restableix"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Reinicia els comptadors"
 
@@ -4455,7 +4460,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Reinicia"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Reinicia el tallafocs"
 
@@ -4476,19 +4481,19 @@ msgstr "Restaura còpia de seguretat"
 msgid "Reveal/hide password"
 msgstr "Mostra/amaga la contrasenya"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Reverteix"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4522,8 +4527,8 @@ msgid "Router Password"
 msgstr "Contrasenya de l'encaminador"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Rutes"
 
@@ -4535,7 +4540,7 @@ msgstr ""
 "Les rutes especifiquen per quina interfície i passarel·la es pot arribar a "
 "un cert ordinador o xarxa."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4592,7 +4597,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4603,7 +4608,7 @@ msgid "Save"
 msgstr "Desa"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Desa i aplica"
@@ -4625,11 +4630,11 @@ msgstr "Escaneja"
 msgid "Scheduled Tasks"
 msgstr "Tasques programades"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Secció afegida"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Secció treta"
 
@@ -4644,9 +4649,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4730,7 +4735,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4760,7 +4765,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Senyal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Mida"
@@ -4787,7 +4792,7 @@ msgid "Skip to navigation"
 msgstr "Salta a la navegació"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4811,8 +4816,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Origen"
 
@@ -4873,7 +4878,7 @@ msgstr "Inici"
 msgid "Start priority"
 msgstr "Prioritat d'inici"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4904,7 +4909,7 @@ msgstr "Rutes estàtiques"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Adreça estàtica"
 
@@ -4980,7 +4985,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4994,7 +4999,7 @@ msgstr "Protocol de commutador"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -5013,8 +5018,8 @@ msgstr "Sincronitza amb el navegador"
 msgid "System"
 msgstr "Sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Registre del sistema"
 
@@ -5047,16 +5052,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Velocitat TX"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Taula"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Destí"
 
@@ -5101,7 +5106,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5134,7 +5139,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Les següents regles estan actualment actives en aquest sistema."
 
@@ -5274,7 +5279,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5373,8 +5378,8 @@ msgstr ""
 "Aquesta llista mostra una vista general sobre els processos corrent al "
 "sistema actualment i el seu estat."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5421,9 +5426,9 @@ msgstr "Total disponible"
 msgid "Traceroute"
 msgstr "Rastre de ruta"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Trànsit"
 
@@ -5448,7 +5453,7 @@ msgid "Tunnel ID"
 msgstr "ID del túnel"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Interfície del túnel"
 
@@ -5515,6 +5520,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5526,6 +5536,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5534,6 +5552,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5551,12 +5573,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Desconegut"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5566,7 +5588,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Sense gestionar"
 
@@ -5580,7 +5602,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Canvis sense desar"
 
@@ -5606,7 +5628,7 @@ msgstr "Tipus de protocol no suportat."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5621,21 +5643,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Puja un arxiu..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5927,19 +5949,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Sense fils"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Adaptador sense fils"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Xarxa sense fils"
 
@@ -5983,7 +6005,7 @@ msgstr "Escriure les peticions DNS rebudes al registre del sistema"
 msgid "Write system log to file"
 msgstr "Escriure el registre del sistema al fitxer"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Sí"
@@ -6206,7 +6228,7 @@ msgstr "cap enllaç"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "cap"
 
@@ -6314,7 +6336,7 @@ msgstr "desconegut"
 msgid "unlimited"
 msgstr "il·limitat"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -20,7 +20,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d bitů"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d neplatné/á pole"
 
@@ -56,11 +56,11 @@ msgid "-- Additional Field --"
 msgstr "-- Doplňující pole --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -68,7 +68,7 @@ msgstr "-- Prosím vyberte --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- vlastní --"
@@ -167,12 +167,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protokol Verze 4\">IPv4</abbr>-Adresa"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Verze 4\">IPv4</abbr>-Brána"
 
@@ -208,7 +206,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Název"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-Adresa"
 
@@ -244,7 +241,7 @@ msgstr ""
 "<br/>Poznámka: Pokud byl soubor crontab před úpravami prázdný, je nutné "
 "službu cron restartovat ručně."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Adresář se stejným názvem již existuje."
 
@@ -274,6 +271,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -336,13 +337,13 @@ msgstr "Přístupový bod"
 msgid "Actions"
 msgstr "Akce"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Aktivní záznamy ve směrovací tabulce <abbr title=\"Internet Protocol Version "
 "4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Aktivní záznamy ve směrovací tabulce <abbr title=\"Internet Protocol Version "
@@ -368,11 +369,11 @@ msgstr "Aktivní propůjčené DHCPv6 adresy (leases)"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -476,7 +477,7 @@ msgid "Alert"
 msgstr "Upozornění"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Alias rozhraní"
@@ -658,16 +659,16 @@ msgstr "Libovolná zóna"
 msgid "Apply backup?"
 msgstr "Aplikovat zálohu?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Provádění požadavku selhalo se stavem <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Přesto aplikovat"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Aplikuji změny nastavení… %ds"
 
@@ -881,7 +882,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Přepíše falešnou hodnotu NX Domény"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Síťový most"
 
@@ -898,8 +899,8 @@ msgstr "Číslo síťového mostu"
 msgid "Bring up on boot"
 msgstr "Zapnout po startu"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Procházet…"
 
@@ -931,8 +932,8 @@ msgstr "Mezipaměť"
 msgid "Call failed"
 msgstr "Volání selhalo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -948,17 +949,17 @@ msgstr "Zrušit"
 msgid "Category"
 msgstr "Kategorie"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Řetěz"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Změny"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Změny byly vráceny zpět."
 
@@ -1079,7 +1080,8 @@ msgstr "Zavřít seznam..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Probíhá sběr dat..."
@@ -1096,7 +1098,7 @@ msgstr "Příkaz OK"
 msgid "Command failed"
 msgstr "Příkaz selhal"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Komentář"
 
@@ -1113,16 +1115,16 @@ msgstr ""
 "robustnosti při vyjednávání klíče, obzvláště v prostředích s velkým síťovým "
 "provozem."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Nastavení"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "Změny nastavení byly provedeny."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "Změny nastavení byly vráceny zpět!"
 
@@ -1153,7 +1155,7 @@ msgstr "Pokus o připojení selhal"
 msgid "Connection lost"
 msgstr "Spojení ztraceno"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Připojení"
 
@@ -1169,7 +1171,7 @@ msgstr "Obsah byl uložen."
 msgid "Continue"
 msgstr "Pokračovat"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1260,7 +1262,7 @@ msgstr "DHCP a DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP klient"
 
@@ -1386,11 +1388,11 @@ msgstr ""
 "Další možnosti DHCP, například \"<code>6,192.168.2.1,192.168.2.2</code>\", "
 "které odkazuje na různé DNS servery pro klienty."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1402,7 +1404,7 @@ msgstr "Odstranit"
 msgid "Delete key"
 msgstr "Smazat klíč"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Odstranění se nezdařilo: %s"
 
@@ -1418,7 +1420,7 @@ msgstr "Interval zprávy Delivery Traffic Indication"
 msgid "Description"
 msgstr "Popis"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Odznačit"
 
@@ -1427,7 +1429,7 @@ msgid "Design"
 msgstr "Vzhled"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Cíl"
 
@@ -1463,7 +1465,7 @@ msgstr "Zařízení není aktivní"
 msgid "Device is restarting…"
 msgstr "Zařízení se restartuje…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Zařízení není dostupné!"
 
@@ -1480,7 +1482,7 @@ msgstr "Diagnostika"
 msgid "Dial number"
 msgstr "Vytáčené číslo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Adresář"
 
@@ -1547,10 +1549,10 @@ msgstr "Odpojit"
 msgid "Disconnection attempt failed"
 msgstr "Odpojení selhalo"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1590,7 +1592,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Nepřeposílat reverzní dotazy na místní sítě"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Opravdu chcete smazat \"%s\"?"
 
@@ -1602,7 +1604,7 @@ msgstr "Opravdu chcete smazat následující SSH klíč?"
 msgid "Do you really want to erase all settings?"
 msgstr "Opravdu chcete smazat veškeré nastavení?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Opravdu chcete rekurzivně smazat adresář \"%s\"?"
 
@@ -1642,7 +1644,7 @@ msgstr "Stáhnout mtdblock"
 msgid "Downstream SNR offset"
 msgstr "Downstream SNR offset"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Přetažením změníte pořadí"
 
@@ -1688,9 +1690,9 @@ msgstr "EA bitová délka"
 msgid "EAP-Method"
 msgstr "Metoda EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1883,12 +1885,12 @@ msgid "Errored seconds (ES)"
 msgstr "Chybové sekundy (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernetový adaptér"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernetový switch"
 
@@ -1970,7 +1972,7 @@ msgstr "Fast Transition protokol"
 msgid "Failed to change the system password."
 msgstr "Nepodařilo se změnit systémové heslo."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 #, fuzzy
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
@@ -1981,15 +1983,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Nepodařilo se vykonat \"/etc/init.d/%s %s\" akce: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Soubor"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Soubor není přístupný"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Název souboru"
 
@@ -2043,7 +2045,7 @@ msgstr "Značka paketu (fwmark)"
 msgid "Firewall Settings"
 msgstr "Nastavení firewallu"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Stav firewallu"
 
@@ -2232,8 +2234,8 @@ msgstr "Globální možnosti sítě"
 msgid "Go to password configuration..."
 msgstr "Přejít na nastavení hesla..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2275,8 +2277,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Skrývat <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Skrýt prázdné řetězy"
 
@@ -2367,7 +2369,7 @@ msgstr "Chybí IP adresa"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 firewall"
 
@@ -2418,8 +2420,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4 adresa"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2446,11 +2453,11 @@ msgstr "IPv4/IPv6 (obojí - výchozí IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "Sousedé IPv6"
 
@@ -2513,7 +2520,7 @@ msgstr "IPv6 suffix"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6 adresa"
 
@@ -2625,7 +2632,7 @@ msgstr "Ignorovat resolv soubor"
 msgid "Image"
 msgstr "Obraz"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Dovnitř"
 
@@ -2680,8 +2687,8 @@ msgstr "Instalovat protokolové rozšíření…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Rozhraní"
@@ -2814,8 +2821,8 @@ msgstr "Připojování k síti: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Zachovat nastavení a ponechat aktuální konfiguraci"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Záznam kernelu"
 
@@ -2897,18 +2904,15 @@ msgid "Lease time"
 msgstr "Doba zapůjčení"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Zbývající doba trvání zápůjčky"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Soubor zápůjček"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2923,7 +2927,7 @@ msgstr "Ponechte prázdné pro automatickou detekci"
 msgid "Leave empty to use the current WAN address"
 msgstr "Ponecháte-li prázdné, použije stávající WAN adresu"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -3031,7 +3035,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Port pro příchozí dotazy DNS"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Zátěž"
 
@@ -3039,7 +3043,7 @@ msgstr "Zátěž"
 msgid "Load Average"
 msgstr "Průměrná zátěž"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Načítání obsahu adresáře…"
 
@@ -3156,7 +3160,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-Adresa"
 
@@ -3299,8 +3304,8 @@ msgid "Method not found"
 msgstr "Metoda nebyla nalezena"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrika"
@@ -3371,7 +3376,7 @@ msgstr "Sledování"
 msgid "More Characters"
 msgstr "Více znaků"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Více…"
 
@@ -3463,8 +3468,8 @@ msgstr "NT doména"
 msgid "NTP server candidates"
 msgstr "Kandidáti NTP serveru"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3485,8 +3490,8 @@ msgstr "Navigace"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Síť"
@@ -3512,7 +3517,7 @@ msgstr "Nový název rozhraní…"
 msgid "Next »"
 msgstr "Další »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Ne"
@@ -3533,7 +3538,7 @@ msgstr "Žádné NAT-T"
 msgid "No data received"
 msgstr "Nebyla přijata žádná data"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "V tomto adresáři nejsou žádné položky"
 
@@ -3573,7 +3578,7 @@ msgstr "Dosud nebyly definovány žádné protistrany"
 msgid "No public keys present yet."
 msgstr "Zatím nejsou k dispozici žádné veřejné klíče."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "V tomto řetězci nejsou žádná pravidla."
 
@@ -3735,11 +3740,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Provozní frekvence"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Volba změněna"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Volba odstraněna"
 
@@ -3814,7 +3819,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Volitelné. Port UDP používaný pro odchozí a příchozí pakety."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Možnosti"
 
@@ -3822,7 +3827,7 @@ msgstr "Možnosti"
 msgid "Other:"
 msgstr "Ostatní:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Ven"
 
@@ -3894,7 +3899,7 @@ msgstr "Přepsat tabulku, používanou pro vnitřní cesty"
 msgid "Overview"
 msgstr "Přehled"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Přepsat existující soubor \"%s\"?"
 
@@ -3995,7 +4000,7 @@ msgstr "Bitová délka PSID"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (režim přenosu paketů)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pakety"
 
@@ -4129,7 +4134,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "paketů"
 
@@ -4137,11 +4142,11 @@ msgstr "paketů"
 msgid "Please enter your username and password."
 msgstr "Prosím vložte vaše uživatelské jméno a heslo."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Vyberte soubor, který chcete nahrát."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Politika"
 
@@ -4211,7 +4216,7 @@ msgid "Private Key"
 msgstr "Soukromý klíč"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Procesy"
 
@@ -4219,7 +4224,7 @@ msgstr "Procesy"
 msgid "Profile"
 msgstr "Profil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4355,7 +4360,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Opravdu prohodit protokol?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Grafy v reálném čase"
 
@@ -4395,7 +4400,7 @@ msgstr "Doporučeno. IP adresy rozhraní WireGuard."
 msgid "Reconnect this interface"
 msgstr "Přepojit toto rozhraní"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Reference"
 
@@ -4543,7 +4548,7 @@ msgstr "Vyžaduje wpa-supplicant s podporou SAE"
 msgid "Reset"
 msgstr "Reset"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Resetovat čítače"
 
@@ -4570,7 +4575,7 @@ msgstr "Zdroj nebyl nalezen"
 msgid "Restart"
 msgstr "Restart"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Restartovat firewall"
 
@@ -4591,19 +4596,19 @@ msgstr "Obnovit ze zálohy"
 msgid "Reveal/hide password"
 msgstr "Odhalit/skrýt heslo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Vrátit zpět"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Vrátit změny"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Požadavek na vrácení se nezdařil se stavem <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Vracení konfigurace…"
 
@@ -4637,8 +4642,8 @@ msgid "Router Password"
 msgstr "Heslo routeru"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Trasy"
 
@@ -4649,7 +4654,7 @@ msgid ""
 msgstr ""
 "Trasy určují, přes jaké rozhraní a bránu může být konkrétního hosta dosaženo."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Pravidlo"
 
@@ -4706,7 +4711,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "Odkládací soubor/oddíl"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4717,7 +4722,7 @@ msgid "Save"
 msgstr "Uložit"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Uložit & použít"
@@ -4739,11 +4744,11 @@ msgstr "Skenovat"
 msgid "Scheduled Tasks"
 msgstr "Naplánované úlohy"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Přidána sekce"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Sekce odebrána"
 
@@ -4761,9 +4766,9 @@ msgstr ""
 "kontrola formátu firmware. Použijte, pouze pokud jste si jisti, že firmware "
 "je správný a určený pro vaše zařízení!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Vybrat soubor…"
 
@@ -4851,7 +4856,7 @@ msgstr "Krátká preambule"
 msgid "Show current backup file list"
 msgstr "Ukázat aktuální seznam záložních souborů"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Zobrazit prázdné řetězy"
 
@@ -4881,7 +4886,7 @@ msgstr "Útlum signálu (SATN)"
 msgid "Signal:"
 msgstr "Signál:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Velikost"
@@ -4908,7 +4913,7 @@ msgid "Skip to navigation"
 msgstr "Skočit na navigaci"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "Software VLAN"
 
@@ -4935,8 +4940,8 @@ msgstr ""
 "wiki pro zařízení specifické instalační instrukce."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Zdroj"
 
@@ -5006,7 +5011,7 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Priorita spouštění"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Provádění konfiguračních změn…"
 
@@ -5037,7 +5042,7 @@ msgstr "Statické trasy"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Statická adresa"
 
@@ -5119,7 +5124,7 @@ msgid "Switch Speed Mask"
 msgstr "Maska rychlosti přepínače"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Switch VLAN"
 
@@ -5133,7 +5138,7 @@ msgstr "Směrovací protokol"
 msgid "Switch to CIDR list notation"
 msgstr "Přepnout na notaci seznamu CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Symbolický odkaz"
 
@@ -5152,8 +5157,8 @@ msgstr "Synchronizovat s prohlížečem"
 msgid "System"
 msgstr "Systém"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Systémový log"
 
@@ -5186,16 +5191,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Rychlost TX"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabulka"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Cíl"
 
@@ -5242,7 +5247,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "Konfigurační soubor nelze načíst z důvodu následující chyby:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5286,7 +5291,7 @@ msgstr ""
 "souboru. Porovnejte je s originálním souborem pro zajištění integrity dat. "
 "<br /> Klepněte na \"Pokračovat\" níže pro zahájení procedury flashování."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Následující pravidla jsou nyní na tomto systému aktivní."
 
@@ -5437,7 +5442,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Žádné aktivní zápůjčky"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Žádné změny k provedení"
 
@@ -5551,8 +5556,8 @@ msgstr ""
 "V tomto seznamu vidíte přehled aktuálně běžících systémových procesů a "
 "jejich stavy."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5598,9 +5603,9 @@ msgstr "Dostupná celkem"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Provoz"
 
@@ -5625,7 +5630,7 @@ msgid "Tunnel ID"
 msgstr "ID tunelu"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Rozhraní tunelu"
 
@@ -5692,6 +5697,11 @@ msgstr "Nelze určit odchozí WAN rozhraní"
 msgid "Unable to dispatch"
 msgstr "Nelze odeslat"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5703,6 +5713,14 @@ msgstr "Nelze získat ID klienta"
 msgid "Unable to obtain mount information"
 msgstr "Nelze získat informace o připojených svazcích"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5712,6 +5730,10 @@ msgstr "Nelze přeložit AFTR název hostitele"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Nelze přeložit název hostitele druhé strany"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5728,12 +5750,12 @@ msgid "Unexpected reply data format"
 msgstr "Neočekávaný formát dat odpovědi"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Neznámý"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Neznámá chyba (%s)"
 
@@ -5743,7 +5765,7 @@ msgstr "Neznámý chybový kód"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Nespravovaný"
 
@@ -5757,7 +5779,7 @@ msgstr "Odpojit"
 msgid "Unnamed key"
 msgstr "Nepojmenovaný klíč"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Neuložené změny"
 
@@ -5783,7 +5805,7 @@ msgstr "Nepodporovaný typ protokolu."
 msgid "Up"
 msgstr "Nahoru"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Nahrát"
 
@@ -5800,21 +5822,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Nahrát archiv..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Nahrát soubor"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Nahrát soubor…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Požadavek na nahrání selhal: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Nahrávání souboru…"
 
@@ -6120,19 +6142,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Bezdrátová síť"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Bezdrátový adaptér"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Bezdrátová síť"
 
@@ -6176,7 +6198,7 @@ msgstr "Zapisovat přijaté požadavky DNS do systemového logu"
 msgid "Write system log to file"
 msgstr "Zapisovat systémový protokol do souboru"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Ano"
@@ -6398,7 +6420,7 @@ msgstr "žádné spojení"
 msgid "non-empty value"
 msgstr "neprázdná hodnota"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "žádný"
 
@@ -6506,7 +6528,7 @@ msgstr "neznámý"
 msgid "unlimited"
 msgstr "neomezený"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d ungültige Felder"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- Zusätzliches Feld --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- Bitte auswählen --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- benutzerdefiniert --"
@@ -171,12 +171,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Addresse"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 
@@ -212,7 +210,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-Adresse"
 
@@ -250,7 +247,7 @@ msgstr ""
 "<br/>Hinweis: Der Cron-Dienst muss manuell neu gestartet werden wenn die "
 "Crontab-Datei vor der Bearbeitung leer war."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Es existiert bereits ein Verzeichnis mit dem gleichen Namen."
 
@@ -281,6 +278,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -343,11 +344,11 @@ msgstr "Zugangspunkt"
 msgid "Actions"
 msgstr "Aktionen"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routen"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routen"
 
@@ -371,11 +372,11 @@ msgstr "Aktive DHCPv6-Leases"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -479,7 +480,7 @@ msgid "Alert"
 msgstr "Alarm"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Alias-Schnittstelle"
@@ -667,18 +668,18 @@ msgstr "Beliebige Zone"
 msgid "Apply backup?"
 msgstr "Backup anwenden?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 "Anforderung zur Anwendung der Änderungen mit Status <code>%h</code> "
 "fehlgeschlagen"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Ungeprüft übernehmen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Warte auf das Anwenden der Konfiguration… %ds"
 
@@ -892,7 +893,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Ungültige \"NX-Domain\" Antworten ignorieren"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Bridge"
 
@@ -909,8 +910,8 @@ msgstr "Geräteindex der Brücke"
 msgid "Bring up on boot"
 msgstr "Während des Bootvorgangs starten"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Durchsuchen…"
 
@@ -943,8 +944,8 @@ msgstr "Im Cache"
 msgid "Call failed"
 msgstr "Anruf fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -960,17 +961,17 @@ msgstr "Abbrechen"
 msgid "Category"
 msgstr "Kategorie"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Kette (Chain)"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Änderungen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Änderungen wurden verworfen."
 
@@ -1092,7 +1093,8 @@ msgstr "Schließe Liste..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Sammle Daten..."
@@ -1109,7 +1111,7 @@ msgstr "Kommando OK"
 msgid "Command failed"
 msgstr "Befehl fehlgeschlagen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1125,16 +1127,16 @@ msgstr ""
 "Kompatibilitätsprobleme verursachen und die Zuverlässigkeit von "
 "Schlüsselerneuerungen in ausgelasteten Umgebungen verringern."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "Die Konfiguration wurde angewendet."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "Die Konfiguration wurde zurückgerollt!"
 
@@ -1165,7 +1167,7 @@ msgstr "Verbindungsversuch fehlgeschlagen"
 msgid "Connection lost"
 msgstr "Verbindung verloren"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Verbindungen"
 
@@ -1181,7 +1183,7 @@ msgstr "Inhalte wurden gespeichert."
 msgid "Continue"
 msgstr "Fortfahren"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1274,7 +1276,7 @@ msgstr "DHCP und DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP Client"
 
@@ -1400,11 +1402,11 @@ msgstr ""
 "Definiert zusätzliche DHCP-Optionen, z.B. \"<code>6,192.168.2.1,192.168.2.2</"
 "code>\" um einen anderen DNS-Server an Clients zu verteilen."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1416,7 +1418,7 @@ msgstr "Löschen"
 msgid "Delete key"
 msgstr "Schlüssel löschen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Löschauftrag fehlgeschlagen: %s"
 
@@ -1432,7 +1434,7 @@ msgstr "DTIM (Delivery Traffic Indication) Nachrichtenintervall"
 msgid "Description"
 msgstr "Beschreibung"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Abwählen"
 
@@ -1441,7 +1443,7 @@ msgid "Design"
 msgstr "Design"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Ziel"
 
@@ -1477,7 +1479,7 @@ msgstr "Netzwerkadapter ist nicht aktiv"
 msgid "Device is restarting…"
 msgstr "Netzwerkadapter startet neu…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Das Gerät ist nicht erreichbar!"
 
@@ -1494,7 +1496,7 @@ msgstr "Diagnosen"
 msgid "Dial number"
 msgstr "Einwahlnummer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Verzeichnis"
 
@@ -1561,10 +1563,10 @@ msgstr "Trennen"
 msgid "Disconnection attempt failed"
 msgstr "Verbindungstrennung fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1607,7 +1609,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Keine Rückwärtsauflösungen für lokale Netzwerke weiterleiten"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Soll \"%s\" wirklich gelöscht werden?"
 
@@ -1620,7 +1622,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr "Möchten Sie wirklich alle Einstellungen löschen?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Soll das Verzeichnis \"%s\" wirklich rekursiv gelöscht werden?"
 
@@ -1660,7 +1662,7 @@ msgstr "Mtdblock-Datei herunterladen"
 msgid "Downstream SNR offset"
 msgstr "Downstream SNR-Offset"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Ziehen zum Umsortieren"
 
@@ -1707,9 +1709,9 @@ msgstr "EA-Bitlänge"
 msgid "EAP-Method"
 msgstr "EAP-Methode"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1902,12 +1904,12 @@ msgid "Errored seconds (ES)"
 msgstr "Fehlersekunden (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Netzwerkschnittstelle"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Netzwerk Switch"
 
@@ -1989,7 +1991,7 @@ msgstr "FT Protokoll"
 msgid "Failed to change the system password."
 msgstr "Das Systempasswort konnte nicht geändert werden."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "Konnte nicht innerhalb von %d Sekunden bestätigen, warte auf Zurückrollen "
@@ -1999,15 +2001,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Fehler beim Ausführen der Aktion \"/etc/init.d/%s %s\": %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Datei"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Datei nicht verfügbar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Dateiname"
 
@@ -2061,7 +2063,7 @@ msgstr "Firewall Mark"
 msgid "Firewall Settings"
 msgstr "Firewall Einstellungen"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Firewall-Status"
 
@@ -2253,8 +2255,8 @@ msgstr "Globale Netzwerkeinstellungen"
 msgid "Go to password configuration..."
 msgstr "Zur Passwortkonfiguration..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2297,8 +2299,8 @@ msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr> verstecken"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Leere Chains ausblenden"
 
@@ -2388,7 +2390,7 @@ msgstr "IP-Adresse fehlt"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 Firewall"
 
@@ -2439,8 +2441,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-Adresse"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2467,11 +2474,11 @@ msgstr "IPv4/IPv6 (beide - standardmäßig IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 Firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "IPv6 Nachbarn"
 
@@ -2534,7 +2541,7 @@ msgstr "IPv6 Endung"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-Adresse"
 
@@ -2648,7 +2655,7 @@ msgstr "Resolv-Datei ignorieren"
 msgid "Image"
 msgstr "Image"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Ein"
 
@@ -2704,8 +2711,8 @@ msgstr "Installiere Protokoll-Erweiterungen..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Schnittstelle"
@@ -2838,8 +2845,8 @@ msgstr "Trete Netzwerk %q bei"
 msgid "Keep settings and retain the current configuration"
 msgstr "Einstellungen beibehalten und die aktuelle Konfiguration sichern"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Kernelprotokoll"
 
@@ -2921,18 +2928,15 @@ msgid "Lease time"
 msgstr "Laufzeit"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Verbleibende Gültigkeit"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Leasedatei"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2947,7 +2951,7 @@ msgstr "Zur automatischen Erkennung leer lassen"
 msgid "Leave empty to use the current WAN address"
 msgstr "Leer lassen um die aktuelle WAN-Adresse zu verwenden"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Legende:"
 
@@ -3054,7 +3058,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Serverport für eingehende DNS Abfragen"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Last"
 
@@ -3062,7 +3066,7 @@ msgstr "Last"
 msgid "Load Average"
 msgstr "Durchschnittslast"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Lade Verzeichniseinträge…"
 
@@ -3180,7 +3184,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-Adresse"
 
@@ -3320,8 +3325,8 @@ msgid "Method not found"
 msgstr "Methode nicht gefunden"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrik"
@@ -3392,7 +3397,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr "Mehr Zeichen"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Mehr…"
 
@@ -3483,8 +3488,8 @@ msgstr "NT-Domäne"
 msgid "NTP server candidates"
 msgstr "NTP Server Kandidaten"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3505,8 +3510,8 @@ msgstr "Navigation"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Netzwerk"
@@ -3532,7 +3537,7 @@ msgstr "Name der neuen Schnittstelle…"
 msgid "Next »"
 msgstr "Weiter »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Nein"
@@ -3553,7 +3558,7 @@ msgstr "Kein NAT-T"
 msgid "No data received"
 msgstr "Keine Daten empfangen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "Keine Einträge in diesem Verzeichnis"
 
@@ -3593,7 +3598,7 @@ msgstr "Noch keine Peers definiert"
 msgid "No public keys present yet."
 msgstr "Bisher keine SSH-Schlüssel hinterlegt."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Keine Regeln in dieser Kette."
 
@@ -3756,11 +3761,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Betriebsfrequenz"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Option geändert"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Option entfernt"
 
@@ -3835,7 +3840,7 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 "Optional. Benutzte UDP-Port-Nummer für ausgehende und eingehende Pakete."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Optionen"
 
@@ -3843,7 +3848,7 @@ msgstr "Optionen"
 msgid "Other:"
 msgstr "Andere:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Aus"
 
@@ -3915,7 +3920,7 @@ msgstr "Überschreibt die benutzte Tabelle für interne Routen"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Existierende Datei \"%s\" überschreiben?"
 
@@ -4016,7 +4021,7 @@ msgstr "PSID-Bitlänge"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Paket-Transfer-Modus)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pakete"
 
@@ -4150,7 +4155,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pkte."
 
@@ -4158,11 +4163,11 @@ msgstr "Pkte."
 msgid "Please enter your username and password."
 msgstr "Bitte Benutzernamen und Passwort eingeben."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Bitte wählen Sie die hochzuladende Datei aus."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Standardregel"
 
@@ -4232,7 +4237,7 @@ msgid "Private Key"
 msgstr "Privater Schlüssel"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Prozesse"
 
@@ -4240,7 +4245,7 @@ msgstr "Prozesse"
 msgid "Profile"
 msgstr "Profil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4381,7 +4386,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Protokoll wirklich wechseln?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Echtzeit-Diagramme"
 
@@ -4421,7 +4426,7 @@ msgstr "Empfohlen. IP-Adresse der WireGuard-Schnittstelle."
 msgid "Reconnect this interface"
 msgstr "Diese Schnittstelle neu verbinden"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Verweise"
 
@@ -4569,7 +4574,7 @@ msgstr "Benötigt \"wpa-supplicant\" mit SAE-Support"
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Zähler zurücksetzen"
 
@@ -4596,7 +4601,7 @@ msgstr "Resource nicht gefunden"
 msgid "Restart"
 msgstr "Neustarten"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Firewall neu starten"
 
@@ -4617,19 +4622,19 @@ msgstr "Sicherung wiederherstellen"
 msgid "Reveal/hide password"
 msgstr "Passwort zeigen/verstecken"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Verwerfen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Änderungen verwerfen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Anforderung zum Verwerfen mit Status <code>%h</code> fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Verwerfe Konfigurationsänderungen…"
 
@@ -4663,8 +4668,8 @@ msgid "Router Password"
 msgstr "Routerpasswort"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Routen"
 
@@ -4676,7 +4681,7 @@ msgstr ""
 "Netzwerkrouten geben an, über welche Schnittstellen bestimmte Rechner oder "
 "Netzwerke erreicht werden können."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Regel"
 
@@ -4733,7 +4738,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4744,7 +4749,7 @@ msgid "Save"
 msgstr "Speichern"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Speichern & Anwenden"
@@ -4766,11 +4771,11 @@ msgstr "Suche"
 msgid "Scheduled Tasks"
 msgstr "Geplante Aufgaben"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Sektion hinzugefügt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Sektion entfernt"
 
@@ -4788,9 +4793,9 @@ msgstr ""
 "wenn die Formatüberprüfung fehlschlägt. Diese Option nur benutzen wenn das "
 "Abbild korrekt und für dieses Gerät bestimmt ist!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Datei auswählen…"
 
@@ -4879,7 +4884,7 @@ msgstr "Kurze Präambel"
 msgid "Show current backup file list"
 msgstr "Zeige aktuelle Liste der gesicherten Dateien"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Leere Chains anzeigen"
 
@@ -4909,7 +4914,7 @@ msgstr "Signaldämpfung (SATN)"
 msgid "Signal:"
 msgstr "Signal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Größe"
@@ -4936,7 +4941,7 @@ msgid "Skip to navigation"
 msgstr "Zur Navigation springen"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "Software-VLAN"
 
@@ -4964,8 +4969,8 @@ msgstr ""
 "Installationsanleitungen entnehmen Sie bitte dem Wiki."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Quelle"
 
@@ -5037,7 +5042,7 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Startpriorität"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Starte Anwendung der Konfigurationsänderungen…"
 
@@ -5068,7 +5073,7 @@ msgstr "Statische Routen"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Statische Adresse"
 
@@ -5151,7 +5156,7 @@ msgid "Switch Speed Mask"
 msgstr "Switch-Geschwindigkeits-Maske"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Switch-VLAN"
 
@@ -5165,7 +5170,7 @@ msgstr "Wechsle Protokoll"
 msgid "Switch to CIDR list notation"
 msgstr "Auf CIDR-Listen-Notation wechseln"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Symbolischer Link"
 
@@ -5184,8 +5189,8 @@ msgstr "Mit Browser synchronisieren"
 msgid "System"
 msgstr "System"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Systemprotokoll"
 
@@ -5219,16 +5224,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "TX-Rate"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabelle"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Ziel"
 
@@ -5280,7 +5285,7 @@ msgstr ""
 "Die Konfigurationsdatei konnte aufgrund der folgenden Fehler nicht geladen "
 "werden:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5327,7 +5332,7 @@ msgstr ""
 "zu gewährleisten.<br />Auf \"Fortfahren\" klicken um den Schreibvorgang zu "
 "starten."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Die folgenden Regeln sind zur Zeit auf dem System aktiv."
 
@@ -5487,7 +5492,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Es gibt keine aktiven Leases"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Es gibt keine anzuwendenden Änderungen"
 
@@ -5602,8 +5607,8 @@ msgstr ""
 "Diese Tabelle gibt eine Übersicht über aktuell laufende Systemprozesse und "
 "deren Status."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5651,9 +5656,9 @@ msgid "Traceroute"
 msgstr "Routenverfolgung"
 
 # Ich bin der Meinung Traffic versteht jeder! Wenn der Begriff "deutscher" sein soll, würde ich "Datenmenge" angeben. Aber "Verkehrs" passt nicht!
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Traffic"
 
@@ -5678,7 +5683,7 @@ msgid "Tunnel ID"
 msgstr "Tunnel-ID"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Tunnelschnittstelle"
 
@@ -5745,6 +5750,11 @@ msgstr "Externe Netzwerkschnittstelle konnte nicht bestimmt werden"
 msgid "Unable to dispatch"
 msgstr "Kann Anfrage nicht zustellen"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5756,6 +5766,14 @@ msgstr "Client-ID konnte nicht bezogen werden"
 msgid "Unable to obtain mount information"
 msgstr "Die Mountinformationen können nicht ermittelt werden"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5765,6 +5783,10 @@ msgstr "Der AFTR-Hostname konnte nicht aufgelöst werden"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Der Name des entfernten Hosts konnte nicht aufgelöst werden"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5781,12 +5803,12 @@ msgid "Unexpected reply data format"
 msgstr "Unerwartetes Antwortdatenformat"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Unbekannt"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Protokollfehler: %s"
 
@@ -5796,7 +5818,7 @@ msgstr "Unbekannter Fehlercode"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Ignoriert"
 
@@ -5810,7 +5832,7 @@ msgstr "Aushängen"
 msgid "Unnamed key"
 msgstr "Unbenannter Schlüssel"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Ungespeicherte Änderungen"
 
@@ -5836,7 +5858,7 @@ msgstr "Nicht unterstützter Protokolltyp."
 msgid "Up"
 msgstr "Hoch"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Hochladen"
 
@@ -5853,21 +5875,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Backup wiederherstellen..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Datei hochladen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Datei hochladen…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Upload-Anfrage fehlgeschlagen: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Datei wird hochgeladen…"
 
@@ -6175,19 +6197,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "WLAN"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "WLAN-Gerät"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Drahtlosnetzwerk"
 
@@ -6231,7 +6253,7 @@ msgstr "Empfangene DNS-Anfragen in das Systemprotokoll schreiben"
 msgid "Write system log to file"
 msgstr "Systemprotokoll in Datei schreiben"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Ja"
@@ -6455,7 +6477,7 @@ msgstr "nicht verbunden"
 msgid "non-empty value"
 msgstr "nicht-leeren Wert"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "keine"
 
@@ -6563,7 +6585,7 @@ msgstr "unbekannt"
 msgid "unlimited"
 msgstr "unbegrenzt"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -22,7 +22,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d μη έγκυρο/α πεδίο/α"
 
@@ -58,11 +58,11 @@ msgid "-- Additional Field --"
 msgstr "-- Επιπλέον Πεδίο --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -70,7 +70,7 @@ msgstr "-- Παρακαλώ επιλέξτε --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- προσαρμοσμένο --"
@@ -169,12 +169,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Διεύθυνση <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "Πύλη <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
@@ -209,7 +207,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Όνομα <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Διεύθυνση <abbr title=\"Media Access Control\">MAC</abbr>"
 
@@ -243,7 +240,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Ένας φάκελος με το ίδιο όνομα υπάρχει ήδη."
 
@@ -273,6 +270,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -335,12 +336,12 @@ msgstr "Σημείο Πρόσβασης"
 msgid "Actions"
 msgstr "Ενέργειες"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Ενεργές Διαδρομές <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Ενεργές Διαδρομές <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
@@ -365,11 +366,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -474,7 +475,7 @@ msgid "Alert"
 msgstr "Ειδοποίηση"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -655,16 +656,16 @@ msgstr "Οιαδήποτε ζώνη"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -871,7 +872,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Παράκαμψη Ψευδούς Τομέα NX"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Γέφυρα"
 
@@ -888,8 +889,8 @@ msgstr "Αριθμός μονάδας γέφυρας"
 msgid "Bring up on boot"
 msgstr "Ανέβασμα κατά την εκκίνηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -920,8 +921,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -937,17 +938,17 @@ msgstr "Ακύρωση"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Αλυσίδα"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Αλλαγές"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1064,7 +1065,8 @@ msgstr "Κλείσιμο λίστας..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Συλλογή δεδομένων..."
@@ -1081,7 +1083,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1093,16 +1095,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Διαμόρφωση"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1133,7 +1135,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Συνδέσεις"
 
@@ -1149,7 +1151,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1235,7 +1237,7 @@ msgstr "DHCP και DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Πελάτης DHCP"
 
@@ -1361,11 +1363,11 @@ msgstr ""
 "Ορίστε επιπλέον επιλογές DHCP, που διαφημίζουν διαφορετικούς εξυπηρετητές "
 "DNS στους πελάτες, για παράδειγμα \"<code>6,192.168.2.1,192.168.2.2</code>\"."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1377,7 +1379,7 @@ msgstr "Διαγραφή"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1393,7 +1395,7 @@ msgstr ""
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1402,7 +1404,7 @@ msgid "Design"
 msgstr "Εμφάνιση"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Προορισμός"
 
@@ -1438,7 +1440,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1455,7 +1457,7 @@ msgstr "Διαγνωστικά"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Φάκελος"
 
@@ -1522,10 +1524,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1567,7 +1569,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1579,7 +1581,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1619,7 +1621,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1666,9 +1668,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Μέθοδος EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1855,12 +1857,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Προσαρμογέας Ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet Switch"
 
@@ -1943,7 +1945,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1951,15 +1953,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Αρχείο"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -2011,7 +2013,7 @@ msgstr "Σημάδι τείχους προστασίας"
 msgid "Firewall Settings"
 msgstr "Ρυθμίσεις Τείχους Προστασίας"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Κατάσταση Τείχους Προστασίας"
 
@@ -2199,8 +2201,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2242,8 +2244,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Κρυφό <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2334,7 +2336,7 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 Τείχος Προστασίας"
 
@@ -2385,8 +2387,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-Διεύθυνση"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2413,11 +2420,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 Τείχος Προστασίας"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2480,7 +2487,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2596,7 +2603,7 @@ msgstr "Αγνόησε αρχείο resolve"
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Είσοδος"
 
@@ -2649,8 +2656,8 @@ msgstr "Εγκατάσταση επεκτάσεων πρωτοκόλλου..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Διεπαφή"
@@ -2782,8 +2789,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Καταγραφή Πυρήνα"
 
@@ -2865,18 +2872,15 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Υπόλοιπο χρόνου Lease"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Αρχείο Leases"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2891,7 +2895,7 @@ msgstr "Αφήστε το κενό για να γίνει αυτόματη αν�
 msgid "Leave empty to use the current WAN address"
 msgstr "Αφήστε το κενό για να γίνει χρήση της τρέχουσας διεύθυνσης WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Υπόμνημα:"
 
@@ -2980,7 +2984,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Φόρτος"
 
@@ -2988,7 +2992,7 @@ msgstr "Φόρτος"
 msgid "Load Average"
 msgstr "Μέσος όρος φόρτου"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3099,7 +3103,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-Διεύθυνση"
 
@@ -3240,8 +3245,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Μέτρο"
@@ -3312,7 +3317,7 @@ msgstr "Παρακολούθηση"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3403,8 +3408,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3425,8 +3430,8 @@ msgstr "Πλοήγηση"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Δίκτυο"
@@ -3452,7 +3457,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Επόμενο »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3473,7 +3478,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3513,7 +3518,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Δεν υπάρχει κανόνας σε αυτή την αλυσίδα."
 
@@ -3674,11 +3679,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Η επιλογή άλλαξε"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Η επιλογή αφαιρέθηκε"
 
@@ -3739,7 +3744,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Επιλογές"
 
@@ -3747,7 +3752,7 @@ msgstr "Επιλογές"
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Έξοδος"
 
@@ -3817,7 +3822,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Επισκόπηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3918,7 +3923,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Πακέτα"
 
@@ -4052,7 +4057,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Πκτ."
 
@@ -4060,11 +4065,11 @@ msgstr "Πκτ."
 msgid "Please enter your username and password."
 msgstr "Παρακαλώ εισάγετε όνομα χρήστη και κωδικό πρόσβασης."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Πολιτική"
 
@@ -4133,7 +4138,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Εργασίες"
 
@@ -4141,7 +4146,7 @@ msgstr "Εργασίες"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Πρωτ."
 
@@ -4269,7 +4274,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Αλλαγή πρωτοκόλλου;"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Γραφήματα πραγματικού χρόνου"
 
@@ -4309,7 +4314,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "Επανασύνδεση της διεπαφής"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Αναφορές"
 
@@ -4448,7 +4453,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Αρχικοποίηση"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Αρχικοποίηση Μετρητών"
 
@@ -4475,7 +4480,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Επανεκκίνηση"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Επανεκκίνηση Τείχους Προστασίας"
 
@@ -4496,19 +4501,19 @@ msgstr "Επαναφορά αντιγράφου ασφαλείας"
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Αναίρεση"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4542,8 +4547,8 @@ msgid "Router Password"
 msgstr "Κωδικός Πρόσβασης Δρομολογητή"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 #, fuzzy
 msgid "Routes"
 msgstr "Διαδρομές"
@@ -4556,7 +4561,7 @@ msgstr ""
 "Οι διαδρομές ορίζουν τη διεπαφή και πύλη από την οποία κάποιος υπολογιστής ή "
 "δίκτυο μπορεί να είναι προσβάσιμο/ς."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4613,7 +4618,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4624,7 +4629,7 @@ msgid "Save"
 msgstr "Αποθήκευση"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Αποθήκευση & Εφαρμογή"
@@ -4646,11 +4651,11 @@ msgstr "Σάρωση"
 msgid "Scheduled Tasks"
 msgstr "Προγραμματισμένες Εργασίες"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4665,9 +4670,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4751,7 +4756,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4781,7 +4786,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Σήμα:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Μέγεθος"
@@ -4808,7 +4813,7 @@ msgid "Skip to navigation"
 msgstr "Παράκαμψη σε πλοήγηση"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4832,8 +4837,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Πηγή"
 
@@ -4894,7 +4899,7 @@ msgstr "Αρχή"
 msgid "Start priority"
 msgstr "Προτεραιότητα εκκίνησης"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4925,7 +4930,7 @@ msgstr "Στατικές Διαδρομές"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Στατική διεύθυνση"
 
@@ -5001,7 +5006,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -5015,7 +5020,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -5034,8 +5039,8 @@ msgstr ""
 msgid "System"
 msgstr "Σύστημα"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Καταγραφή Συστήματος"
 
@@ -5068,16 +5073,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Πίνακας"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Στόχος"
 
@@ -5122,7 +5127,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5155,7 +5160,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Οι παρακάτω κανόνες είναι αυτή τη στιγμή ενεργοί σε αυτό το σύστημα."
 
@@ -5291,7 +5296,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5385,8 +5390,8 @@ msgstr ""
 "Αυτή η λίστα δίνει μία εικόνα των τρέχοντων εργασιών συστήματος και της "
 "κατάστασής τους."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5433,9 +5438,9 @@ msgstr "Διαθέσιμο Συνολικά"
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Κίνηση"
 
@@ -5460,7 +5465,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Διεπαφή Τούνελ"
 
@@ -5527,6 +5532,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5538,6 +5548,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5546,6 +5564,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5563,12 +5585,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Άγνωστο"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5578,7 +5600,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5592,7 +5614,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Μη-αποθηκευμένες Αλλαγές"
 
@@ -5618,7 +5640,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5633,21 +5655,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5937,19 +5959,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Ασύρματο"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Ασύρματος Προσαρμογέας"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Ασύρματο Δίκτυο"
 
@@ -5993,7 +6015,7 @@ msgstr "Καταγραφή των ληφθέντων DNS αιτήσεων στο
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6215,7 +6237,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "κανένα"
 
@@ -6323,7 +6345,7 @@ msgstr ""
 msgid "unlimited"
 msgstr "απεριόριστα"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -58,11 +58,11 @@ msgid "-- Additional Field --"
 msgstr "-- Additional Field --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -70,7 +70,7 @@ msgstr "-- Please choose --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- custom --"
@@ -169,12 +169,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 
@@ -209,7 +207,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 
@@ -243,7 +240,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -273,6 +270,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -335,11 +336,11 @@ msgstr "Access Point"
 msgid "Actions"
 msgstr "Actions"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 
@@ -363,11 +364,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -471,7 +472,7 @@ msgid "Alert"
 msgstr "Alert"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -646,16 +647,16 @@ msgstr "Any zone"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -861,7 +862,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Bogus NX Domain Override"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Bridge"
 
@@ -878,8 +879,8 @@ msgstr "Bridge unit number"
 msgid "Bring up on boot"
 msgstr "Bring up on boot"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -910,8 +911,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -927,17 +928,17 @@ msgstr "Cancel"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Chain"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Changes"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1053,7 +1054,8 @@ msgstr "Close list..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Collecting data..."
@@ -1070,7 +1072,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1082,16 +1084,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configuration"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1122,7 +1124,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Connections"
 
@@ -1138,7 +1140,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1224,7 +1226,7 @@ msgstr "DHCP and DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP client"
 
@@ -1351,11 +1353,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" which advertises different DNS "
 "servers to clients."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1367,7 +1369,7 @@ msgstr "Delete"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1383,7 +1385,7 @@ msgstr ""
 msgid "Description"
 msgstr "Description"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1392,7 +1394,7 @@ msgid "Design"
 msgstr "Design"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destination"
 
@@ -1428,7 +1430,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1445,7 +1447,7 @@ msgstr "Diagnostics"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Directory"
 
@@ -1510,10 +1512,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1551,7 +1553,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1563,7 +1565,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1603,7 +1605,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1647,9 +1649,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-Method"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1836,12 +1838,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernet Adapter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet Switch"
 
@@ -1921,7 +1923,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1929,15 +1931,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1989,7 +1991,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "Firewall Settings"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Firewall Status"
 
@@ -2175,8 +2177,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2218,8 +2220,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2309,7 +2311,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2360,7 +2362,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2388,11 +2395,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2455,7 +2462,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2566,7 +2573,7 @@ msgstr "Ignore resolve file"
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "In"
 
@@ -2619,8 +2626,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
@@ -2752,8 +2759,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Kernel Log"
 
@@ -2835,18 +2842,15 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Lease time remaining"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Leasefile"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2950,7 +2954,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Load"
 
@@ -2958,7 +2962,7 @@ msgstr "Load"
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3069,7 +3073,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3209,8 +3214,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metric"
@@ -3281,7 +3286,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3372,8 +3377,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3394,8 +3399,8 @@ msgstr "Navigation"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Network"
@@ -3421,7 +3426,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3442,7 +3447,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3482,7 +3487,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "No rules in this chain."
 
@@ -3643,11 +3648,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3708,7 +3713,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Options"
 
@@ -3716,7 +3721,7 @@ msgstr "Options"
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Out"
 
@@ -3786,7 +3791,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Overview"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3887,7 +3892,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Packets"
 
@@ -4021,7 +4026,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pkts."
 
@@ -4029,11 +4034,11 @@ msgstr "Pkts."
 msgid "Please enter your username and password."
 msgstr "Please enter your username and password."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Policy"
 
@@ -4101,7 +4106,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Processes"
 
@@ -4109,7 +4114,7 @@ msgstr "Processes"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4237,7 +4242,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4277,7 +4282,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "References"
 
@@ -4416,7 +4421,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Reset"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Reset Counters"
 
@@ -4443,7 +4448,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Restart"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Restart Firewall"
 
@@ -4464,19 +4469,19 @@ msgstr "Restore backup"
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Revert"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4510,8 +4515,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Routes"
 
@@ -4523,7 +4528,7 @@ msgstr ""
 "Routes specify over which interface and gateway a certain host or network "
 "can be reached."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4580,7 +4585,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4591,7 +4596,7 @@ msgid "Save"
 msgstr "Save"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Save & Apply"
@@ -4613,11 +4618,11 @@ msgstr "Scan"
 msgid "Scheduled Tasks"
 msgstr "Scheduled Tasks"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4632,9 +4637,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4718,7 +4723,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4748,7 +4753,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Size"
@@ -4775,7 +4780,7 @@ msgid "Skip to navigation"
 msgstr "Skip to navigation"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4799,8 +4804,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Source"
 
@@ -4861,7 +4866,7 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Start priority"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4892,7 +4897,7 @@ msgstr "Static Routes"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4968,7 +4973,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4982,7 +4987,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -5001,8 +5006,8 @@ msgstr ""
 msgid "System"
 msgstr "System"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "System Log"
 
@@ -5035,16 +5040,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Table"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Target"
 
@@ -5087,7 +5092,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5120,7 +5125,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "The following rules are currently active on this system."
 
@@ -5256,7 +5261,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5348,8 +5353,8 @@ msgstr ""
 "This list gives an overview over currently running system processes and "
 "their status."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5395,9 +5400,9 @@ msgstr ""
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Traffic"
 
@@ -5422,7 +5427,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5489,6 +5494,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5500,6 +5510,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5508,6 +5526,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5525,12 +5547,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5540,7 +5562,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5554,7 +5576,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Unsaved Changes"
 
@@ -5580,7 +5602,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5595,21 +5617,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5901,19 +5923,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Wireless Adapter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Wireless Network"
 
@@ -5957,7 +5979,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6176,7 +6198,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "none"
 
@@ -6284,7 +6306,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d campo(s) inválido(s)"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- Campo adicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- Por favor elija --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- Personalizado --"
@@ -172,12 +172,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Dirección <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 "Puerta de enlace <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
@@ -213,7 +211,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Nombre del <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Dirección <abbr title=\"Media Access Control\">MAC</abbr>"
 
@@ -249,7 +246,7 @@ msgstr ""
 "<br/>Nota: debe reiniciar manualmente el servicio cron si el archivo crontab "
 "estaba vacío antes de editar."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Ya existe un directorio con el mismo nombre."
 
@@ -281,6 +278,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -343,11 +344,11 @@ msgstr "AP"
 msgid "Actions"
 msgstr "Acciones"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Rutas <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> activas"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Rutas <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> activas"
 
@@ -371,11 +372,11 @@ msgstr "Clientes DHCPv6 activos"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -481,7 +482,7 @@ msgid "Alert"
 msgstr "Alerta"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Apodo de interfaz"
@@ -667,16 +668,16 @@ msgstr "Cualquier zona"
 msgid "Apply backup?"
 msgstr "¿Aplicar respaldo?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Solicitud de aplicar fallida con estado <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Aplicar sin restricción"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Esperando a que se aplique la configuración… %ds"
 
@@ -893,7 +894,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Ignorar dominio falso NX"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Puente"
 
@@ -910,8 +911,8 @@ msgstr "Número de unidad del puente"
 msgid "Bring up on boot"
 msgstr "Iniciar en el arranque"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Explorar…"
 
@@ -943,8 +944,8 @@ msgstr "En caché"
 msgid "Call failed"
 msgstr "Llamada fallida"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -960,17 +961,17 @@ msgstr "Cancelar"
 msgid "Category"
 msgstr "Categoría"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Cadena"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Cambios"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Se revirtieron los cambios."
 
@@ -1090,7 +1091,8 @@ msgstr "Cerrar lista..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Recolectando datos…"
@@ -1107,7 +1109,7 @@ msgstr "Comando OK"
 msgid "Command failed"
 msgstr "Comando fallido"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Comentario"
 
@@ -1124,16 +1126,16 @@ msgstr ""
 "interoperabilidad y reducir la robustez de la negociación de claves, "
 "especialmente en entornos con una gran carga de tráfico."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configuración"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "Se ha aplicado la configuración."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "¡La configuración ha sido revertida!"
 
@@ -1164,7 +1166,7 @@ msgstr "Intento de conexión fallido"
 msgid "Connection lost"
 msgstr "Conexión perdida"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Conexiones"
 
@@ -1180,7 +1182,7 @@ msgstr "Los contenidos han sido guardados."
 msgid "Continue"
 msgstr "Continuar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1272,7 +1274,7 @@ msgstr "DHCP y DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Cliente DHCP"
 
@@ -1399,11 +1401,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" que publica diferentes servidores "
 "DNS a los clientes."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1415,7 +1417,7 @@ msgstr "Eliminar"
 msgid "Delete key"
 msgstr "Eliminar clave"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Error al eliminar la solicitud: %s"
 
@@ -1431,7 +1433,7 @@ msgstr "Intervalo de mensaje de indicación de tráfico de entrega"
 msgid "Description"
 msgstr "Descripción"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Deseleccionar"
 
@@ -1440,7 +1442,7 @@ msgid "Design"
 msgstr "Diseño"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destino"
 
@@ -1476,7 +1478,7 @@ msgstr "El dispositivo no está activo"
 msgid "Device is restarting…"
 msgstr "El dispositivo se está reiniciando…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Dispositivo inalcanzable!"
 
@@ -1493,7 +1495,7 @@ msgstr "Diagnósticos"
 msgid "Dial number"
 msgstr "Marcar el número"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Directorio"
 
@@ -1560,10 +1562,10 @@ msgstr "Desconectar"
 msgid "Disconnection attempt failed"
 msgstr "Intento de desconexión fallido"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1603,7 +1605,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "No reenviar búsquedas inversas para redes locales"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "¿Realmente quieres eliminar \"%s\" ?"
 
@@ -1615,7 +1617,7 @@ msgstr "¿Realmente quiere eliminar la siguiente clave SSH?"
 msgid "Do you really want to erase all settings?"
 msgstr "¿Realmente quieres borrar todos las configuraciones?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "¿Realmente desea eliminar recursivamente el directorio \"%s\" ?"
 
@@ -1655,7 +1657,7 @@ msgstr "Descargar mtdblock"
 msgid "Downstream SNR offset"
 msgstr "Desplazamiento SNR en sentido descendente"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Arrastrar para reordenar"
 
@@ -1701,9 +1703,9 @@ msgstr "Longitud de bits EA"
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1897,12 +1899,12 @@ msgid "Errored seconds (ES)"
 msgstr "Segundos errados (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Adaptador ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Switch ethernet"
 
@@ -1984,7 +1986,7 @@ msgstr "Protocolo FT"
 msgid "Failed to change the system password."
 msgstr "Error al cambiar la contraseña del sistema."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "Error al confirmar aplicar dentro de %ds. Esperando a que se reviertan los "
@@ -1994,15 +1996,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Error al ejecutar la acción \"/etc/init.d/%s%s\": %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Archivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Archivo no accesible"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Nombre del archivo"
 
@@ -2057,7 +2059,7 @@ msgstr "Marca de Firewall"
 msgid "Firewall Settings"
 msgstr "Configuración del Firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Estado del Firewall"
 
@@ -2247,8 +2249,8 @@ msgstr "Opciones globales de red"
 msgid "Go to password configuration..."
 msgstr "Ir a la configuración de la contraseña..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2290,8 +2292,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Ocultar <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Ocultar cadenas vacias"
 
@@ -2381,7 +2383,7 @@ msgstr "Falta la dirección IP"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Firewall IPv4"
 
@@ -2432,8 +2434,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Dirección IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2460,11 +2467,11 @@ msgstr "IPv4/IPv6 (ambos: el valor predeterminado es IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Firewall IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "Vecinos de IPv6"
 
@@ -2527,7 +2534,7 @@ msgstr "Sufijo IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Dirección IPv6"
 
@@ -2644,7 +2651,7 @@ msgstr "Ignorar el archivo resolve"
 msgid "Image"
 msgstr "Imagen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Entrada"
 
@@ -2700,8 +2707,8 @@ msgstr "Instalar extensiones de protocolo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfaz"
@@ -2832,8 +2839,8 @@ msgstr "Conectarse a: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Mantener los ajustes y conservar la configuración actual"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Registro del Kernel"
 
@@ -2915,18 +2922,15 @@ msgid "Lease time"
 msgstr "Tiempo de expiración"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Tiempo de conexión restante"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Archivo de conexiones"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr "TIempo de conexión restante"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2941,7 +2945,7 @@ msgstr "Deje vacío para autodetectar"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deje vacío para usar la dirección WAN actual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Registro de cambios:"
 
@@ -3045,7 +3049,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Puerto de escucha para consultas DNS entrantes"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Cargar"
 
@@ -3053,7 +3057,7 @@ msgstr "Cargar"
 msgid "Load Average"
 msgstr "Carga media"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Cargando el contenido del directorio…"
 
@@ -3170,7 +3174,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "Dirección MAC"
 
@@ -3312,8 +3317,8 @@ msgid "Method not found"
 msgstr "Método no encontrado"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Métrica"
@@ -3384,7 +3389,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr "Más caracteres"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Más…"
 
@@ -3475,8 +3480,8 @@ msgstr "Dominio NT"
 msgid "NTP server candidates"
 msgstr "Servidores NTP a consultar"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3497,8 +3502,8 @@ msgstr "Navegación"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Red"
@@ -3524,7 +3529,7 @@ msgstr "Nuevo nombre de interfaz…"
 msgid "Next »"
 msgstr "Siguiente »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "No"
@@ -3545,7 +3550,7 @@ msgstr "Sin NAT-T"
 msgid "No data received"
 msgstr "Sin datos recibidos"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "No hay entradas en este directorio"
 
@@ -3585,7 +3590,7 @@ msgstr "Sin pares definidos"
 msgid "No public keys present yet."
 msgstr "No hay claves públicas presentes todavía."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "No hay reglas en esta cadena."
 
@@ -3748,11 +3753,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Frecuencia de operación"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Opción cambiada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Opción removida"
 
@@ -3826,7 +3831,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Opcional. Puerto UDP utilizado para paquetes salientes y entrantes."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Opciones"
 
@@ -3834,7 +3839,7 @@ msgstr "Opciones"
 msgid "Other:"
 msgstr "Otros:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Salida"
 
@@ -3906,7 +3911,7 @@ msgstr "Anular la tabla utilizada para rutas internas"
 msgid "Overview"
 msgstr "Vista general"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Sobrescribir archivo \"%s\" existente?"
 
@@ -4007,7 +4012,7 @@ msgstr "Longitud de PSID-bits"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Modo de transferencia de paquetes)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Paquetes"
 
@@ -4141,7 +4146,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Paq."
 
@@ -4149,11 +4154,11 @@ msgstr "Paq."
 msgid "Please enter your username and password."
 msgstr "Por favor, introduzca su nombre de usuario y contraseña."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Por favor, seleccione el archivo que desea cargar."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Política"
 
@@ -4223,7 +4228,7 @@ msgid "Private Key"
 msgstr "Clave privada"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Procesos"
 
@@ -4231,7 +4236,7 @@ msgstr "Procesos"
 msgid "Profile"
 msgstr "Prefil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4370,7 +4375,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "¿Está seguro de querer cambiar el protocolo?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Gráficos en tiempo real"
 
@@ -4410,7 +4415,7 @@ msgstr "Recomendado. Direcciones IP de la interfaz de WireGuard."
 msgid "Reconnect this interface"
 msgstr "Reconectar esta interfaz"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referencias"
 
@@ -4556,7 +4561,7 @@ msgstr "Requiere wpa-supplicant con soporte SAE"
 msgid "Reset"
 msgstr "Restablecer"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Reiniciar contadores"
 
@@ -4583,7 +4588,7 @@ msgstr "Recurso no encontrado"
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Reiniciar Firewall"
 
@@ -4604,19 +4609,19 @@ msgstr "Restaurar copia de seguridad"
 msgid "Reveal/hide password"
 msgstr "Mostrar/ocultar contraseña"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Revertir"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Revertir cambios"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Error al revertir la solicitud con el estado <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Revirtiendo configuración…"
 
@@ -4650,8 +4655,8 @@ msgid "Router Password"
 msgstr "Contraseña del router"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Rutas"
 
@@ -4663,7 +4668,7 @@ msgstr ""
 "Las rutas especifican sobre qué interfaz y puerta de enlace se puede llegar "
 "a un cierto dispositivo o red."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Regla"
 
@@ -4720,7 +4725,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4731,7 +4736,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Guardar y aplicar"
@@ -4753,11 +4758,11 @@ msgstr "Escanear"
 msgid "Scheduled Tasks"
 msgstr "Tareas programadas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Sección añadida"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Sección removida"
 
@@ -4775,9 +4780,9 @@ msgstr ""
 "la verificación del formato de la imagen. ¡Úselo solo si está seguro de que "
 "el firmware es correcto y está diseñado para su dispositivo!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Seleccionar archivo…"
 
@@ -4866,7 +4871,7 @@ msgstr "Preámbulo corto"
 msgid "Show current backup file list"
 msgstr "Mostrar lista de archivos a resguardar"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Mostrar cadenas vacias"
 
@@ -4896,7 +4901,7 @@ msgstr "Atenuación de señal (SATN)"
 msgid "Signal:"
 msgstr "Señal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Tamaño"
@@ -4923,7 +4928,7 @@ msgid "Skip to navigation"
 msgstr "Saltar a navegación"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "Software VLAN"
 
@@ -4950,8 +4955,8 @@ msgstr ""
 "instalación específicas."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Origen"
 
@@ -5023,7 +5028,7 @@ msgstr "Iniciar"
 msgid "Start priority"
 msgstr "Prioridad de inicio"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Iniciando aplicar configuración…"
 
@@ -5054,7 +5059,7 @@ msgstr "Rutas estáticas"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Dirección estática"
 
@@ -5136,7 +5141,7 @@ msgid "Switch Speed Mask"
 msgstr "Cambiar velocidad de máscara"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Switch VLAN"
 
@@ -5150,7 +5155,7 @@ msgstr "Intercambiar protocolo"
 msgid "Switch to CIDR list notation"
 msgstr "Cambiar a la notación de lista CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Enlace simbólico"
 
@@ -5169,8 +5174,8 @@ msgstr "Sincronizar con el navegador"
 msgid "System"
 msgstr "Sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Registro del sistema"
 
@@ -5203,17 +5208,17 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Tasa TX"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabla"
 
 # Target = Meta --> Objetivo --> Destino?
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Destino"
 
@@ -5264,7 +5269,7 @@ msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 "El archivo de configuración no se pudo cargar debido al siguiente error:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5310,7 +5315,7 @@ msgstr ""
 "para garantizar la integridad de los datos. <br /> Haga clic en \"Continuar"
 "\" a continuación para iniciar el procedimiento de instalación."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Las siguientes reglas están actualmente activas en este sistema."
 
@@ -5462,7 +5467,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "No hay direcciones activas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "No hay cambios para aplicar"
 
@@ -5571,8 +5576,8 @@ msgid ""
 "their status."
 msgstr "Procesos del sistema que se están ejecutando actualmente y su estado."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5619,9 +5624,9 @@ msgstr "Total disponible"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Tráfico"
 
@@ -5646,7 +5651,7 @@ msgid "Tunnel ID"
 msgstr "ID de túnel"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Interfaz de túnel"
 
@@ -5713,6 +5718,11 @@ msgstr "No se puede determinar la interfaz ascendente"
 msgid "Unable to dispatch"
 msgstr "Imposible repartir"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5724,6 +5734,14 @@ msgstr "No se puede obtener la identificación del cliente"
 msgid "Unable to obtain mount information"
 msgstr "No se puede obtener información sobre el montaje"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5733,6 +5751,10 @@ msgstr "No se puede resolver el nombre de host AFTR"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "No se puede resolver el nombre de host del par"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5749,12 +5771,12 @@ msgid "Unexpected reply data format"
 msgstr "Formato de datos de respuesta inesperado"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Desconocido"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Error desconocido (%s)"
 
@@ -5764,7 +5786,7 @@ msgstr "Código de error desconocido"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "No administrado"
 
@@ -5778,7 +5800,7 @@ msgstr "Desmontar"
 msgid "Unnamed key"
 msgstr "Clave sin nombre"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Cambios sin aplicar"
 
@@ -5804,7 +5826,7 @@ msgstr "Tipo de protocolo no soportado."
 msgid "Up"
 msgstr "Arriba"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Subida"
 
@@ -5821,21 +5843,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Subir archivo..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Subir archivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Subir archivo…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Error al cargar la solicitud: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Cargando archivo…"
 
@@ -6139,19 +6161,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "WiFi"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Adaptador WiFi"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Red WiFi"
 
@@ -6195,7 +6217,7 @@ msgstr "Escribe las peticiones de DNS recibidas en el registro del sistema"
 msgid "Write system log to file"
 msgstr "Escribe el registro del sistema al archivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Si"
@@ -6418,7 +6440,7 @@ msgstr "Sin enlace"
 msgid "non-empty value"
 msgstr "valor no vacío"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "ninguno"
 
@@ -6526,7 +6548,7 @@ msgstr "Desconocido"
 msgid "unlimited"
 msgstr "Ilimitado"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368
@@ -6725,6 +6747,9 @@ msgstr "Si"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Volver"
+
+#~ msgid "Leasetime remaining"
+#~ msgstr "TIempo de conexión restante"
 
 #~ msgid "Bad address specified!"
 #~ msgstr "¡Dirección no válida!"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d champs invalides"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- Champ Supplémentaire --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- Choisir --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personnalisé --"
@@ -170,12 +170,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Adresse <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "Passerelle <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
@@ -213,7 +211,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Nom de la <abbr title=\"Diode Électro-Luminescente\">DEL</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Adresse <abbr title=\"Media Access Control\">MAC</abbr>"
 
@@ -249,7 +246,7 @@ msgstr ""
 "<br/>Note : il est nécessaire de redémarrer le service cron si le fichier "
 "crontab était vide au moment de l'éditer."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Un dossier avec le même nom existe déjà."
 
@@ -280,6 +277,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -346,11 +347,11 @@ msgstr "Point d'accès"
 msgid "Actions"
 msgstr "Actions"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Routes <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> actives"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Routes <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> actives"
 
@@ -374,11 +375,11 @@ msgstr "Bails DHCPv6 actifs"
 msgid "Ad-Hoc"
 msgstr "Ad-hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -483,7 +484,7 @@ msgid "Alert"
 msgstr "Alerte"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -664,16 +665,16 @@ msgstr "N'importe quelle zone"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Appliquer sans vérification"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -879,7 +880,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Contourne les «  NX Domain » bogués"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Passerelle"
 
@@ -896,8 +897,8 @@ msgstr "Numéro d'unité du pont"
 msgid "Bring up on boot"
 msgstr "L'activer au démarrage"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -928,8 +929,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -945,17 +946,17 @@ msgstr "Annuler"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Chaîne"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Changements"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Les modifications ont été annulées."
 
@@ -1074,7 +1075,8 @@ msgstr "Fermer la liste…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Récupération des données…"
@@ -1091,7 +1093,7 @@ msgstr ""
 msgid "Command failed"
 msgstr "Échec de la commande"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -1103,16 +1105,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configuration"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1143,7 +1145,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Connexions"
 
@@ -1159,7 +1161,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1245,7 +1247,7 @@ msgstr "DHCP et DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "client DHCP"
 
@@ -1372,11 +1374,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" qui publie différents serveurs "
 "DNS à ses clients."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1388,7 +1390,7 @@ msgstr "Effacer"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1404,7 +1406,7 @@ msgstr ""
 msgid "Description"
 msgstr "Description"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1413,7 +1415,7 @@ msgid "Design"
 msgstr "Apparence"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destination"
 
@@ -1449,7 +1451,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1466,7 +1468,7 @@ msgstr "Diagnostics"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Répertoire"
 
@@ -1533,10 +1535,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1579,7 +1581,7 @@ msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 "Ne pas transmettre les requêtes de recherche inverse pour les réseaux locaux"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1591,7 +1593,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1631,7 +1633,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1677,9 +1679,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Méthode EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1870,12 +1872,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Module Ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
 
@@ -1957,7 +1959,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1965,15 +1967,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Fichier"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -2025,7 +2027,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "Paramètres du pare-feu"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "État du pare-feu"
 
@@ -2213,8 +2215,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Aller à la configuration du mot de passe…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2256,8 +2258,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Cacher le <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2347,7 +2349,7 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Pare-feu IPv4"
 
@@ -2398,8 +2400,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Adresse IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2426,11 +2433,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Pare-feu IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2493,7 +2500,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Adresse IPv6"
 
@@ -2607,7 +2614,7 @@ msgstr "Ignorer le fichier de résolution"
 msgid "Image"
 msgstr "Image"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Entrée"
 
@@ -2660,8 +2667,8 @@ msgstr "Installation des extensions de protocole…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
@@ -2795,8 +2802,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Journal du noyau"
 
@@ -2878,18 +2885,15 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Durée de validité"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Fichier de baux"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2904,7 +2908,7 @@ msgstr "Laisser vide pour l'auto-détection"
 msgid "Leave empty to use the current WAN address"
 msgstr "Laisser vide pour utiliser l'adresse WAN actuelle"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Légende :"
 
@@ -2996,7 +3000,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Port d'écoute des requêtes DNS entrantes"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Charge"
 
@@ -3004,7 +3008,7 @@ msgstr "Charge"
 msgid "Load Average"
 msgstr "Charge moyenne"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3123,7 +3127,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "Adresse MAC"
 
@@ -3263,8 +3268,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Métrique"
@@ -3335,7 +3340,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3426,8 +3431,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Serveurs NTP candidats"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3448,8 +3453,8 @@ msgstr "Navigation"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Réseau"
@@ -3475,7 +3480,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Prochain »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Non"
@@ -3496,7 +3501,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3536,7 +3541,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Aucune règle dans cette chaîne"
 
@@ -3697,11 +3702,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Option modifiée"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Option retirée"
 
@@ -3762,7 +3767,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Options"
 
@@ -3770,7 +3775,7 @@ msgstr "Options"
 msgid "Other:"
 msgstr "Autres :"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Sortie"
 
@@ -3842,7 +3847,7 @@ msgstr "Modifier la table utilisée pour les routes internes"
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3943,7 +3948,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Paquets"
 
@@ -4077,7 +4082,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pqts."
 
@@ -4085,11 +4090,11 @@ msgstr "Pqts."
 msgid "Please enter your username and password."
 msgstr "Saisissez votre nom d'utilisateur et mot de passe."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Politique"
 
@@ -4159,7 +4164,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Processus"
 
@@ -4167,7 +4172,7 @@ msgstr "Processus"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4293,7 +4298,7 @@ msgstr "Lire /etc/ethers pour configurer le serveur DHCP"
 msgid "Really switch protocol?"
 msgstr "Voulez-vous vraiment changer de protocole ?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Graphiques temps-réel"
 
@@ -4333,7 +4338,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "Reconnecter cet interface"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Références"
 
@@ -4472,7 +4477,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Remise à zéro"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Remise à zéro des compteurs"
 
@@ -4499,7 +4504,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Redémarrer"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Redémarrer le pare-feu"
 
@@ -4520,19 +4525,19 @@ msgstr "Restaurer une sauvegarde"
 msgid "Reveal/hide password"
 msgstr "Montrer/cacher le mot de passe"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Annuler les modifications"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Annuler les modifications"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "La demande d'annulation a échoué, statut <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Annulation de la configuration…"
 
@@ -4566,8 +4571,8 @@ msgid "Router Password"
 msgstr "Mot de passe du routeur"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Routes"
 
@@ -4579,7 +4584,7 @@ msgstr ""
 "Avec les routes statiques vous pouvez spécifier à travers quelle interface "
 "ou passerelle un réseau peut être contacté."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4637,7 +4642,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4648,7 +4653,7 @@ msgid "Save"
 msgstr "Enregistrer"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Sauvegarder et Appliquer"
@@ -4670,11 +4675,11 @@ msgstr "Scan"
 msgid "Scheduled Tasks"
 msgstr "Tâches Régulières"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Section ajoutée"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Section retirée"
 
@@ -4689,9 +4694,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4777,7 +4782,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr "Afficher la liste des fichiers de la sauvegarde actuelle"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4807,7 +4812,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Signal :"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Taille"
@@ -4834,7 +4839,7 @@ msgid "Skip to navigation"
 msgstr "Skip to navigation"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4862,8 +4867,8 @@ msgstr ""
 "matériel."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Source"
 
@@ -4926,7 +4931,7 @@ msgstr "Démarrer"
 msgid "Start priority"
 msgstr "Priorité de démarrage"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4957,7 +4962,7 @@ msgstr "Routes statiques"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Adresse statique"
 
@@ -5037,7 +5042,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -5051,7 +5056,7 @@ msgstr "Changer de protocole"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -5070,8 +5075,8 @@ msgstr "Synchro avec le navigateur"
 msgid "System"
 msgstr "Système"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Journal système"
 
@@ -5104,16 +5109,16 @@ msgstr "Transmis"
 msgid "TX Rate"
 msgstr "Débit en émission"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Table"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Cible"
 
@@ -5160,7 +5165,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5198,7 +5203,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Les règles suivantes sont actuellement actives sur ce système."
 
@@ -5344,7 +5349,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Aucun bail actif"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5450,8 +5455,8 @@ msgstr ""
 "Cette liste donne une vue d'ensemble des processus en cours d'exécution et "
 "leur statut."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5498,9 +5503,9 @@ msgstr "Total disponible"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Trafic"
 
@@ -5525,7 +5530,7 @@ msgid "Tunnel ID"
 msgstr "ID du tunnel"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Interface du tunnel"
 
@@ -5592,6 +5597,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr "Impossible d'envoyer"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5603,6 +5613,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5611,6 +5629,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5628,12 +5650,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Inconnu"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5643,7 +5665,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "non-géré"
 
@@ -5657,7 +5679,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Changements non appliqués"
 
@@ -5683,7 +5705,7 @@ msgstr "Type de protocole non pris en charge."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5698,21 +5720,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Envoi de l'archive…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -6010,19 +6032,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Sans-fil"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Module Wi-Fi"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Réseau sans-fil"
 
@@ -6066,7 +6088,7 @@ msgstr "Écrire les requêtes DNS reçues dans syslog"
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Oui"
@@ -6286,7 +6308,7 @@ msgstr "pas de lien"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "aucun"
 
@@ -6394,7 +6416,7 @@ msgstr "inconnu"
 msgid "unlimited"
 msgstr "non limité"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -20,7 +20,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -56,11 +56,11 @@ msgid "-- Additional Field --"
 msgstr "-- שדה נוסף --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -68,7 +68,7 @@ msgstr "-- נא לבחור --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- מותאם אישית --"
@@ -165,12 +165,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "כתובות <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 
@@ -204,7 +202,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "שם <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "כתובת-<abbr title=\"Media Access Control\">MAC</abbr>"
 
@@ -234,7 +231,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -263,6 +260,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -328,11 +329,11 @@ msgstr "נקודת גישה"
 msgid "Actions"
 msgstr "פעולות"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
@@ -358,11 +359,11 @@ msgstr "הרשאות DHCPv6 פעילות"
 msgid "Ad-Hoc"
 msgstr "אד-הוק"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -469,7 +470,7 @@ msgid "Alert"
 msgstr "אזעקה"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -647,16 +648,16 @@ msgstr "כל תחום"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -862,7 +863,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "גשר"
 
@@ -880,8 +881,8 @@ msgstr "מס' יח' גשר"
 msgid "Bring up on boot"
 msgstr "הבא באיתחול"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -912,8 +913,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -929,17 +930,17 @@ msgstr "בטל"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "שרשרת"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "שינויים"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1047,7 +1048,8 @@ msgstr "סגור רשימה..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "אוסף מידע..."
@@ -1064,7 +1066,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1076,16 +1078,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "הגדרות"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1116,7 +1118,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "חיבורים"
 
@@ -1132,7 +1134,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1218,7 +1220,7 @@ msgstr "DHCP ו- DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "לקוח DHCP"
 
@@ -1344,11 +1346,11 @@ msgstr ""
 "הגדר אפשרויות DHCP נוספות, למשל \"<code>6,192.168.2.1,192.168.2.2</code>\" "
 "אשר מציגות שרתי DNS שונים ללקוח"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1360,7 +1362,7 @@ msgstr "למחוק"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1376,7 +1378,7 @@ msgstr ""
 msgid "Description"
 msgstr "תיאור"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1385,7 +1387,7 @@ msgid "Design"
 msgstr "עיצוב"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "יעד"
 
@@ -1421,7 +1423,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1438,7 +1440,7 @@ msgstr "אבחון"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1503,10 +1505,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1540,7 +1542,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1552,7 +1554,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1590,7 +1592,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1633,9 +1635,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1822,12 +1824,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1907,7 +1909,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1915,15 +1917,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1975,7 +1977,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr ""
 
@@ -2161,8 +2163,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2202,8 +2204,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2293,7 +2295,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2344,7 +2346,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2372,11 +2379,11 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2439,7 +2446,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2545,7 +2552,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2598,8 +2605,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
@@ -2728,8 +2735,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr ""
 
@@ -2811,17 +2818,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2837,7 +2841,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2926,7 +2930,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "עומס"
 
@@ -2934,7 +2938,7 @@ msgstr "עומס"
 msgid "Load Average"
 msgstr "עומס ממוצע"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3045,7 +3049,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3185,8 +3190,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3257,7 +3262,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3346,8 +3351,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3368,8 +3373,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr ""
@@ -3395,7 +3400,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3416,7 +3421,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3456,7 +3461,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3617,11 +3622,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3682,7 +3687,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3690,7 +3695,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3760,7 +3765,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -3995,7 +4000,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -4003,11 +4008,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr "אנא הזן את שם המשתמש והסיסמה שלך:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4075,7 +4080,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr ""
 
@@ -4083,7 +4088,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4209,7 +4214,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4249,7 +4254,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4388,7 +4393,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr ""
 
@@ -4415,7 +4420,7 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr ""
 
@@ -4436,19 +4441,19 @@ msgstr ""
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4482,8 +4487,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr ""
 
@@ -4493,7 +4498,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4550,7 +4555,7 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4561,7 +4566,7 @@ msgid "Save"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4583,11 +4588,11 @@ msgstr ""
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4602,9 +4607,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4688,7 +4693,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4718,7 +4723,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr ""
@@ -4745,7 +4750,7 @@ msgid "Skip to navigation"
 msgstr "דלג אל הניווט"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4771,8 +4776,8 @@ msgstr ""
 "אל ה-wiki של OpenWrt עבור הוראות ספציפיות למכשיר שלך."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "מקור"
 
@@ -4833,7 +4838,7 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4864,7 +4869,7 @@ msgstr "ניתובים סטטיים"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "כתובת סטטית"
 
@@ -4943,7 +4948,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4976,8 +4981,8 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr ""
 
@@ -5010,16 +5015,16 @@ msgstr "שידור"
 msgid "TX Rate"
 msgstr "קצב שידור"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "טבלה"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "יעד"
 
@@ -5062,7 +5067,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5093,7 +5098,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "החוקים הבאים מאופשרים כרגע במערכת זו."
 
@@ -5222,7 +5227,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5310,8 +5315,8 @@ msgid ""
 "their status."
 msgstr "רשימה זו מציגה סקירה של תהליכי המערכת הרצים כרגע ואת מצבם."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5355,9 +5360,9 @@ msgstr "סה\"כ פנוי"
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "תעבורה"
 
@@ -5382,7 +5387,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5449,6 +5454,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5460,6 +5470,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5468,6 +5486,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5485,12 +5507,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5500,7 +5522,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5514,7 +5536,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5540,7 +5562,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5555,21 +5577,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5859,19 +5881,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr ""
 
@@ -5915,7 +5937,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6129,7 +6151,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "ללא"
 
@@ -6237,7 +6259,7 @@ msgstr ""
 msgid "unlimited"
 msgstr "ללא הגבלה"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -18,7 +18,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d अमान्य क्षेत्र"
 
@@ -54,11 +54,11 @@ msgid "-- Additional Field --"
 msgstr "अतिरिक्त अनुभाग"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -66,7 +66,7 @@ msgstr "कृपया चुने"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "--अमानक--"
@@ -163,12 +163,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 
@@ -201,7 +199,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 
@@ -231,7 +228,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "समान नाम वाली एक निर्देशिका पहले से मौजूद है।"
 
@@ -261,6 +258,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -323,11 +324,11 @@ msgstr "प्रवेश स्थल"
 msgid "Actions"
 msgstr "चाल-चलन"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
@@ -351,11 +352,11 @@ msgstr "सक्रिय DHCPv6 पट्टों"
 msgid "Ad-Hoc"
 msgstr "तदर्थ"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -459,7 +460,7 @@ msgid "Alert"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -633,16 +634,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -845,7 +846,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr ""
 
@@ -862,8 +863,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -894,8 +895,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -911,17 +912,17 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1029,7 +1030,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr ""
@@ -1046,7 +1048,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1058,16 +1060,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1098,7 +1100,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr ""
 
@@ -1114,7 +1116,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1198,7 +1200,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1322,11 +1324,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1338,7 +1340,7 @@ msgstr ""
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1354,7 +1356,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1363,7 +1365,7 @@ msgid "Design"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr ""
 
@@ -1399,7 +1401,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1416,7 +1418,7 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1481,10 +1483,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1518,7 +1520,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1530,7 +1532,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1568,7 +1570,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1609,9 +1611,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1798,12 +1800,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1883,7 +1885,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1891,15 +1893,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1951,7 +1953,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr ""
 
@@ -2137,8 +2139,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2178,8 +2180,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2269,7 +2271,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2320,7 +2322,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2348,11 +2355,11 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2415,7 +2422,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2521,7 +2528,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2574,8 +2581,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
@@ -2704,8 +2711,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr ""
 
@@ -2787,17 +2794,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2813,7 +2817,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr ""
 
@@ -2910,7 +2914,7 @@ msgstr ""
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3021,7 +3025,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3161,8 +3166,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3233,7 +3238,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3322,8 +3327,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3344,8 +3349,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr ""
@@ -3371,7 +3376,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3392,7 +3397,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3432,7 +3437,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3593,11 +3598,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3658,7 +3663,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3666,7 +3671,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3736,7 +3741,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3837,7 +3842,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -3971,7 +3976,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -3979,11 +3984,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4051,7 +4056,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr ""
 
@@ -4059,7 +4064,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4185,7 +4190,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4225,7 +4230,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4364,7 +4369,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr ""
 
@@ -4391,7 +4396,7 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr ""
 
@@ -4412,19 +4417,19 @@ msgstr ""
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4458,8 +4463,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr ""
 
@@ -4469,7 +4474,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4526,7 +4531,7 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4537,7 +4542,7 @@ msgid "Save"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4559,11 +4564,11 @@ msgstr ""
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4578,9 +4583,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4664,7 +4669,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4694,7 +4699,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr ""
@@ -4721,7 +4726,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4745,8 +4750,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr ""
 
@@ -4807,7 +4812,7 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4838,7 +4843,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4914,7 +4919,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4928,7 +4933,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4947,8 +4952,8 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr ""
 
@@ -4981,16 +4986,16 @@ msgstr ""
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr ""
 
@@ -5033,7 +5038,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5064,7 +5069,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5193,7 +5198,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5281,8 +5286,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5325,9 +5330,9 @@ msgstr ""
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr ""
 
@@ -5352,7 +5357,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5419,6 +5424,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5430,6 +5440,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5438,6 +5456,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5455,12 +5477,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5470,7 +5492,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5484,7 +5506,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5510,7 +5532,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5525,21 +5547,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5829,19 +5851,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr ""
 
@@ -5885,7 +5907,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6099,7 +6121,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr ""
 
@@ -6207,7 +6229,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -21,7 +21,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d érvénytelen mező"
 
@@ -57,11 +57,11 @@ msgid "-- Additional Field --"
 msgstr "-- További mező --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -69,7 +69,7 @@ msgstr "-- Kérem válasszon --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- egyéni --"
@@ -171,12 +171,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-cím"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-átjáró"
 
@@ -211,7 +209,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> neve"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-cím"
 
@@ -247,7 +244,7 @@ msgstr ""
 "<br/>Megjegyzés: újra kell indítania kézzel a cron szolgáltatást, ha a "
 "crontab fájl üres volt a szerkesztés előtt."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Már létezik egy ilyen nevű könyvtár."
 
@@ -277,6 +274,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -339,12 +340,12 @@ msgstr "Hozzáférési pont"
 msgid "Actions"
 msgstr "Műveletek"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Aktív <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> útvonalak"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Aktív <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-útvonalak"
@@ -369,11 +370,11 @@ msgstr "Aktív DHCPv6 bérletek"
 msgid "Ad-Hoc"
 msgstr "Eseti"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -477,7 +478,7 @@ msgid "Alert"
 msgstr "Riasztás"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Álnév csatoló"
@@ -664,16 +665,16 @@ msgstr "Bármely zóna"
 msgid "Apply backup?"
 msgstr "Alkalmazza a biztonsági mentést?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "A kérés alkalmazása meghiúsult <code>%h</code> állapotkóddal"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Kijelöletlenek alkalmazása"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "A beállítások változtatásainak alkalmazása… %d mp"
 
@@ -888,7 +889,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Hamis NX-tartomány felülbírálása"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Híd"
 
@@ -905,8 +906,8 @@ msgstr "Hídegység száma"
 msgid "Bring up on boot"
 msgstr "Felhozás rendszerindításkor"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Tallózás…"
 
@@ -939,8 +940,8 @@ msgstr "Gyorsítótárazott"
 msgid "Call failed"
 msgstr "Hívás sikertelen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -956,17 +957,17 @@ msgstr "Mégse"
 msgid "Category"
 msgstr "Kategória"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Lánc"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Változtatások"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "A változtatások visszavonva."
 
@@ -1089,7 +1090,8 @@ msgstr "Lista bezárása…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Adatok összegyűjtése…"
@@ -1106,7 +1108,7 @@ msgstr "Parancs rendben"
 msgid "Command failed"
 msgstr "Parancs sikertelen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Megjegyzés"
 
@@ -1123,16 +1125,16 @@ msgstr ""
 "a kulcsegyeztetés robusztusságának csökkentését okozhatja, különösen az erős "
 "forgalomterheléssel rendelkező környezetekben."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Beállítás"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "A beállítás változtatásai alkalmazva."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "A beállítás változtatásai vissza lettek állítva!"
 
@@ -1163,7 +1165,7 @@ msgstr "Kapcsolódási kísérlet sikertelen"
 msgid "Connection lost"
 msgstr "A kapcsolat elveszett"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Kapcsolatok"
 
@@ -1179,7 +1181,7 @@ msgstr "A tartalom mentésre került."
 msgid "Continue"
 msgstr "Folytatás"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1271,7 +1273,7 @@ msgstr "DHCP és DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP ügyfél"
 
@@ -1398,11 +1400,11 @@ msgstr ""
 "„<code>6,192.168.2.1,192.168.2.2</code>”, amely különböző DNS-kiszolgálókat "
 "hirdet az ügyfelek részére."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1414,7 +1416,7 @@ msgstr "Törlés"
 msgid "Delete key"
 msgstr "Kulcs törlése"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Törlési kérés sikertelen: %s"
 
@@ -1430,7 +1432,7 @@ msgstr "Kézbesítési forgalom jelző üzenet időköze"
 msgid "Description"
 msgstr "Leírás"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Kijelölés megszüntetése"
 
@@ -1439,7 +1441,7 @@ msgid "Design"
 msgstr "Megjelenés"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Cél"
 
@@ -1475,7 +1477,7 @@ msgstr "Az eszköz nem aktív"
 msgid "Device is restarting…"
 msgstr "Az eszköz újraindul…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Az eszköz elérhetetlen!"
 
@@ -1492,7 +1494,7 @@ msgstr "Diagnosztika"
 msgid "Dial number"
 msgstr "Szám tárcsázása"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Könyvtár"
 
@@ -1559,10 +1561,10 @@ msgstr "Leválasztás"
 msgid "Disconnection attempt failed"
 msgstr "Leválasztási kísérlet sikertelen"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1603,7 +1605,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Ne továbbítson fordított keresési kéréseket a helyi hálózathoz"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Valóban törölni szeretné ezt: „%s”?"
 
@@ -1615,7 +1617,7 @@ msgstr "Valóban törölni szeretné a következő SSH-kulcsot?"
 msgid "Do you really want to erase all settings?"
 msgstr "Valóban törölni szeretné az összes beállítást?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Valóban törölni szeretné rekurzívan a(z) „%s” könyvtárat?"
 
@@ -1636,8 +1638,8 @@ msgid ""
 "Don't forward <abbr title=\"Domain Name System\">DNS</abbr>-Requests without "
 "<abbr title=\"Domain Name System\">DNS</abbr>-Name"
 msgstr ""
-"Ne továbbítsa a <abbr title=\"Domain Name System\">DNS</abbr>-kéréseket <"
-"abbr title=\"Domain Name System\">DNS</abbr>-név nélkül"
+"Ne továbbítsa a <abbr title=\"Domain Name System\">DNS</abbr>-kéréseket "
+"<abbr title=\"Domain Name System\">DNS</abbr>-név nélkül"
 
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:152
 msgid "Down"
@@ -1655,7 +1657,7 @@ msgstr "Az mtdblock letöltése"
 msgid "Downstream SNR offset"
 msgstr "Belső SNR eltolás"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Húzza az átrendezéshez"
 
@@ -1702,9 +1704,9 @@ msgstr "EA-bitek hossza"
 msgid "EAP-Method"
 msgstr "EAP módszer"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1897,12 +1899,12 @@ msgid "Errored seconds (ES)"
 msgstr "Hibás másodpercek (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernet adapter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet kapcsoló"
 
@@ -1982,7 +1984,7 @@ msgstr "FT protokoll"
 msgid "Failed to change the system password."
 msgstr "Nem sikerült megváltoztatni a rendszer jelszavát."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "Nem sikerült megerősíteni az alkalmazást %d másodpercen belül, várakozás a "
@@ -1992,15 +1994,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Nem sikerült végrehajtani az „/etc/init.d/%s %s” műveletet: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Fájl"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "A fájl nem érhető el"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Fájlnév"
 
@@ -2054,7 +2056,7 @@ msgstr "Tűzfal jelölés"
 msgid "Firewall Settings"
 msgstr "Tűzfalbeállítások"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Tűzfal állapota"
 
@@ -2245,8 +2247,8 @@ msgstr "Globális hálózati beállítások"
 msgid "Go to password configuration..."
 msgstr "Ugrás a jelszóbeállításhoz…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2288,8 +2290,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr> elrejtése"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Üres láncok elrejtése"
 
@@ -2380,7 +2382,7 @@ msgstr "IP-cím hiányzik"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 tűzfal"
 
@@ -2431,8 +2433,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-cím"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2459,11 +2466,11 @@ msgstr "IPv4/IPv6 (mindkettő – alapértelmezetten IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 tűzfal"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "IPv6 szomszédok"
 
@@ -2526,7 +2533,7 @@ msgstr "IPv6-utótag"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-cím"
 
@@ -2644,7 +2651,7 @@ msgstr "A feloldási fájl figyelmen kívül hagyása"
 msgid "Image"
 msgstr "Kép"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Be"
 
@@ -2691,10 +2698,6 @@ msgstr "Előkészítő parancsfájl"
 msgid "Initscripts"
 msgstr "Előkészítő parancsfájlok"
 
-#: modules/luci-mod-network/luasrc/view/admin_network/diagnostics.htm:98
-msgid "Install iputils-traceroute6 for IPv6 traceroute"
-msgstr "Az iputils-traceroute6 telepítése az IPv6 útvonalkövetéshez"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
 msgid "Install protocol extensions..."
 msgstr "Protokollkiterjesztések telepítése…"
@@ -2704,8 +2707,8 @@ msgstr "Protokollkiterjesztések telepítése…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Csatoló"
@@ -2840,8 +2843,8 @@ msgstr "Csatlakozás hálózathoz: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Beállítások megtartása és a jelenlegi konfiguráció megőrzése"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Kernel napló"
 
@@ -2923,18 +2926,15 @@ msgid "Lease time"
 msgstr "Bérleti idő"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "A bérletből hátralévő idő"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Bérletfájl"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2949,7 +2949,7 @@ msgstr "Automatikus felismeréshez hagyja üresen"
 msgid "Leave empty to use the current WAN address"
 msgstr "Hagyja üresen a jelenlegi WAN-cím használatához"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Jelmagyarázat:"
 
@@ -3053,7 +3053,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Port figyelése a bejövő DNS-lekérdezésekhez"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Terhelés"
 
@@ -3061,7 +3061,7 @@ msgstr "Terhelés"
 msgid "Load Average"
 msgstr "Átlagos terhelés"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Könyvtártartalmak betöltése…"
 
@@ -3178,7 +3178,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-cím"
 
@@ -3320,8 +3321,8 @@ msgid "Method not found"
 msgstr "Nem található módszer"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Mérőszám"
@@ -3392,7 +3393,7 @@ msgstr "Megfigyelés"
 msgid "More Characters"
 msgstr "Több karakter"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Több…"
 
@@ -3483,8 +3484,8 @@ msgstr "NT-tartomány"
 msgid "NTP server candidates"
 msgstr "NTP-kiszolgáló jelöltek"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3505,8 +3506,8 @@ msgstr "Navigáció"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Hálózat"
@@ -3532,7 +3533,7 @@ msgstr "Új csatolónév…"
 msgid "Next »"
 msgstr "Következő »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Nem"
@@ -3553,7 +3554,7 @@ msgstr "Nincs NAT-T"
 msgid "No data received"
 msgstr "Nem érkezett adat"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "Nincsenek bejegyzések ebben a könyvtárban"
 
@@ -3593,7 +3594,7 @@ msgstr "Még nincsenek partnerek meghatározva"
 msgid "No public keys present yet."
 msgstr "Még nincsenek nyilvános kulcsok."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Nincsenek szabályok ebben a láncban."
 
@@ -3756,11 +3757,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Működési gyakoriság"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Beállítás megváltoztatva"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Beállítás eltávolítva"
 
@@ -3835,7 +3836,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Elhagyható. A kimenő és bejövő csomagokhoz használt UDP port."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Beállítások"
 
@@ -3843,7 +3844,7 @@ msgstr "Beállítások"
 msgid "Other:"
 msgstr "Egyéb:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Ki"
 
@@ -3915,7 +3916,7 @@ msgstr "A belső útvonalakhoz használt tábla felülbírálása"
 msgid "Overview"
 msgstr "Áttekintő"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Felülírja a meglévő „%s” fájlt?"
 
@@ -4016,7 +4017,7 @@ msgstr "PSID bitek hossza"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (csomagátviteli mód)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Csomagok"
 
@@ -4150,7 +4151,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "csom."
 
@@ -4158,11 +4159,11 @@ msgstr "csom."
 msgid "Please enter your username and password."
 msgstr "Adja meg a felhasználónevét és a jelszavát."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Válassza ki a feltöltendő fájlt."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Házirend"
 
@@ -4232,7 +4233,7 @@ msgid "Private Key"
 msgstr "Személyes kulcs"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Folyamatok"
 
@@ -4240,7 +4241,7 @@ msgstr "Folyamatok"
 msgid "Profile"
 msgstr "Profil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Valóban protokollt cserél?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Valós idejű grafikonok"
 
@@ -4419,7 +4420,7 @@ msgstr "Ajánlott. A WireGuard csatoló IP-címei."
 msgid "Reconnect this interface"
 msgstr "Csatoló újrakapcsolódása"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Hivatkozások"
 
@@ -4567,7 +4568,7 @@ msgstr "SAE támogatással rendelkező WPA-ügyfél szükséges"
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Számlálók nullázása"
 
@@ -4594,7 +4595,7 @@ msgstr "Az erőforrás nem található"
 msgid "Restart"
 msgstr "Újraindítás"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Tűzfal újraindítása"
 
@@ -4615,19 +4616,19 @@ msgstr "Biztonsági mentés visszaállítása"
 msgid "Reveal/hide password"
 msgstr "Jelszó felfedése/elrejtése"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Visszavonás"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Változtatások visszavonása"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "A kérés visszavonása meghiúsult <code>%h</code> állapotkóddal"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Beállítás visszaállítása…"
 
@@ -4661,8 +4662,8 @@ msgid "Router Password"
 msgstr "Útválasztó jelszava"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Útvonalak"
 
@@ -4674,7 +4675,7 @@ msgstr ""
 "Az útvonalak határozzák meg, hogy egy bizonyos gép vagy hálózat mely "
 "csatolón és átjárón keresztül érhető el."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Szabály"
 
@@ -4731,7 +4732,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4742,7 +4743,7 @@ msgid "Save"
 msgstr "Mentés"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Mentés és alkalmazás"
@@ -4764,11 +4765,11 @@ msgstr "Keresés"
 msgid "Scheduled Tasks"
 msgstr "Ütemezett feladatok"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Szakasz hozzáadva"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Szakasz eltávolítva"
 
@@ -4786,9 +4787,9 @@ msgstr ""
 "akkor is ha a lemezképformátum ellenőrzése sikertelen. Csak akkor használja, "
 "ha biztos abban, hogy a firmware helyes és az Ön eszközéhez készült!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Fájl kiválasztása…"
 
@@ -4877,7 +4878,7 @@ msgstr "Rövid előszó"
 msgid "Show current backup file list"
 msgstr "Jelenlegi biztonsági mentés fájllista megjelenítése"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Üres láncok megjelenítése"
 
@@ -4907,7 +4908,7 @@ msgstr "Jel csillapítása (SATN)"
 msgid "Signal:"
 msgstr "Jel:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Méret"
@@ -4934,7 +4935,7 @@ msgid "Skip to navigation"
 msgstr "Ugrás a navigációhoz"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "Szoftveres VLAN"
 
@@ -4961,8 +4962,8 @@ msgstr ""
 "tartozó telepítési utasításokért."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Forrás"
 
@@ -5035,7 +5036,7 @@ msgstr "Indítás"
 msgid "Start priority"
 msgstr "Indítási prioritás"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Beállítások alkalmazásának indítása…"
 
@@ -5066,7 +5067,7 @@ msgstr "Statikus útvonalak"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Statikus cím"
 
@@ -5148,7 +5149,7 @@ msgid "Switch Speed Mask"
 msgstr "Kapcsoló sebességmaszkja"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Kapcsoló VLAN"
 
@@ -5162,7 +5163,7 @@ msgstr "Protokoll váltása"
 msgid "Switch to CIDR list notation"
 msgstr "Váltás CIDR lista jelölésre"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Szimbolikus hivatkozás"
 
@@ -5181,8 +5182,8 @@ msgstr "Szinkronizálás a böngészővel"
 msgid "System"
 msgstr "Rendszer"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Rendszernapló"
 
@@ -5215,16 +5216,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "TX sebesség"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tábla"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Cél"
 
@@ -5273,7 +5274,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "A beállítófájlt nem sikerült betölteni a következő hiba miatt:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5320,7 +5321,7 @@ msgstr ""
 "adatok helyességéről.<br />Kattintson a lenti „Folytatás” gombra a "
 "telepítési eljárás indításához."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Jelenleg a következő szabályok aktívak a rendszeren."
 
@@ -5474,7 +5475,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Nincsenek aktív bérletek"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Nincsenek alkalmazandó változtatások"
 
@@ -5552,8 +5553,8 @@ msgid ""
 "This is the only <abbr title=\"Dynamic Host Configuration Protocol\">DHCP</"
 "abbr> in the local network"
 msgstr ""
-"Ez az egyetlen <abbr title=\"Dynamic Host Configuration Protocol\""
-">DHCP</abbr> a helyi hálózatban"
+"Ez az egyetlen <abbr title=\"Dynamic Host Configuration Protocol\">DHCP</"
+"abbr> a helyi hálózatban"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:73
 msgid "This is the plain username for logging into the account"
@@ -5586,8 +5587,8 @@ msgstr ""
 "Ez a lista áttekintést ad a jelenleg futó rendszerfolyamatokról és azok "
 "állapotáról."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5634,9 +5635,9 @@ msgstr "Összes elérhető"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Forgalom"
 
@@ -5661,7 +5662,7 @@ msgid "Tunnel ID"
 msgstr "Alagút-azonosító"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Alagút csatoló"
 
@@ -5728,6 +5729,11 @@ msgstr "Nem lehet meghatározni a külső csatolót"
 msgid "Unable to dispatch"
 msgstr "Nem lehet elküldeni"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5739,6 +5745,14 @@ msgstr "Nem lehet beszerezni az ügyfél-azonosítót"
 msgid "Unable to obtain mount information"
 msgstr "Nem lehet megszerezni a csatolási információkat"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5748,6 +5762,10 @@ msgstr "Nem lehet feloldani az AFTR gépnevet"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Nem lehet feloldani a partner gépnevét"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5764,12 +5782,12 @@ msgid "Unexpected reply data format"
 msgstr "Váratlan válaszadat-formátum"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Ismeretlen"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Ismeretlen hiba (%s)"
 
@@ -5779,7 +5797,7 @@ msgstr "Ismeretlen hibakód"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Nem kezelt"
 
@@ -5793,7 +5811,7 @@ msgstr "Leválasztás"
 msgid "Unnamed key"
 msgstr "Névtelen kulcs"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Mentetlen változtatások"
 
@@ -5819,7 +5837,7 @@ msgstr "Nem támogatott protokolltípus."
 msgid "Up"
 msgstr "Fel"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Feltöltés"
 
@@ -5836,21 +5854,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Archívum feltöltése…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Fájl feltöltése"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Fájl feltöltése…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Feltöltési kérés sikertelen: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Fájl feltöltése…"
 
@@ -6114,8 +6132,8 @@ msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
 msgstr ""
-"A WPA titkosításához „wpa_supplicant” (ügyfél módnál) vagy „hostapd” ("
-"hozzáférési pontnál és eseti módban) telepítése szükséges."
+"A WPA titkosításához „wpa_supplicant” (ügyfél módnál) vagy "
+"„hostapd” (hozzáférési pontnál és eseti módban) telepítése szükséges."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/reboot.js:40
 msgid "Waiting for device..."
@@ -6158,19 +6176,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Vezeték nélküli"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Vezeték nélküli adapter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Vezeték nélküli hálózat"
 
@@ -6214,7 +6232,7 @@ msgstr "Fogadott DNS-kérések írása a rendszernaplóba"
 msgid "Write system log to file"
 msgstr "Rendszernapló írása fájlba"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Igen"
@@ -6439,7 +6457,7 @@ msgstr "nincs kapcsolat"
 msgid "non-empty value"
 msgstr "nem üres érték"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "nincs"
 
@@ -6547,7 +6565,7 @@ msgstr "ismeretlen"
 msgid "unlimited"
 msgstr "korlátlan"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368
@@ -6746,6 +6764,9 @@ msgstr "igen"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Vissza"
+
+#~ msgid "Install iputils-traceroute6 for IPv6 traceroute"
+#~ msgstr "Az iputils-traceroute6 telepítése az IPv6 útvonalkövetéshez"
 
 #~ msgid "Bad address specified!"
 #~ msgstr "Hibás címet adott meg!"

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -840,10 +840,6 @@ msgstr "Firmware biztonsági mentése vagy beírása"
 msgid "Backup file list"
 msgstr "Biztonsági mentés fájllistája"
 
-#: modules/luci-mod-network/luasrc/view/admin_network/diagnostics.htm:51
-msgid "Bad address specified!"
-msgstr "Rossz cím lett megadva!"
-
 #: modules/luci-compat/luasrc/view/cbi/wireless_modefreq.htm:158
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:371
 msgid "Band"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -23,7 +23,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- Campo aggiuntivo --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- Per favore scegli --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalizzato --"
@@ -172,12 +172,10 @@ msgstr ""
 "<abbr title=\"Impostazione Identificatore Servizio Esteso\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Indirizzo <abbr title=\"Protocollo Internet Versione 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "Gateway <abbr title=\"Protocollo Internet Versione 4\">IPv4</abbr>"
 
@@ -213,7 +211,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Diodo ad Emissione di Luce\">LED</abbr> Nome"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Indirizzo <abbr title=\"Controllo Accesso Supporto\">MAC</abbr>"
 
@@ -249,7 +246,7 @@ msgstr ""
 "<br/>Nota: devi riavviare manualmente il servizio cron se il file crontab "
 "era vuoto prima delle modifiche."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -279,6 +276,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -341,13 +342,13 @@ msgstr "Punto di Accesso"
 msgid "Actions"
 msgstr "Azioni"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Instradamento <abbr title=\"Protocollo Internet Versione 4\">IPv4</abbr> "
 "attivo"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Instradamento <abbr title=\"Protocollo Internet Versione 6\">IPv6</abbr> "
@@ -373,11 +374,11 @@ msgstr "Contratti attivi DHCPv6"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -482,7 +483,7 @@ msgid "Alert"
 msgstr "Allarme"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -661,16 +662,16 @@ msgstr "Qualsiasi Zona"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -876,7 +877,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Ignora Dominio Bogus NX"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Ponte"
 
@@ -893,8 +894,8 @@ msgstr "Numero Unità Ponte"
 msgid "Bring up on boot"
 msgstr "Attivare all'avvio"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -925,8 +926,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -942,17 +943,17 @@ msgstr "Annulla"
 msgid "Category"
 msgstr "Categoria"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Catena"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Modifiche"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1070,7 +1071,8 @@ msgstr "Scegliere dall'elenco..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Raccolgo i dati..."
@@ -1087,7 +1089,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1099,16 +1101,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configurazione"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1139,7 +1141,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Connessioni"
 
@@ -1155,7 +1157,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1241,7 +1243,7 @@ msgstr "DHCP e DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Cliente DHCP"
 
@@ -1368,11 +1370,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" fornisce differenti server DNS ai "
 "client."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1384,7 +1386,7 @@ msgstr "Elimina"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1400,7 +1402,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descrizione"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1409,7 +1411,7 @@ msgid "Design"
 msgstr "Tema"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destinazione"
 
@@ -1445,7 +1447,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Dispositivo irraggiungibile"
 
@@ -1462,7 +1464,7 @@ msgstr "Diagnostica"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Cartella"
 
@@ -1529,10 +1531,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1571,7 +1573,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Non proseguire con le ricerche inverse per le reti locali."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1583,7 +1585,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1623,7 +1625,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1669,9 +1671,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Metodo EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1858,12 +1860,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Scheda di Rete"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Switch di Rete"
 
@@ -1945,7 +1947,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1953,15 +1955,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "File"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -2013,7 +2015,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "Impostazioni Firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Stato del Firewall"
 
@@ -2201,8 +2203,8 @@ msgstr "Opzioni rete globale"
 msgid "Go to password configuration..."
 msgstr "Vai alla configurazione della password..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2244,8 +2246,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Nascondi <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2336,7 +2338,7 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 Firewall"
 
@@ -2387,8 +2389,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Indirizzo-IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2415,11 +2422,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 Firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2482,7 +2489,7 @@ msgstr "Suffisso IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Indirizzo-IPv6"
 
@@ -2599,7 +2606,7 @@ msgstr "Ignora file resolv"
 msgid "Image"
 msgstr "Immagine"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "In"
 
@@ -2652,8 +2659,8 @@ msgstr "Installa le estensioni del protocollo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfaccia"
@@ -2785,8 +2792,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Registro del Kernel"
 
@@ -2868,18 +2875,15 @@ msgid "Lease time"
 msgstr "Tempo Contratto"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Tempo contratto residuo"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "File di contratti"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2894,7 +2898,7 @@ msgstr "Lasciare vuoto per l'autorilevamento"
 msgid "Leave empty to use the current WAN address"
 msgstr "Lasciare vuoto per usare l'indirizzo WAN attuale"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -2985,7 +2989,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Porta di ascolto per le richieste DNS in entrata"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Carico"
 
@@ -2993,7 +2997,7 @@ msgstr "Carico"
 msgid "Load Average"
 msgstr "Carico Medio"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3110,7 +3114,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3250,8 +3255,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrica"
@@ -3322,7 +3327,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3413,8 +3418,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Candidati server NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3435,8 +3440,8 @@ msgstr "Navigazione"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Rete"
@@ -3462,7 +3467,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Prossimo »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3483,7 +3488,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3523,7 +3528,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Nessuna regola in questa catena"
 
@@ -3684,11 +3689,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Opzione cambiata"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Opzione cancellata"
 
@@ -3749,7 +3754,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Opzioni"
 
@@ -3757,7 +3762,7 @@ msgstr "Opzioni"
 msgid "Other:"
 msgstr "Altro:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Uscita"
 
@@ -3829,7 +3834,7 @@ msgstr "Sovrascrivi la tabella usata per le route interne"
 msgid "Overview"
 msgstr "Riassunto"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pacchetti"
 
@@ -4064,7 +4069,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -4072,11 +4077,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr "Per favore inserisci il tuo username e la password."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4144,7 +4149,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Processi"
 
@@ -4152,7 +4157,7 @@ msgstr "Processi"
 msgid "Profile"
 msgstr "Profilo"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4280,7 +4285,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Cambiare veramente il protocollo?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Grafici in Tempo Reale"
 
@@ -4320,7 +4325,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "Ricollega questa interfaccia"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Riferimenti"
 
@@ -4459,7 +4464,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Reset"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Azzera Contatori"
 
@@ -4486,7 +4491,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Riavvia"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Riavvia Firewall"
 
@@ -4507,19 +4512,19 @@ msgstr "Ripristina backup"
 msgid "Reveal/hide password"
 msgstr "Rivela/nascondi password"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Ripristina"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4553,8 +4558,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Route"
 
@@ -4566,7 +4571,7 @@ msgstr ""
 "Le route specificano attraverso quale interfaccia e gateway un certo host o "
 "rete può essere raggiunto."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4623,7 +4628,7 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4634,7 +4639,7 @@ msgid "Save"
 msgstr "Salva"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salva & applica"
@@ -4656,11 +4661,11 @@ msgstr "Scan"
 msgid "Scheduled Tasks"
 msgstr "Operazioni programmate"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Sezione aggiunta"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Sezione rimossa"
 
@@ -4675,9 +4680,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4761,7 +4766,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4791,7 +4796,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Dimensione"
@@ -4818,7 +4823,7 @@ msgid "Skip to navigation"
 msgstr "Salta a navigazione"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4846,8 +4851,8 @@ msgstr ""
 "specifici."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Origine"
 
@@ -4912,7 +4917,7 @@ msgstr "Inizio"
 msgid "Start priority"
 msgstr "Priorità di avvio"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4943,7 +4948,7 @@ msgstr "Instradamenti Statici"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Indirizzo Statico"
 
@@ -5023,7 +5028,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -5037,7 +5042,7 @@ msgstr "Cambia protocollo"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -5056,8 +5061,8 @@ msgstr "Sincronizza con il browser"
 msgid "System"
 msgstr "Sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Registro di Sistema"
 
@@ -5090,16 +5095,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Velocità TX"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabella"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Destinazione"
 
@@ -5144,7 +5149,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5177,7 +5182,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Le seguenti regole sono al momento attive su questo sistema."
 
@@ -5313,7 +5318,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5407,8 +5412,8 @@ msgstr ""
 "Questa lista da un riassunto dei processi correntemente attivi e del loro "
 "stato."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5454,9 +5459,9 @@ msgstr "Totale"
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Traffico"
 
@@ -5481,7 +5486,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5548,6 +5553,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5559,6 +5569,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5567,6 +5585,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5584,12 +5606,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Sconosciuto"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5599,7 +5621,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Non gestito"
 
@@ -5613,7 +5635,7 @@ msgstr "Smonta"
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Modifiche non salvate"
 
@@ -5639,7 +5661,7 @@ msgstr "Tipo protocollo non supportato."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5654,21 +5676,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Carica archivio..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5966,19 +5988,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Wireless"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Dispositivo Wireless"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Rete Wireless"
 
@@ -6022,7 +6044,7 @@ msgstr "Scrittura delle richiesta DNS ricevute nel syslog"
 msgid "Write system log to file"
 msgstr "Scrivi registro di sistema su file"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6245,7 +6267,7 @@ msgstr "Nessun collegamento"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "nessuna"
 
@@ -6353,7 +6375,7 @@ msgstr "sconosciuto"
 msgid "unlimited"
 msgstr "illimitato"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d ビット"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "無効な入力欄: %d 個"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- 追加項目 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- 選択してください --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- 手動設定 --"
@@ -170,12 +170,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-アドレス"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-ゲートウェイ"
 
@@ -211,7 +209,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 名"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-アドレス"
 
@@ -247,7 +244,7 @@ msgstr ""
 "<br />注意: 編集前の crontab ファイルが空の場合、手動で cron サービスの再起動"
 "を行う必要があります。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "同名のディレクトリが既に存在します。"
 
@@ -277,6 +274,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -336,12 +337,12 @@ msgstr "アクセスポイント"
 msgid "Actions"
 msgstr "動作"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "稼働中の <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-経路情報"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "稼働中の <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-経路情報"
@@ -366,11 +367,11 @@ msgstr "アクティブなDHCPv6リース"
 msgid "Ad-Hoc"
 msgstr "アドホック"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -476,7 +477,7 @@ msgid "Alert"
 msgstr "警告"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "エイリアス インターフェース"
@@ -658,16 +659,16 @@ msgstr "全てのゾーン"
 msgid "Apply backup?"
 msgstr "バックアップの適用"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "適用リクエストはステータス <code>%h</code> で失敗しました"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "チェック無しの適用"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "設定を適用中です… %d 秒"
 
@@ -880,7 +881,7 @@ msgid "Bogus NX Domain Override"
 msgstr "偽の NX ドメイン オーバーライド"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "ブリッジ"
 
@@ -897,8 +898,8 @@ msgstr "ブリッジ ユニット番号"
 msgid "Bring up on boot"
 msgstr "デフォルトで起動する"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "参照..."
 
@@ -929,8 +930,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -946,17 +947,17 @@ msgstr "キャンセル"
 msgid "Category"
 msgstr "カテゴリー"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "チェイン"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "変更"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "変更は取り消されました。"
 
@@ -1077,7 +1078,8 @@ msgstr "リストを閉じる"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "データ収集中です..."
@@ -1094,7 +1096,7 @@ msgstr "コマンド OK"
 msgid "Command failed"
 msgstr "コマンド失敗"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "コメント"
 
@@ -1110,16 +1112,16 @@ msgstr ""
 "この回避策は、相互運用性の問題や、特に高負荷のトラフィック環境下におけるキー "
 "ネゴシエーションの信頼性低下の原因となることがあります。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "設定"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "設定が適用されました。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "設定はロールバックされました！"
 
@@ -1150,7 +1152,7 @@ msgstr "接続の試行が失敗しました"
 msgid "Connection lost"
 msgstr "接続喪失"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "ネットワーク接続"
 
@@ -1166,7 +1168,7 @@ msgstr "内容が保存されました。"
 msgid "Continue"
 msgstr "続行"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1257,7 +1259,7 @@ msgstr "DHCP 及び DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP クライアント"
 
@@ -1383,11 +1385,11 @@ msgstr ""
 "追加のDHCPオプションを設定します。（例：\"<code>6,192.168.2.1,192.168.2.2</"
 "code>\" と設定することで、クライアントに指定のDNSサーバーを通知します。）"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1399,7 +1401,7 @@ msgstr "削除"
 msgid "Delete key"
 msgstr "公開鍵を削除"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "削除リクエスト失敗: %s"
 
@@ -1415,7 +1417,7 @@ msgstr "Delivery Traffic Indication Message インターバル"
 msgid "Description"
 msgstr "説明"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1424,7 +1426,7 @@ msgid "Design"
 msgstr "デザイン"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "宛先"
 
@@ -1460,7 +1462,7 @@ msgstr "デバイスがアクティブではありません"
 msgid "Device is restarting…"
 msgstr "デバイスを再起動中..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "デバイスに到達できません"
 
@@ -1477,7 +1479,7 @@ msgstr "診断機能"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "ディレクトリ"
 
@@ -1544,10 +1546,10 @@ msgstr "切断"
 msgid "Disconnection attempt failed"
 msgstr "切断の試行が失敗しました"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1586,7 +1588,7 @@ msgstr "パブリック DNSサーバーが返答できなかったリクエス�
 msgid "Do not forward reverse lookups for local networks"
 msgstr "ローカル ネットワークへの逆引きを転送しません"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "本当に \"%s\" を削除しますか？"
 
@@ -1598,7 +1600,7 @@ msgstr "本当に以下の SSH 公開鍵を削除しますか？"
 msgid "Do you really want to erase all settings?"
 msgstr "本当に全ての設定を消去しますか？"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "本当にディレクトリ \"%s\" を再帰的に削除しますか？"
 
@@ -1638,7 +1640,7 @@ msgstr "mtdblock のダウンロード"
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "ドラッグして並び替え"
 
@@ -1684,9 +1686,9 @@ msgstr "EA ビット長"
 msgid "EAP-Method"
 msgstr "EAP メソッド"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1879,12 +1881,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "イーサネットアダプタ"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "イーサネットスイッチ"
 
@@ -1966,7 +1968,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr "システム パスワードの変更に失敗しました。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "%d 秒以内の適用を確認できませんでした。ロールバック中です..."
 
@@ -1974,15 +1976,15 @@ msgstr "%d 秒以内の適用を確認できませんでした。ロールバッ
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "\"/etc/init.d/%s %s\" の実行に失敗しました: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "ファイル"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "ファイル名"
 
@@ -2036,7 +2038,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "ファイアウォール設定"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "ファイアウォール ステータス"
 
@@ -2225,8 +2227,8 @@ msgstr "グローバル ネットワークオプション"
 msgid "Go to password configuration..."
 msgstr "パスワード設定へ移動..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2267,8 +2269,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>の隠匿"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "空のチェインを非表示"
 
@@ -2359,7 +2361,7 @@ msgstr "IP アドレスがありません"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 ファイアウォール"
 
@@ -2410,8 +2412,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-アドレス"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2438,11 +2445,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 ファイアウォール"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2505,7 +2512,7 @@ msgstr "IPv6 サフィックス"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-アドレス"
 
@@ -2619,7 +2626,7 @@ msgstr "リゾルバ ファイルを無視する"
 msgid "Image"
 msgstr "イメージ"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "イン"
 
@@ -2674,8 +2681,8 @@ msgstr "プロトコル拡張機能をインストールします..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "インターフェース"
@@ -2808,8 +2815,8 @@ msgstr "ネットワークに接続: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "現在の設定を保持"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "カーネル ログ"
 
@@ -2891,18 +2898,15 @@ msgid "Lease time"
 msgstr "リース時間"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "残りリース時間"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "リースファイル"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2917,7 +2921,7 @@ msgstr "空欄の場合、自動検知を行います"
 msgid "Leave empty to use the current WAN address"
 msgstr "空欄の場合、現在のWANアドレスを使用します"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "凡例:"
 
@@ -3012,7 +3016,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "DNSクエリを受信するポート"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "負荷"
 
@@ -3020,7 +3024,7 @@ msgstr "負荷"
 msgid "Load Average"
 msgstr "システム平均負荷"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "ディレクトリ内を読み込み中..."
 
@@ -3138,7 +3142,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-アドレス"
 
@@ -3279,8 +3284,8 @@ msgid "Method not found"
 msgstr "メソッドが見つかりません"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "メトリック"
@@ -3351,7 +3356,7 @@ msgstr "モニター"
 msgid "More Characters"
 msgstr "文字数不足"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "さらに表示…"
 
@@ -3442,8 +3447,8 @@ msgstr "NT ドメイン"
 msgid "NTP server candidates"
 msgstr "NTPサーバー候補"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3464,8 +3469,8 @@ msgstr "ナビゲーション"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "ネットワーク"
@@ -3491,7 +3496,7 @@ msgstr "新規インターフェース名"
 msgid "Next »"
 msgstr "次 »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "いいえ"
@@ -3512,7 +3517,7 @@ msgstr "NAT-Tを使用しない"
 msgid "No data received"
 msgstr "受信データ無し"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "ディレクトリ内にエントリーがありません"
 
@@ -3552,7 +3557,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr "まだ公開鍵はありません。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "チェイン内にルールがありません"
 
@@ -3715,11 +3720,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "動作周波数"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "変更されるオプション"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "削除されるオプション"
 
@@ -3788,7 +3793,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "発信パケットと受信パケットに使用されるUDPポート（オプション）"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "オプション"
 
@@ -3796,7 +3801,7 @@ msgstr "オプション"
 msgid "Other:"
 msgstr "その他:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "アウト"
 
@@ -3868,7 +3873,7 @@ msgstr "内部ルートに使用されるテーブルを上書きします。"
 msgid "Overview"
 msgstr "概要"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "既存のファイル \"%s\" を上書きしますか？"
 
@@ -3969,7 +3974,7 @@ msgstr "PSID ビット長"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "パケット"
 
@@ -4103,7 +4108,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "パケット"
 
@@ -4111,11 +4116,11 @@ msgstr "パケット"
 msgid "Please enter your username and password."
 msgstr "ユーザー名とパスワードを入力してください。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "アップロードするファイルを選択してください。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "ポリシー"
 
@@ -4185,7 +4190,7 @@ msgid "Private Key"
 msgstr "秘密鍵"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "プロセス"
 
@@ -4193,7 +4198,7 @@ msgstr "プロセス"
 msgid "Profile"
 msgstr "プロファイル"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "プロトコル"
 
@@ -4329,7 +4334,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "本当にプロトコルを切り替えますか?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "リアルタイム グラフ"
 
@@ -4369,7 +4374,7 @@ msgstr "WireGuard インターフェースのIPアドレスです。（推奨）
 msgid "Reconnect this interface"
 msgstr "インターフェースを再接続します"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "参照カウンタ"
 
@@ -4512,7 +4517,7 @@ msgstr "SAE サポートを含む wpa-supplicant が必要"
 msgid "Reset"
 msgstr "リセット"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "カウンタをリセット"
 
@@ -4539,7 +4544,7 @@ msgstr "リソースが見つかりません"
 msgid "Restart"
 msgstr "再起動"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "ファイアウォールを再起動"
 
@@ -4560,19 +4565,19 @@ msgstr "バックアップから復元する"
 msgid "Reveal/hide password"
 msgstr "パスワードを表示する/隠す"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "元に戻す"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "変更の取り消し"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "取り消しのリクエストはステータス <code>%h</code> で失敗しました"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "設定を元に戻しています..."
 
@@ -4606,8 +4611,8 @@ msgid "Router Password"
 msgstr "ルーター パスワード"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "経路情報"
 
@@ -4619,7 +4624,7 @@ msgstr ""
 "特定のホスト又はネットワークに、どのインターフェース及びゲートウェイを通して"
 "通信を行うか、経路情報を設定します。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "ルール"
 
@@ -4676,7 +4681,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "スワップ"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4687,7 +4692,7 @@ msgid "Save"
 msgstr "保存"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存 & 適用"
@@ -4709,11 +4714,11 @@ msgstr "スキャン"
 msgid "Scheduled Tasks"
 msgstr "スケジュールタスク"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "追加されるセクション"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "削除されるセクション"
 
@@ -4731,9 +4736,9 @@ msgstr ""
 "を選択してください。ファームウェアが正しいこと、デバイスに適していることを確"
 "認できている場合にのみ使用してください！"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "ファイルを選択..."
 
@@ -4820,7 +4825,7 @@ msgstr "Short Preamble"
 msgid "Show current backup file list"
 msgstr "現在のバックアップファイルのリストを表示する"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "空のチェインを表示"
 
@@ -4850,7 +4855,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "信号:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "サイズ"
@@ -4877,7 +4882,7 @@ msgid "Skip to navigation"
 msgstr "ナビゲーションへ移動"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "ソフトウェア VLAN"
 
@@ -4904,8 +4909,8 @@ msgstr ""
 "デバイスのインストール手順を参照してください。"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "送信元"
 
@@ -4973,7 +4978,7 @@ msgstr "開始"
 msgid "Start priority"
 msgstr "優先順位"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "設定の適用を開始しています..."
 
@@ -5004,7 +5009,7 @@ msgstr "静的ルーティング"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "静的アドレス"
 
@@ -5085,7 +5090,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "スイッチ VLAN"
 
@@ -5099,7 +5104,7 @@ msgstr "プロトコルの切り替え"
 msgid "Switch to CIDR list notation"
 msgstr "CIDR リスト表記へ切替"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "シンボリックリンク"
 
@@ -5118,8 +5123,8 @@ msgstr "ブラウザの時刻と同期"
 msgid "System"
 msgstr "システム"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "システムログ"
 
@@ -5152,16 +5157,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "送信レート"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "テーブル"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "ターゲット"
 
@@ -5208,7 +5213,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "設定ファイルは以下のエラーにより読み込めませんでした:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5250,7 +5255,7 @@ msgstr ""
 "イズです。オリジナルのファイルと比較し、データの整合性を確認してください。"
 "<br />\"続行\" をクリックすると、更新処理を開始します。"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "このシステムでは、現在以下のルールが有効になっています。"
 
@@ -5400,7 +5405,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "アクティブなリースはありません"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "適用する変更はありません"
 
@@ -5506,8 +5511,8 @@ msgstr ""
 "このリストは現在システムで動作しているプロセスとそのステータスを表示していま"
 "す。"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5553,9 +5558,9 @@ msgstr "合計"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "トラフィック"
 
@@ -5580,7 +5585,7 @@ msgid "Tunnel ID"
 msgstr "トンネル ID"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "トンネルインターフェース"
 
@@ -5647,6 +5652,11 @@ msgstr "アップストリーム インターフェースを確定できませ�
 msgid "Unable to dispatch"
 msgstr "ディスパッチできません"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5658,6 +5668,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr "マウント情報を取得できません"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5667,6 +5685,10 @@ msgstr "AFTR ホスト名を解決できません"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "ピアのホスト名を解決できません"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5683,12 +5705,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "不明"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "不明なエラー (%s)"
 
@@ -5698,7 +5720,7 @@ msgstr "不明なエラーコード"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Unmanaged"
 
@@ -5712,7 +5734,7 @@ msgstr "アンマウント"
 msgid "Unnamed key"
 msgstr "名称未設定の公開鍵"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "保存されていない変更"
 
@@ -5738,7 +5760,7 @@ msgstr "サポートされていないプロトコルタイプ"
 msgid "Up"
 msgstr "上へ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "アップロード"
 
@@ -5755,21 +5777,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "アーカイブをアップロード..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "ファイルのアップロード"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "ファイルをアップロード…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "アップロード リクエスト失敗: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "ファイルのアップロード..."
 
@@ -6071,19 +6093,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "無線"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "無線アダプタ"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "無線ネットワーク"
 
@@ -6127,7 +6149,7 @@ msgstr "受信したDNSリクエストをsyslogへ記録します"
 msgid "Write system log to file"
 msgstr "システムログをファイルに書き込む"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "はい"
@@ -6349,7 +6371,7 @@ msgstr "リンクなし"
 msgid "non-empty value"
 msgstr "空ではない値"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "なし"
 
@@ -6457,7 +6479,7 @@ msgstr "不明"
 msgid "unlimited"
 msgstr "無期限"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -58,11 +58,11 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -70,7 +70,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -167,12 +167,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-주소"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 
@@ -205,7 +203,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 이름"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-주소"
 
@@ -239,7 +236,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -268,6 +265,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -328,12 +329,12 @@ msgstr ""
 msgid "Actions"
 msgstr "관리 도구"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Route 경로"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Route 경로"
@@ -358,11 +359,11 @@ msgstr "Active DHCPv6 임대 목록"
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -466,7 +467,7 @@ msgid "Alert"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -640,16 +641,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -855,7 +856,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr ""
 
@@ -872,8 +873,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr "부팅시 활성화"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -904,8 +905,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -921,17 +922,17 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "변경 사항"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1047,7 +1048,8 @@ msgstr "목록 닫기..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Data 를 수집중입니다..."
@@ -1064,7 +1066,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1076,16 +1078,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "설정"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1116,7 +1118,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "연결"
 
@@ -1132,7 +1134,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1218,7 +1220,7 @@ msgstr "DHCP 와 DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP client"
 
@@ -1345,11 +1347,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" 는 client 에게 다른 DNS 서버를 세"
 "팅하도록 권고할 수 있습니다."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1361,7 +1363,7 @@ msgstr "삭제"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1377,7 +1379,7 @@ msgstr ""
 msgid "Description"
 msgstr "설명"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1386,7 +1388,7 @@ msgid "Design"
 msgstr "디자인"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr ""
 
@@ -1422,7 +1424,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1439,7 +1441,7 @@ msgstr "진단"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1506,10 +1508,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1546,7 +1548,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1558,7 +1560,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1596,7 +1598,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1641,9 +1643,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1830,12 +1832,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet 스위치"
 
@@ -1915,7 +1917,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1923,15 +1925,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1983,7 +1985,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "방화벽 설정"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "방화벽 상태"
 
@@ -2169,8 +2171,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "암호 설정 하기"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2211,8 +2213,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr> 숨기기"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2302,7 +2304,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 방화벽"
 
@@ -2353,8 +2355,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-주소"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2381,11 +2388,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 방화벽"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "IPv6 Neighbour 들"
 
@@ -2448,7 +2455,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-주소"
 
@@ -2554,7 +2561,7 @@ msgstr "resolve 파일 무시"
 msgid "Image"
 msgstr "이미지"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "In"
 
@@ -2607,8 +2614,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "인터페이스"
@@ -2737,8 +2744,8 @@ msgstr "네트워크 연결중: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Kernel 로그"
 
@@ -2820,17 +2827,14 @@ msgid "Lease time"
 msgstr "임대 시간"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "남아있는 임대 시간"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2846,7 +2850,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2937,7 +2941,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "부하"
 
@@ -2945,7 +2949,7 @@ msgstr "부하"
 msgid "Load Average"
 msgstr "부하 평균"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3056,7 +3060,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-주소"
 
@@ -3196,8 +3201,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3268,7 +3273,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3357,8 +3362,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "NTP 서버 목록"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3379,8 +3384,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "네트워크"
@@ -3406,7 +3411,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3427,7 +3432,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3467,7 +3472,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3628,11 +3633,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr "동작 주파수"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "변경된 option"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "삭제된 option"
 
@@ -3693,7 +3698,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3701,7 +3706,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3773,7 +3778,7 @@ msgstr ""
 msgid "Overview"
 msgstr "개요"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3874,7 +3879,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -4008,7 +4013,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pkts."
 
@@ -4016,11 +4021,11 @@ msgstr "Pkts."
 msgid "Please enter your username and password."
 msgstr "사용자이름과 암호를 입력해 주세요."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4088,7 +4093,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "프로세스"
 
@@ -4096,7 +4101,7 @@ msgstr "프로세스"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4224,7 +4229,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "정말 프로토콜 변경을 원하세요?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "실시간 그래프"
 
@@ -4264,7 +4269,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "이 인터페이스를 재연결합니다"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4403,7 +4408,7 @@ msgstr ""
 msgid "Reset"
 msgstr "초기화"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Counter 초기화"
 
@@ -4430,7 +4435,7 @@ msgstr ""
 msgid "Restart"
 msgstr "재시작"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "방화벽 재시작"
 
@@ -4451,19 +4456,19 @@ msgstr "백업 복구"
 msgid "Reveal/hide password"
 msgstr "암호 보이기/숨기기"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "변경 취소"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4497,8 +4502,8 @@ msgid "Router Password"
 msgstr "라우터 암호"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Route 경로"
 
@@ -4510,7 +4515,7 @@ msgstr ""
 "Route 경로는 특정 호스트 혹은 네트워크가 사용해야 할 인터페이스와 gateway 정"
 "보를 나타냅니다."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4567,7 +4572,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4578,7 +4583,7 @@ msgid "Save"
 msgstr "저장"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "저장 & 적용"
@@ -4600,11 +4605,11 @@ msgstr "Scan 하기"
 msgid "Scheduled Tasks"
 msgstr "작업 관리"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "추가된 section"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "삭제된 section"
 
@@ -4619,9 +4624,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4705,7 +4710,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr "현재 백업 파일 목록 보기"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4735,7 +4740,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Size"
@@ -4762,7 +4767,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4786,8 +4791,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr ""
 
@@ -4848,7 +4853,7 @@ msgstr "시작"
 msgid "Start priority"
 msgstr "시작 우선순위"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4879,7 +4884,7 @@ msgstr "Static Route 경로"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4958,7 +4963,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "스위치 VLAN"
 
@@ -4972,7 +4977,7 @@ msgstr "프로토콜 변경"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4991,8 +4996,8 @@ msgstr "브라우저 시간대로 동기화"
 msgid "System"
 msgstr "시스템"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "시스템 로그"
 
@@ -5025,16 +5030,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr ""
 
@@ -5077,7 +5082,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5108,7 +5113,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "다음의 rule 들이 현재 이 시스템에 적용 중입니다."
 
@@ -5242,7 +5247,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5338,8 +5343,8 @@ msgid ""
 msgstr ""
 "이 목록은 현재 실행중인 시스템 프로세스와 해당 상태에 대한 개요를 보여줍니다."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5385,9 +5390,9 @@ msgstr "총 이용 가능한 양"
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "트래픽"
 
@@ -5412,7 +5417,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5479,6 +5484,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5490,6 +5500,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5498,6 +5516,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5515,12 +5537,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "알수없음"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5530,7 +5552,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5544,7 +5566,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "적용 안된 변경 사항"
 
@@ -5570,7 +5592,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5585,21 +5607,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "아카이브 업로드..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5894,19 +5916,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "무선"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "무선랜 네트워크"
 
@@ -5950,7 +5972,7 @@ msgstr "받은 DNS 요청 내용을 systlog 에 기록합니다"
 msgid "Write system log to file"
 msgstr "System log 출력 파일 경로"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6170,7 +6192,7 @@ msgstr "link 없음"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr ""
 
@@ -6278,7 +6300,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -19,7 +19,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -55,11 +55,11 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -67,7 +67,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -164,12 +164,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 
@@ -202,7 +200,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 
@@ -232,7 +229,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -261,6 +258,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -321,11 +322,11 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
@@ -349,11 +350,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -457,7 +458,7 @@ msgid "Alert"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -631,16 +632,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -843,7 +844,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr ""
 
@@ -860,8 +861,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -892,8 +893,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -909,17 +910,17 @@ msgstr "रद्द करा"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1027,7 +1028,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "डेटा संकलित करीत आहे ..."
@@ -1044,7 +1046,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1056,16 +1058,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1096,7 +1098,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr ""
 
@@ -1112,7 +1114,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1196,7 +1198,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1320,11 +1322,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1336,7 +1338,7 @@ msgstr ""
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1352,7 +1354,7 @@ msgstr ""
 msgid "Description"
 msgstr "वर्णन"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1361,7 +1363,7 @@ msgid "Design"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr ""
 
@@ -1397,7 +1399,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1414,7 +1416,7 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1479,10 +1481,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1516,7 +1518,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1528,7 +1530,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1566,7 +1568,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1607,9 +1609,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1796,12 +1798,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1881,7 +1883,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1889,15 +1891,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1949,7 +1951,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr ""
 
@@ -2135,8 +2137,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2176,8 +2178,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2267,7 +2269,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2318,7 +2320,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2346,11 +2353,11 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2519,7 +2526,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2572,8 +2579,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
@@ -2702,8 +2709,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr ""
 
@@ -2785,17 +2792,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2811,7 +2815,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2900,7 +2904,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr ""
 
@@ -2908,7 +2912,7 @@ msgstr ""
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3019,7 +3023,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3159,8 +3164,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3231,7 +3236,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3320,8 +3325,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3342,8 +3347,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr ""
@@ -3369,7 +3374,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3390,7 +3395,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3430,7 +3435,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3591,11 +3596,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3656,7 +3661,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3664,7 +3669,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3734,7 +3739,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3835,7 +3840,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -3969,7 +3974,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -3977,11 +3982,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4049,7 +4054,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr ""
 
@@ -4057,7 +4062,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4183,7 +4188,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4223,7 +4228,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4362,7 +4367,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr ""
 
@@ -4389,7 +4394,7 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr ""
 
@@ -4410,19 +4415,19 @@ msgstr ""
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4456,8 +4461,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr ""
 
@@ -4467,7 +4472,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4524,7 +4529,7 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4535,7 +4540,7 @@ msgid "Save"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4557,11 +4562,11 @@ msgstr ""
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4576,9 +4581,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4662,7 +4667,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4692,7 +4697,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr ""
@@ -4719,7 +4724,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4743,8 +4748,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "स्रोत"
 
@@ -4805,7 +4810,7 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4836,7 +4841,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4912,7 +4917,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4926,7 +4931,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4945,8 +4950,8 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr ""
 
@@ -4979,16 +4984,16 @@ msgstr ""
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr ""
 
@@ -5031,7 +5036,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5062,7 +5067,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5191,7 +5196,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5279,8 +5284,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5323,9 +5328,9 @@ msgstr ""
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr ""
 
@@ -5350,7 +5355,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5417,6 +5422,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5428,6 +5438,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5436,6 +5454,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5453,12 +5475,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5468,7 +5490,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5482,7 +5504,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5508,7 +5530,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5523,21 +5545,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5827,19 +5849,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr ""
 
@@ -5883,7 +5905,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6097,7 +6119,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr ""
 
@@ -6205,7 +6227,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -2908,10 +2908,6 @@ msgstr ""
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-mod-network/luasrc/view/admin_network/diagnostics.htm:33
-msgid "Loading"
-msgstr "लोड करीत आहे"
-
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
 msgid "Loading directory contents…"
 msgstr ""

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -58,11 +58,11 @@ msgid "-- Additional Field --"
 msgstr "-- Gelanggang Tambahan --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -70,7 +70,7 @@ msgstr "-- Sila pilih --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- memperibadi --"
@@ -168,12 +168,10 @@ msgstr ""
 "<abbr title=\"perkhidmatan set mengenalpasti diperpanjangkan\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "IPv4-Alamat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "IPv4-Pintu gerbang"
 
@@ -206,7 +204,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "MAC-Alamat"
 
@@ -236,7 +233,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -265,6 +262,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -325,11 +326,11 @@ msgstr "Pusat akses"
 msgid "Actions"
 msgstr "Aksi"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Aktive IPv4-Routen"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktif IPv6-Laluan"
 
@@ -353,11 +354,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -461,7 +462,7 @@ msgid "Alert"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -635,16 +636,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -847,7 +848,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Bridge"
 
@@ -864,8 +865,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -896,8 +897,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -913,17 +914,17 @@ msgstr "Batal"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Rantai"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Laman"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1031,7 +1032,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Mengumpul data..."
@@ -1048,7 +1050,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1060,16 +1062,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Konfigurasi"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1100,7 +1102,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr ""
 
@@ -1116,7 +1118,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1200,7 +1202,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1324,11 +1326,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1340,7 +1342,7 @@ msgstr "Padam"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1356,7 +1358,7 @@ msgstr ""
 msgid "Description"
 msgstr "Keterangan"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1365,7 +1367,7 @@ msgid "Design"
 msgstr "Disain"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Tempat tujuan"
 
@@ -1401,7 +1403,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1418,7 +1420,7 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1483,10 +1485,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1525,7 +1527,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1537,7 +1539,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1575,7 +1577,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1617,9 +1619,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-Kaedah"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1806,12 +1808,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernet Adapter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet Beralih"
 
@@ -1891,7 +1893,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1899,15 +1901,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1959,7 +1961,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "Tetapan Firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Status Firewall"
 
@@ -2145,8 +2147,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2188,8 +2190,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Menyembunyikan ESSID"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2279,7 +2281,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2330,7 +2332,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2358,11 +2365,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "Konfigurasi IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2425,7 +2432,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2536,7 +2543,7 @@ msgstr "Abaikan fail yang selesai"
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Masuk"
 
@@ -2589,8 +2596,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
@@ -2723,8 +2730,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Log Kernel"
 
@@ -2806,18 +2813,15 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Sisa masa penyewaan"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Sewa fail"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2832,7 +2836,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2921,7 +2925,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Load"
 
@@ -2929,7 +2933,7 @@ msgstr "Load"
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3040,7 +3044,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3180,8 +3185,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrik"
@@ -3252,7 +3257,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3343,8 +3348,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3365,8 +3370,8 @@ msgstr "Navigation"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Rangkaian"
@@ -3392,7 +3397,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Kemudian »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3413,7 +3418,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3453,7 +3458,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Tidak ada peraturan dalam rantai ini"
 
@@ -3614,11 +3619,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3679,7 +3684,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Pilihan"
 
@@ -3687,7 +3692,7 @@ msgstr "Pilihan"
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Keluar"
 
@@ -3757,7 +3762,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Keseluruhan"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3858,7 +3863,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Paket"
 
@@ -3992,7 +3997,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pkts."
 
@@ -4000,11 +4005,11 @@ msgstr "Pkts."
 msgid "Please enter your username and password."
 msgstr "Sila masukkan username dan kata laluan anda."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Dasar"
 
@@ -4072,7 +4077,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Proses"
 
@@ -4080,7 +4085,7 @@ msgstr "Proses"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4207,7 +4212,7 @@ msgstr "Baca /etc/ethers untuk mengkonfigurasikan DHCP-Server"
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4247,7 +4252,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Rujukan"
 
@@ -4386,7 +4391,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Reset"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Reset Loket"
 
@@ -4413,7 +4418,7 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Restart Firewall"
 
@@ -4434,19 +4439,19 @@ msgstr "Kembalikan sandaran"
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Kembali"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4480,8 +4485,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Laluan"
 
@@ -4493,7 +4498,7 @@ msgstr ""
 "Laluan menentukan di mana interface dan gateway host atau rangkaian tertentu "
 "yang boleh dicapai."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4550,7 +4555,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4561,7 +4566,7 @@ msgid "Save"
 msgstr "Simpan"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Simpan & Melaksanakan"
@@ -4583,11 +4588,11 @@ msgstr "Scan"
 msgid "Scheduled Tasks"
 msgstr "Tugas Jadual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4602,9 +4607,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4688,7 +4693,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4718,7 +4723,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Saiz"
@@ -4745,7 +4750,7 @@ msgid "Skip to navigation"
 msgstr "Skip ke navigation"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4769,8 +4774,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Sumber"
 
@@ -4831,7 +4836,7 @@ msgstr "Mula"
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4862,7 +4867,7 @@ msgstr "Laluan Statik"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4938,7 +4943,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4952,7 +4957,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4971,8 +4976,8 @@ msgstr ""
 msgid "System"
 msgstr "Sistem"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Log Sistem"
 
@@ -5006,16 +5011,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Meja"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Sasaran"
 
@@ -5060,7 +5065,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5091,7 +5096,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Peraturan berikut sedang aktif pada sistem ini."
 
@@ -5227,7 +5232,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5319,8 +5324,8 @@ msgstr ""
 "Senarai ini memberikan gambaran lebih pada proses sistem yang sedang "
 "berjalan dan statusnya."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5363,9 +5368,9 @@ msgstr ""
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Lalu lintas"
 
@@ -5390,7 +5395,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5457,6 +5462,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5468,6 +5478,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5476,6 +5494,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5493,12 +5515,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5508,7 +5530,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5522,7 +5544,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Perubahan yang belum disimpan"
 
@@ -5548,7 +5570,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5563,21 +5585,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5869,19 +5891,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Adapter Wayarles"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Rangkaian Wayarles"
 
@@ -5925,7 +5947,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6139,7 +6161,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "tidak ada"
 
@@ -6247,7 +6269,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -19,7 +19,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -55,11 +55,11 @@ msgid "-- Additional Field --"
 msgstr "-- Tilleggs Felt --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -67,7 +67,7 @@ msgstr "-- Vennligst velg --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- egendefinert --"
@@ -166,12 +166,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Adresse"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 
@@ -206,7 +204,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Navn"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-Adresse"
 
@@ -240,7 +237,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -270,6 +267,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "<abbr title=\"Aksesspunkt Navn\">APN</abbr>"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -336,11 +337,11 @@ msgstr "Aksesspunkt"
 msgid "Actions"
 msgstr "Handlinger"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Ruter"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Ruter"
 
@@ -364,11 +365,11 @@ msgstr "Aktive DHCPv6 Leier"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc (Uavhengig)"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -472,7 +473,7 @@ msgid "Alert"
 msgstr "Varsle"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -646,16 +647,16 @@ msgstr "Alle soner"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -861,7 +862,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Overstyr falske NX Domener"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Bro"
 
@@ -878,8 +879,8 @@ msgstr "Bro enhetsnummer"
 msgid "Bring up on boot"
 msgstr "Slå på ved oppstart"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -910,8 +911,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -927,17 +928,17 @@ msgstr "Avbryt"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Lenke"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Endringer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1055,7 +1056,8 @@ msgstr "Lukk liste..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Samler inn data…"
@@ -1072,7 +1074,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1084,16 +1086,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Konfigurasjon"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1124,7 +1126,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Tilkoblinger"
 
@@ -1140,7 +1142,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1226,7 +1228,7 @@ msgstr "DHCP og DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP klient"
 
@@ -1352,11 +1354,11 @@ msgstr ""
 "Definer flere DHCP valg, f.eks \"<code>192.168.2.1,192.168.2.2</code>\" som "
 "annonserer forskjellige DNS servere til klientene."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1368,7 +1370,7 @@ msgstr "Fjern"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1384,7 +1386,7 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1393,7 +1395,7 @@ msgid "Design"
 msgstr "Design"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destinasjon"
 
@@ -1429,7 +1431,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1446,7 +1448,7 @@ msgstr "Nettverksdiagnostikk"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Katalog"
 
@@ -1513,10 +1515,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1556,7 +1558,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Ikke videresend reverserte oppslag for lokale nettverk"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1568,7 +1570,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1608,7 +1610,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1654,9 +1656,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-metode"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1843,12 +1845,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernet Tilslutning"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet Svitsj"
 
@@ -1929,7 +1931,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1937,15 +1939,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1997,7 +1999,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "Brannmur Innstillinger"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Brannmur Status"
 
@@ -2184,8 +2186,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Gå til passord konfigurasjon..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2227,8 +2229,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Skjul <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2319,7 +2321,7 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 Brannmur"
 
@@ -2370,8 +2372,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-Adresse"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2398,11 +2405,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 Brannmur"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2465,7 +2472,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-Adresse"
 
@@ -2575,7 +2582,7 @@ msgstr "Ignorer oppslagsfil"
 msgid "Image"
 msgstr "Firmware"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "i"
 
@@ -2628,8 +2635,8 @@ msgstr "Installer protokoll utvidelser..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Grensesnitt"
@@ -2761,8 +2768,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Kjerne Logg"
 
@@ -2844,18 +2851,15 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "<abbr title=\"Leasefile\">Leie-fil</abbr>"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr "Gjenværende leietid"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2870,7 +2874,7 @@ msgstr "La stå tomt for automatisk oppdagelse"
 msgid "Leave empty to use the current WAN address"
 msgstr "La stå tomt for å bruke gjeldene WAN adresse"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Forklaring:"
 
@@ -2962,7 +2966,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Lytte-port for innkommende DNS-spørring"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Belastning"
 
@@ -2970,7 +2974,7 @@ msgstr "Belastning"
 msgid "Load Average"
 msgstr "Belastning Gjennomsnitt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3086,7 +3090,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-Adresse"
 
@@ -3226,8 +3231,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrisk"
@@ -3298,7 +3303,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3389,8 +3394,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "NTP server kandidater"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3411,8 +3416,8 @@ msgstr "Navigasjon"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Nettverk"
@@ -3438,7 +3443,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Neste »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3459,7 +3464,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3499,7 +3504,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Ingen regler i denne tabellen"
 
@@ -3660,11 +3665,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Innstilling endret"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Innstilling fjernet"
 
@@ -3725,7 +3730,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Alternativer"
 
@@ -3733,7 +3738,7 @@ msgstr "Alternativer"
 msgid "Other:"
 msgstr "Andre:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Ut"
 
@@ -3805,7 +3810,7 @@ msgstr "Overstyr tabellen som brukes for interne ruter"
 msgid "Overview"
 msgstr "Oversikt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3906,7 +3911,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pakker"
 
@@ -4040,7 +4045,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pakker."
 
@@ -4048,11 +4053,11 @@ msgstr "Pakker."
 msgid "Please enter your username and password."
 msgstr "Skriv inn ditt brukernavn og passord."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Policy"
 
@@ -4122,7 +4127,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Prosesser"
 
@@ -4130,7 +4135,7 @@ msgstr "Prosesser"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4258,7 +4263,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Vil du endre protokoll?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Grafer i sanntid"
 
@@ -4298,7 +4303,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "Koble til igjen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referanser"
 
@@ -4437,7 +4442,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Nullstill"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Nullstill Tellere"
 
@@ -4464,7 +4469,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Omstart"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Omstart Brannmur"
 
@@ -4485,19 +4490,19 @@ msgstr "Gjenopprett sikkerhetskopi"
 msgid "Reveal/hide password"
 msgstr "Vis/Skjul passord"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Tilbakestill"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4531,8 +4536,8 @@ msgid "Router Password"
 msgstr "Ruter Passord"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Ruter"
 
@@ -4544,7 +4549,7 @@ msgstr ""
 "Ruter, angir hvilket nettverksgrensesnitt og hvilken gateway som brukes for "
 "å nå et gitt nettverk eller vert."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4601,7 +4606,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4612,7 +4617,7 @@ msgid "Save"
 msgstr "Lagre"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Lagre & Aktiver"
@@ -4634,11 +4639,11 @@ msgstr "Skann"
 msgid "Scheduled Tasks"
 msgstr "Planlagte Oppgaver"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Seksjon lagt til"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Seksjon fjernet"
 
@@ -4653,9 +4658,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4741,7 +4746,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr "Vis gjeldende liste med sikkerhetskopifiler"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4771,7 +4776,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Signal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Størrelse"
@@ -4798,7 +4803,7 @@ msgid "Skip to navigation"
 msgstr "Gå til navigasjon"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4825,8 +4830,8 @@ msgstr ""
 "enheter."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Kilde"
 
@@ -4888,7 +4893,7 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Start prioritet"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4919,7 +4924,7 @@ msgstr "Statiske Ruter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Statisk adresse"
 
@@ -4998,7 +5003,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -5012,7 +5017,7 @@ msgstr "Svitsj protokoll"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -5031,8 +5036,8 @@ msgstr "Synkroniser med nettleser"
 msgid "System"
 msgstr "System"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "System Logg"
 
@@ -5065,16 +5070,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "TX rate"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabell"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Mål"
 
@@ -5120,7 +5125,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5153,7 +5158,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Følgende regler er aktiver på systemet."
 
@@ -5296,7 +5301,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5396,8 +5401,8 @@ msgid ""
 "their status."
 msgstr "Denne listen gir en oversikt over kjørende prosesser og deres status."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5444,9 +5449,9 @@ msgstr "Totalt Tilgjengelig"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Trafikk"
 
@@ -5471,7 +5476,7 @@ msgid "Tunnel ID"
 msgstr "Tunnel ID"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Tunnel grensesnitt"
 
@@ -5538,6 +5543,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr "Kan ikke sende"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5549,6 +5559,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5557,6 +5575,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5574,12 +5596,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Ukjent"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5589,7 +5611,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Uhåndtert"
 
@@ -5603,7 +5625,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Ulagrede Endringer"
 
@@ -5629,7 +5651,7 @@ msgstr "Protokoll type er ikke støttet."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5644,21 +5666,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Last opp arkiv..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5957,19 +5979,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Trådløs"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Trådløs Tilslutning"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Trådløst Nettverk"
 
@@ -6013,7 +6035,7 @@ msgstr "Skriv mottatte DNS forespørsler til syslog"
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6235,7 +6257,7 @@ msgstr "ingen forbindelse"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "ingen"
 
@@ -6343,7 +6365,7 @@ msgstr "ukjent"
 msgid "unlimited"
 msgstr "ubegrenset"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368
@@ -6542,6 +6564,9 @@ msgstr "ja"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Tilbake"
+
+#~ msgid "Leasetime remaining"
+#~ msgstr "Gjenværende leietid"
 
 #~ msgid "Bad address specified!"
 #~ msgstr "Ugyldig adresse oppgitt!"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -24,7 +24,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d nieprawidłowe pole(pola)"
 
@@ -60,11 +60,11 @@ msgid "-- Additional Field --"
 msgstr "-- Dodatkowe pole --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -72,7 +72,7 @@ msgstr "-- Proszę wybrać --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- własne --"
@@ -171,12 +171,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Adres <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "Brama <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
@@ -210,7 +208,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Nazwa diody <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Adres <abbr title=\"Media Access Control\">MAC</abbr>"
 
@@ -246,7 +243,7 @@ msgstr ""
 "<br/>Uwaga: musisz ręcznie zrestartować usługę cron, jeśli plik crontab był "
 "pusty przed edycją."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Katalog o tej samej nazwie już istnieje."
 
@@ -276,6 +273,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -341,13 +342,13 @@ msgstr "Punkt dostępowy"
 msgid "Actions"
 msgstr "Akcje"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Aktywne trasy routingu <abbr title=\"Internet Protocol Version 4\">IPv4</"
 "abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Aktywne trasy routingu <abbr title=\"Internet Protocol Version 6\">IPv6</"
@@ -373,11 +374,11 @@ msgstr "Aktywne dzierżawy DHCPv6"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -482,7 +483,7 @@ msgid "Alert"
 msgstr "Alarm"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Alias Interfejsu"
@@ -663,16 +664,16 @@ msgstr "Dowolna strefa"
 msgid "Apply backup?"
 msgstr "Czy zastosować kopię zapasową?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Żądanie zatwierdzenia nie powiodło się ze statusem <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Zastosuj niezaznaczone"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Wprowadzanie zmian w konfiguracji… %ds"
 
@@ -886,7 +887,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Podrobione statystyki NXDOMAIN"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Most"
 
@@ -903,8 +904,8 @@ msgstr "Numer Mostu (urządzenia)"
 msgid "Bring up on boot"
 msgstr "Podnieś przy stracie"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Przeglądaj…"
 
@@ -936,8 +937,8 @@ msgstr "Podręczna"
 msgid "Call failed"
 msgstr "Połączenie nieudane"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -953,17 +954,17 @@ msgstr "Anuluj"
 msgid "Category"
 msgstr "Kategoria"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Łańcuch"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Zmiany"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Zmiany zostały cofnięte."
 
@@ -1083,7 +1084,8 @@ msgstr "Zamknij listę..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Trwa zbieranie danych..."
@@ -1100,7 +1102,7 @@ msgstr "Polecenie OK"
 msgid "Command failed"
 msgstr "Błędne polecenie"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -1117,16 +1119,16 @@ msgstr ""
 "odporność kluczowych negocjacji, szczególnie w środowiskach o dużym "
 "natężeniu ruchu."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Konfiguracja"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "Konfiguracja została zastosowana."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "Konfiguracja została wycofana!"
 
@@ -1157,7 +1159,7 @@ msgstr "Próba połączenia nieudana"
 msgid "Connection lost"
 msgstr "Utrata połączenia"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Połączenia"
 
@@ -1173,7 +1175,7 @@ msgstr "Zawartość została zapisana."
 msgid "Continue"
 msgstr "Kontynuuj"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1265,7 +1267,7 @@ msgstr "DHCP i DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Klient DHCP"
 
@@ -1391,11 +1393,11 @@ msgstr ""
 "Zdefiniuj dodatkowe opcje DHCP, np. \"<code>6,192.168.2.1,192.168.2.2</code>"
 "\" rozgłasza domyślne serwery DNS klientom DHCP."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1407,7 +1409,7 @@ msgstr "Usuń"
 msgid "Delete key"
 msgstr "Usuń klucz"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Zalecane kasowanie nieudane: %s"
 
@@ -1423,7 +1425,7 @@ msgstr "Interwał komunikatu o wskazaniu dostawy ruchu"
 msgid "Description"
 msgstr "Opis"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Odznacz"
 
@@ -1432,7 +1434,7 @@ msgid "Design"
 msgstr "Motyw"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Przeznaczenie"
 
@@ -1468,7 +1470,7 @@ msgstr "Urządzenie nieaktywne"
 msgid "Device is restarting…"
 msgstr "Urządzenie jest restartowane…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Urządzenie nieosiągalne!"
 
@@ -1485,7 +1487,7 @@ msgstr "Diagnostyka"
 msgid "Dial number"
 msgstr "Numer do wybrania"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Katalog"
 
@@ -1552,10 +1554,10 @@ msgstr "Rozłącz"
 msgid "Disconnection attempt failed"
 msgstr "Próba rozłączenia nie powiodła się"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1577,9 +1579,9 @@ msgid ""
 "firewalls"
 msgstr ""
 "Dnsmasq jest kombajnem serwera <abbr title=\"Dynamic Host Configuration "
-"Protocol\">DHCP</abbr> połączonym z serwerem <abbr title=\"Domain Name "
-"System\">DNS</abbr>. Jest to serwer przekazujący (Forwarder) dla firewalli <"
-"abbr title=\"Network Address Translation\">NAT</abbr>"
+"Protocol\">DHCP</abbr> połączonym z serwerem <abbr title=\"Domain Name System"
+"\">DNS</abbr>. Jest to serwer przekazujący (Forwarder) dla firewalli <abbr "
+"title=\"Network Address Translation\">NAT</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:236
 msgid "Do not cache negative replies, e.g. for not existing domains"
@@ -1595,7 +1597,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Nie przekazuj odwrotnych lookup`ów do sieci lokalnych"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Czy jesteś pewien, że chcesz usunąć \"%s\" ?"
 
@@ -1607,7 +1609,7 @@ msgstr "Czy na pewno chcesz usunąć następujący klucz SSH?"
 msgid "Do you really want to erase all settings?"
 msgstr "Czy jesteś pewny, że naprawdę chcesz skasować wszystkie ustawienia?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 "Czy jesteś pewien, że chcesz skasować katalog \"%s\" ze wszystkimi jego "
@@ -1649,7 +1651,7 @@ msgstr "Pobierz mtdblock"
 msgid "Downstream SNR offset"
 msgstr "Kompensacja transmisji SNR"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Przeciągnij, aby zmienić kolejność"
 
@@ -1696,9 +1698,9 @@ msgstr "Długość EA-bits"
 msgid "EAP-Method"
 msgstr "Metoda protokołu rozszerzonego uwierzytelniania (EAP)"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1893,12 +1895,12 @@ msgid "Errored seconds (ES)"
 msgstr "Ilość błędów (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Karta Ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
 
@@ -1979,7 +1981,7 @@ msgstr "Protokół FT"
 msgid "Failed to change the system password."
 msgstr "Zmiana hasła systemowego nieudana."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "Nie udało się zatwierdzić w ciągu %ds, czekam na wycofanie…"
 
@@ -1987,15 +1989,15 @@ msgstr "Nie udało się zatwierdzić w ciągu %ds, czekam na wycofanie…"
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Nie można wykonać \"/etc/init.d/%s %s\" akcja: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Plik"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Plik niedostępny"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Nazwa pliku"
 
@@ -2049,7 +2051,7 @@ msgstr "Znak zapory sieciowej"
 msgid "Firewall Settings"
 msgstr "Ustawienia firewalla"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Stan firewalla"
 
@@ -2240,8 +2242,8 @@ msgstr "Globalne opcje sieciowe"
 msgid "Go to password configuration..."
 msgstr "Przejdź do konfiguracji hasła..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2285,8 +2287,8 @@ msgstr ""
 "Ukryj <abbr title=\"Extended Service Set Identifier (Nazwę sieci)\">ESSID</"
 "abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Ukryj puste łańcuchy"
 
@@ -2376,7 +2378,7 @@ msgstr "Brakuje adresu IP"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Firewall IPv4"
 
@@ -2427,8 +2429,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Adres IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2455,11 +2462,11 @@ msgstr "IPv4/IPv6 (oba - domyślnie IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Firewall IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "Sąsiedztwo IPv6"
 
@@ -2522,7 +2529,7 @@ msgstr "Sufiks IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Adres IPv6"
 
@@ -2638,7 +2645,7 @@ msgstr "Ignoruj pliki resolve"
 msgid "Image"
 msgstr "Obraz"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "W"
 
@@ -2694,8 +2701,8 @@ msgstr "Instaluj rozszerzenia protokołów..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfejs"
@@ -2826,8 +2833,8 @@ msgstr "Przyłączanie do sieci: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Zachowaj ustawienia i bieżącą konfigurację"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Log jądra"
 
@@ -2909,18 +2916,15 @@ msgid "Lease time"
 msgstr "Czas dzierżawy"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Pozostały czas dzierżawy"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Plik dzierżawy"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2935,7 +2939,7 @@ msgstr "Pozostaw puste, aby automatycznie wykryć"
 msgid "Leave empty to use the current WAN address"
 msgstr "Pozostaw puste, aby użyć bieżącego adresu WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -3038,7 +3042,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Port nasłuchu dla przychodzących zapytań DNS"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Obciążenie"
 
@@ -3046,7 +3050,7 @@ msgstr "Obciążenie"
 msgid "Load Average"
 msgstr "Średnie obciążenie"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Ładowanie zawartości katalogu.…"
 
@@ -3162,7 +3166,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "Adres MAC"
 
@@ -3304,8 +3309,8 @@ msgid "Method not found"
 msgstr "Nie znaleziono metody"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metryka"
@@ -3376,7 +3381,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr "Więcej Znaków"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Więcej…"
 
@@ -3467,8 +3472,8 @@ msgstr "Domena NT"
 msgid "NTP server candidates"
 msgstr "Lista serwerów NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3489,8 +3494,8 @@ msgstr "Nawigacja"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Sieć"
@@ -3516,7 +3521,7 @@ msgstr "Nazwa nowego interfejsu…"
 msgid "Next »"
 msgstr "Następna »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Nie"
@@ -3537,7 +3542,7 @@ msgstr "Bez NAT-T"
 msgid "No data received"
 msgstr "Nie otrzymano danych"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "Brak wpisów w tym katalogu"
 
@@ -3577,7 +3582,7 @@ msgstr "Jeszcze nie zdefiniowano peerów"
 msgid "No public keys present yet."
 msgstr "Nie ma jeszcze kluczy publicznych."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Brak zasad w tym łańcuchu."
 
@@ -3740,11 +3745,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Częstotliwość"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Wartość zmieniona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Usunięto wartość"
 
@@ -3817,7 +3822,7 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 "Opcjonalny. Port UDP używany dla pakietów wychodzących i przychodzących."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Opcje"
 
@@ -3825,7 +3830,7 @@ msgstr "Opcje"
 msgid "Other:"
 msgstr "Inne:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Wychodzące"
 
@@ -3897,7 +3902,7 @@ msgstr "Nadpisz tablicę routingu używaną dla wewnętrznych tras routowania"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Nadpisać istniejący plik \"%s\" ?"
 
@@ -3998,7 +4003,7 @@ msgstr "Długość bitów PSID"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (tryb transferu pakietów)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pakiety"
 
@@ -4132,7 +4137,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pktw."
 
@@ -4140,11 +4145,11 @@ msgstr "Pktw."
 msgid "Please enter your username and password."
 msgstr "Proszę wprowadź swój login i hasło."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Wybierz plik do przesłania."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Polityka"
 
@@ -4214,7 +4219,7 @@ msgid "Private Key"
 msgstr "Klucz prywatny"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Procesy"
 
@@ -4222,7 +4227,7 @@ msgstr "Procesy"
 msgid "Profile"
 msgstr "Profil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4360,7 +4365,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Naprawdę zmienić protokół?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Wykresy w czasie rzeczywistym"
 
@@ -4400,7 +4405,7 @@ msgstr "Zalecane. Adresy IP interfejsu WireGuard."
 msgid "Reconnect this interface"
 msgstr "Połącz ponownie ten interfejs"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referencje"
 
@@ -4545,7 +4550,7 @@ msgstr "Wymaga wpa-supplicant ze wsparciem SAE"
 msgid "Reset"
 msgstr "Resetuj"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Wyczyść liczniki"
 
@@ -4572,7 +4577,7 @@ msgstr "Nie znaleziono zasobu"
 msgid "Restart"
 msgstr "Restartuj"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Restartuj Firewall"
 
@@ -4593,19 +4598,19 @@ msgstr "Przywróć kopię zapasową"
 msgid "Reveal/hide password"
 msgstr "Odsłoń/Ukryj hasło"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Przywróć"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Przywróć zmiany"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Żądanie powrotu nie powiodło się ze statusem <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Przywracanie konfiguracji…"
 
@@ -4639,8 +4644,8 @@ msgid "Router Password"
 msgstr "Hasło routera"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Ścieżki routingu"
 
@@ -4652,7 +4657,7 @@ msgstr ""
 "Ścieżki routingu pokazują routerowi przez który interfejs oraz którą bramę "
 "może skomunikować się z daną siecią lub komputerem."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Reguła"
 
@@ -4710,7 +4715,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4721,7 +4726,7 @@ msgid "Save"
 msgstr "Zapisz"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Zapisz i Zastosuj"
@@ -4743,11 +4748,11 @@ msgstr "Skanuj"
 msgid "Scheduled Tasks"
 msgstr "Zaplanowane Zadania"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Dodano sekcję"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Usunięto sekcję"
 
@@ -4765,9 +4770,9 @@ msgstr ""
 "formatu obrazu nie powiedzie się. Używaj tylko wtedy, gdy masz pewność że "
 "oprogramowanie jest poprawne i jest przeznaczone dla Twojego urządzenia!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Wybierz plik…"
 
@@ -4855,7 +4860,7 @@ msgstr "Krótki Wstęp"
 msgid "Show current backup file list"
 msgstr "Pokaż aktualną listę plików do backupu"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Pokaż puste łańcuchy"
 
@@ -4885,7 +4890,7 @@ msgstr "Tłumienie sygnału (SATN)"
 msgid "Signal:"
 msgstr "Sygnał:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Rozmiar"
@@ -4912,7 +4917,7 @@ msgid "Skip to navigation"
 msgstr "Pomiń do nawigacji"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "Programowy VLAN"
 
@@ -4939,8 +4944,8 @@ msgstr ""
 "urządzenia."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Źródło"
 
@@ -5011,7 +5016,7 @@ msgstr "Uruchom"
 msgid "Start priority"
 msgstr "Priorytet uruchamiania"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Zatwierdzanie konfiguracji…"
 
@@ -5042,7 +5047,7 @@ msgstr "Statyczne ścieżki routingu"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Stały adres"
 
@@ -5123,7 +5128,7 @@ msgid "Switch Speed Mask"
 msgstr "Przełącznik Maski Szybkości"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Przełącznik VLAN"
 
@@ -5137,7 +5142,7 @@ msgstr "Protokół przełącznika"
 msgid "Switch to CIDR list notation"
 msgstr "Przejdź do notacji listy CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Dowiązanie symboliczne"
 
@@ -5156,8 +5161,8 @@ msgstr "Synchronizuj z przeglądarką"
 msgid "System"
 msgstr "System"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Log systemowy"
 
@@ -5191,16 +5196,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Szybkość TX"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tablica"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Cel"
 
@@ -5250,7 +5255,7 @@ msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 "Plik konfiguracyjny nie mógł zostać załadowany z powodu następującego błędu:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5295,7 +5300,7 @@ msgstr ""
 "Porównaj je z oryginalnym plikiem, aby zapewnić integralność danych. <br /> "
 "Kliknij \"Kontynuuj\" poniżej, aby rozpocząć procedurę flashowania."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Następujące zasady są obecnie aktywne w tym systemie."
 
@@ -5445,7 +5450,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Nie ma aktywnych dzierżaw"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Nie ma żadnych zmian do zastosowania"
 
@@ -5557,8 +5562,8 @@ msgstr ""
 "Poniższa lista przedstawia aktualnie uruchomione procesy systemowe i ich "
 "status."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5604,9 +5609,9 @@ msgstr "Całkowicie dostępna"
 msgid "Traceroute"
 msgstr "Trasa routowania"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Ruch"
 
@@ -5631,7 +5636,7 @@ msgid "Tunnel ID"
 msgstr "Numer identyfikacyjny tunelu"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Interfejs tunelu"
 
@@ -5698,6 +5703,11 @@ msgstr "Nie można określić interfejsu źródłowego"
 msgid "Unable to dispatch"
 msgstr "Nie można wysłać"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5709,6 +5719,14 @@ msgstr "Nie można uzyskać ID klienta"
 msgid "Unable to obtain mount information"
 msgstr "Nie można uzyskać informacji o montowaniu"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5718,6 +5736,10 @@ msgstr "Nie można rozpoznać nazwy AFTR hosta"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Nie można rozpoznać nazwy peera"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5734,12 +5756,12 @@ msgid "Unexpected reply data format"
 msgstr "Nieprzewidziany format danych odpowiedzi"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Nieznany"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Nieznany błąd (%s)"
 
@@ -5749,7 +5771,7 @@ msgstr "Nieznany kod błędu"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Niezarządzalny"
 
@@ -5763,7 +5785,7 @@ msgstr "Odmontuj"
 msgid "Unnamed key"
 msgstr "Klucz beznazwy"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Niezapisane zmiany"
 
@@ -5789,7 +5811,7 @@ msgstr "Nieobsługiwany typ protokołu."
 msgid "Up"
 msgstr "Góra"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Wyślij"
 
@@ -5806,21 +5828,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Załaduj archiwum..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Prześlij plik"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Prześlij plik…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Przesyłanie nie powiodło się: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Przesyłanie pliku…"
 
@@ -6129,19 +6151,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Sieć bezprzewodowa"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Adapter bezprzewodowy"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Sieć bezprzewodowa"
 
@@ -6185,7 +6207,7 @@ msgstr "Zapisz otrzymane żądania DNS do syslog'a"
 msgid "Write system log to file"
 msgstr "Zapisz log systemowy do pliku"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Tak"
@@ -6410,7 +6432,7 @@ msgstr "niepowiązane"
 msgid "non-empty value"
 msgstr "wartość nieopróżniona"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "brak"
 
@@ -6518,7 +6540,7 @@ msgstr "nieznane"
 msgid "unlimited"
 msgstr "nielimitowane"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d campo(s) inválido(s)"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- Campo Adicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- Por favor, escolha --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalizado --"
@@ -178,12 +178,10 @@ msgstr ""
 "<abbr title=\"Identificador de Conjunto de Serviços Estendidos\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Endereço <abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "Roteador <abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr>"
 
@@ -221,7 +219,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Nome do <abbr title=\"Diodo Emissor de Luz\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Endereço <abbr title=\"Controle de Acesso ao Meio\">MAC</abbr>"
 
@@ -257,7 +254,7 @@ msgstr ""
 "<br/>Nota: se antes da edição o crontab estava vazio, é necessário reiniciar "
 "manualmente o serviço cron."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Um diretório com o mesmo nome já existe."
 
@@ -289,6 +286,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "<abbr title=\"Access Point Name\">APN</abbr>"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -357,12 +358,12 @@ msgstr "Ponto de Acceso (AP)"
 msgid "Actions"
 msgstr "Ações"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Rotas <abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr> ativas"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Rotas <abbr title=\"Protocolo de Internet Versão 6\">IPv6</abbr> ativas"
@@ -387,11 +388,11 @@ msgstr "Alocações DHCPv6 ativas"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -497,7 +498,7 @@ msgid "Alert"
 msgstr "Alerta"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Interface Adicional"
@@ -683,16 +684,16 @@ msgstr "Qualquer zona"
 msgid "Apply backup?"
 msgstr "Aplicar cópia de segurança?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Pedido para aplicar falhou com o estado <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Aplicar sem verificação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Aplicando as mudanças de configuração... %ds"
 
@@ -909,7 +910,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Substituir Domínio NX Falsos"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Ponte"
 
@@ -926,8 +927,8 @@ msgstr "Número da ponte"
 msgid "Bring up on boot"
 msgstr "Levantar na iniciação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Explorar…"
 
@@ -959,8 +960,8 @@ msgstr "Em cache"
 msgid "Call failed"
 msgstr "A chamada falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -976,17 +977,17 @@ msgstr "Cancelar"
 msgid "Category"
 msgstr "Categoria"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Corrente"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Alterações"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "As mudanças foram revertidas."
 
@@ -1108,7 +1109,8 @@ msgstr "Fechar a lista..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Coletando dados..."
@@ -1125,7 +1127,7 @@ msgstr "Comando OK"
 msgid "Command failed"
 msgstr "O comando falhou"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Comentário"
 
@@ -1142,16 +1144,16 @@ msgstr ""
 "compatibilidade e reduzir a robustez da negociação de chaves, especialmente "
 "em ambientes com muito tráfego."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configuração"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "A configuração foi aplicada."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "A configuração foi revertida!"
 
@@ -1182,7 +1184,7 @@ msgstr "A tentativa de conexão falhou"
 msgid "Connection lost"
 msgstr "Conexão perdida"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Conexões"
 
@@ -1198,7 +1200,7 @@ msgstr "O conteúdo foi salvo."
 msgid "Continue"
 msgstr "Continuar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1290,7 +1292,7 @@ msgstr "DHCP e DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Cliente DHCP"
 
@@ -1419,11 +1421,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" que anuncia diferentes servidores "
 "DNS para os clientes."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1435,7 +1437,7 @@ msgstr "Apagar"
 msgid "Delete key"
 msgstr "Apagar chave"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Solicitação para apagar falhou: %s"
 
@@ -1451,7 +1453,7 @@ msgstr "Intervalo da Mensagem Indicativa de Envio de Tráfego"
 msgid "Description"
 msgstr "Descrição"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Remover seleção"
 
@@ -1460,7 +1462,7 @@ msgid "Design"
 msgstr "Tema"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destino"
 
@@ -1496,7 +1498,7 @@ msgstr "O dispositivo não está ativo"
 msgid "Device is restarting…"
 msgstr "O dispositivo está reiniciando…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Dispositivo não alcançável!"
 
@@ -1514,7 +1516,7 @@ msgstr "Diagnóstico"
 msgid "Dial number"
 msgstr "Número de discagem"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Diretório"
 
@@ -1582,10 +1584,10 @@ msgstr "Desconectar"
 msgid "Disconnection attempt failed"
 msgstr "A tentativa de desconexão falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1627,7 +1629,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Não encaminhe buscas por endereço reverso das redes local"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Você realmente deseja apagar \"%s\" ?"
 
@@ -1639,7 +1641,7 @@ msgstr "Você realmente deseja apagar a seguinte chave SSH?"
 msgid "Do you really want to erase all settings?"
 msgstr "Você realmente deseja apagar todas as configurações?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Você realmente deseja apagar recursivamente o diretório \"%s\" ?"
 
@@ -1682,7 +1684,7 @@ msgstr ""
 "Deslocamento <abbr title=\"Razão entre Sinal e Ruído/Signal to Noise Ratio"
 "\">SNR</abbr> do sinal recebido"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Arrastar para reordenar"
 
@@ -1730,9 +1732,9 @@ msgstr "Comprimento dos bits EA"
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1930,12 +1932,12 @@ msgid "Errored seconds (ES)"
 msgstr "Segundos com erro (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
 
@@ -2020,7 +2022,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr "Falha ao alterar a senha do sistema."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "A confirmação das mudanças na configuração não foram confirmadas em %d "
@@ -2030,15 +2032,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Falha ao executar a ação \"/etc/init.d/%s %s\": %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Arquivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Arquivo não associado"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Nome de arquivo"
 
@@ -2093,7 +2095,7 @@ msgstr "Marca do Firewall"
 msgid "Firewall Settings"
 msgstr "Configurações do Firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Condição do Firewall"
 
@@ -2285,8 +2287,8 @@ msgstr "Opção global de rede"
 msgid "Go to password configuration..."
 msgstr "Ir para a configuração de senha..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2332,8 +2334,8 @@ msgstr ""
 "Ocultar <abbr title=\"Identificador de Conjunto de Serviços Estendidos"
 "\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Ocultar as correntes vazias"
 
@@ -2427,7 +2429,7 @@ msgstr "O endereço IP está ausente"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Firewall para IPv4"
 
@@ -2478,8 +2480,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Endereço IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2506,11 +2513,11 @@ msgstr "IPv4/IPv6 (ambos - padrão é IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Firewall para IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "Vizinhos IPv6"
 
@@ -2575,7 +2582,7 @@ msgstr "Sufixo IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Endereço IPv6"
 
@@ -2693,7 +2700,7 @@ msgstr "Ignorar o arquivo de resolução de nomes (resolv.conf)"
 msgid "Image"
 msgstr "Imagem"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Entrada"
 
@@ -2748,8 +2755,8 @@ msgstr "Instalar extensões de protocolo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
@@ -2884,8 +2891,8 @@ msgstr "Juntando-se à rede %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Manter as configurações e manter a configuração atual"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Registro do Kernel"
 
@@ -2967,18 +2974,15 @@ msgid "Lease time"
 msgstr "Tempo de concessão"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Tempo restante da atribuição"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Arquivo de atribuições"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2993,7 +2997,7 @@ msgstr "Deixe vazio para detectar automaticamente"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deixe vazio para usar o endereço WAN atual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -3101,7 +3105,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Porta de escuta para a entrada das consultas DNS"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Carga"
 
@@ -3109,7 +3113,7 @@ msgstr "Carga"
 msgid "Load Average"
 msgstr "Carga Média"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Carregando conteúdo do diretório…"
 
@@ -3229,7 +3233,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "Endereço MAC"
 
@@ -3373,8 +3378,8 @@ msgid "Method not found"
 msgstr "Método não encontrado"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Métrica"
@@ -3445,7 +3450,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr "Mais Caracteres"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Mais…"
 
@@ -3536,8 +3541,8 @@ msgstr "Domínio NT"
 msgid "NTP server candidates"
 msgstr "Candidatos a servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3558,8 +3563,8 @@ msgstr "Navegação"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Rede"
@@ -3585,7 +3590,7 @@ msgstr "Nome de nova interface…"
 msgid "Next »"
 msgstr "Próximo »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Não"
@@ -3606,7 +3611,7 @@ msgstr "Sem NAT-T"
 msgid "No data received"
 msgstr "Nenhum dado recebido"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "Nenhuma entrada neste diretório"
 
@@ -3646,7 +3651,7 @@ msgstr "Sem parceiros definidos ainda"
 msgid "No public keys present yet."
 msgstr "Nenhuma chave pública presente ainda."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Nenhuma regras nesta corrente."
 
@@ -3812,11 +3817,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Frequência de Operação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Opção alterada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Opção removida"
 
@@ -3890,7 +3895,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Opcional. Porta UDP usada para pacotes saintes ou entrantes."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Opções"
 
@@ -3898,7 +3903,7 @@ msgstr "Opções"
 msgid "Other:"
 msgstr "Outro:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Saída"
 
@@ -3973,7 +3978,7 @@ msgstr "Sobrescrever a tabela usada para as rotas internas"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Sobrescrever o arquivo existente \"%s\" ?"
 
@@ -4074,7 +4079,7 @@ msgstr "Comprimento dos bits PSID"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Modo de Transferência de Pacotes)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pacotes"
 
@@ -4208,7 +4213,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pcts."
 
@@ -4216,11 +4221,11 @@ msgstr "Pcts."
 msgid "Please enter your username and password."
 msgstr "Entre com o seu usuário e senha."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Por favor, selecione o arquivo para enviar."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Política"
 
@@ -4291,7 +4296,7 @@ msgid "Private Key"
 msgstr "Chave Privada"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Processos"
 
@@ -4299,7 +4304,7 @@ msgstr "Processos"
 msgid "Profile"
 msgstr "Perfil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Protocolo"
 
@@ -4437,7 +4442,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Realmente trocar o protocolo?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Gráficos em Tempo Real"
 
@@ -4477,7 +4482,7 @@ msgstr "Recomendado. Endereços IP da interface do WireGuard."
 msgid "Reconnect this interface"
 msgstr "Reconectar esta interface"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referências"
 
@@ -4624,7 +4629,7 @@ msgstr "Requer wpa-supplicant com suporte SAE"
 msgid "Reset"
 msgstr "Limpar"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Reiniciar os Contadores"
 
@@ -4651,7 +4656,7 @@ msgstr "Recurso não encontrado"
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Reiniciar o firewall"
 
@@ -4672,20 +4677,20 @@ msgstr "Restaurar cópia de segurança"
 msgid "Reveal/hide password"
 msgstr "Relevar/esconder senha"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Reverter"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Reverter as mudanças"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 "O pedido para reverter as configurações falhou com o estado <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Revertendo configurações…"
 
@@ -4719,8 +4724,8 @@ msgid "Router Password"
 msgstr "Senha do Roteador"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Rotas"
 
@@ -4732,7 +4737,7 @@ msgstr ""
 "As rotas especificam através de qual interface e roteador um certo destino "
 "podem ser alcançado."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Regra"
 
@@ -4790,7 +4795,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4801,7 +4806,7 @@ msgid "Save"
 msgstr "Salvar"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salvar & Aplicar"
@@ -4823,11 +4828,11 @@ msgstr "Procurar"
 msgid "Scheduled Tasks"
 msgstr "Tarefas Agendadas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Seção adicionada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Seção removida"
 
@@ -4845,9 +4850,9 @@ msgstr ""
 "do formato da imagem falhe. Use somente caso tenha certeza que o firmware "
 "está correto e é compatível com o seu dispositivo!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Selecione o arquivo…"
 
@@ -4940,7 +4945,7 @@ msgstr "Preâmbulo curto"
 msgid "Show current backup file list"
 msgstr "Mostra a lista atual de arquivos para a cópia de segurança"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Mostrar as correntes vazias"
 
@@ -4970,7 +4975,7 @@ msgstr "Atenuação do Sinal (<abbr title=\"Signal Attenuation\">SATN</abbr>)"
 msgid "Signal:"
 msgstr "Sinal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Tamanho"
@@ -4997,7 +5002,7 @@ msgid "Skip to navigation"
 msgstr "Pular para a navegação"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "VLAN em Software"
 
@@ -5024,8 +5029,8 @@ msgstr ""
 "instruções específicas da instalação deste dispositivo."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Origem"
 
@@ -5097,7 +5102,7 @@ msgstr "Iniciar"
 msgid "Start priority"
 msgstr "Prioridade de iniciação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Iniciando a aplicação da configuração…"
 
@@ -5128,7 +5133,7 @@ msgstr "Rotas Estáticas"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Endereço Estático"
 
@@ -5210,7 +5215,7 @@ msgid "Switch Speed Mask"
 msgstr "Alternar a Máscara de Velocidade do Switch"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Switch VLAN"
 
@@ -5224,7 +5229,7 @@ msgstr "Trocar o protocolo"
 msgid "Switch to CIDR list notation"
 msgstr "Alternar para a notação da lista CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Link simbólico"
 
@@ -5243,8 +5248,8 @@ msgstr "Sincronizar com o navegador"
 msgid "System"
 msgstr "Sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Registro do Sistema"
 
@@ -5277,16 +5282,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Taxa de TX"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabela"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Destino"
 
@@ -5335,7 +5340,7 @@ msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 "O arquivo de configuração não pode ser carregado devido ao seguinte erro:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5381,7 +5386,7 @@ msgstr ""
 "integridade dos dados. <br /> Clique em \"Continuar\" para iniciar o "
 "procedimento de atualização."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "As seguintes regras estão atualmente ativas neste sistema."
 
@@ -5533,7 +5538,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Não há concessões de IP ativas no momento"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Não há alterações a serem aplicadas"
 
@@ -5612,8 +5617,8 @@ msgid ""
 "This is the only <abbr title=\"Dynamic Host Configuration Protocol\">DHCP</"
 "abbr> in the local network"
 msgstr ""
-"Este é o único servidor <abbr title=\"Dynamic Host Configuration Protocol\""
-">DHCP</abbr> na rede local"
+"Este é o único servidor <abbr title=\"Dynamic Host Configuration Protocol"
+"\">DHCP</abbr> na rede local"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:73
 msgid "This is the plain username for logging into the account"
@@ -5644,8 +5649,8 @@ msgid ""
 msgstr ""
 "Esta lista fornece uma visão geral sobre os processos em execução no sistema."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5692,9 +5697,9 @@ msgstr "Total Disponível"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Tráfego"
 
@@ -5719,7 +5724,7 @@ msgid "Tunnel ID"
 msgstr "Identificador do Túnel"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Interface de Tunelamento"
 
@@ -5786,6 +5791,11 @@ msgstr "Não foi possível determinar a interface com a rede externa"
 msgid "Unable to dispatch"
 msgstr "Não é possível a expedição"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5797,6 +5807,14 @@ msgstr "Não foi possível obter o identificador do cliente"
 msgid "Unable to obtain mount information"
 msgstr "Não é possível obter informações sobre a montagem"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5806,6 +5824,10 @@ msgstr "Não foi possível resolver o nome do AFTR"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Não foi possível resolver o nome do parceiro"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5824,12 +5846,12 @@ msgid "Unexpected reply data format"
 msgstr "Formato de dados de resposta inesperado"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Desconhecido"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Erro desconhecido (%s)"
 
@@ -5839,7 +5861,7 @@ msgstr "Código de erro desconhecido"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Não gerenciado"
 
@@ -5853,7 +5875,7 @@ msgstr "Desmontar"
 msgid "Unnamed key"
 msgstr "Chave sem nome"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Alterações Não Salvas"
 
@@ -5881,7 +5903,7 @@ msgstr "Tipo de protocolo não suportado."
 msgid "Up"
 msgstr "Acima"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Envio"
 
@@ -5898,21 +5920,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Enviar arquivo..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Enviar arquivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Enviar arquivo…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "A Solicitação de envio falhou: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Enviando o arquivo…"
 
@@ -6220,19 +6242,19 @@ msgstr "VPN WireGuard"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Rede sem fio"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Dispositivo de Rede sem Fio"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Rede sem Fio"
 
@@ -6276,7 +6298,7 @@ msgstr "Escreva as requisições DNS para o servidor de registro (syslog)"
 msgid "Write system log to file"
 msgstr "Escrever registro do sistema (log) no arquivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Sim"
@@ -6503,7 +6525,7 @@ msgstr "sem link"
 msgid "non-empty value"
 msgstr "valor não vazio"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "nenhum"
 
@@ -6611,7 +6633,7 @@ msgstr "desconhecido"
 msgid "unlimited"
 msgstr "ilimitado"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d campo(s) inválido(s)"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- Campo Adicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- Por favor escolha --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalizado --"
@@ -176,12 +176,10 @@ msgstr ""
 "<abbr title=\"Identificador de Conjunto de Serviços Estendidos\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Endereço <abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "Gateway <abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr>"
 
@@ -218,7 +216,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Nome do <abbr title=\"Diodo Emissor de Luz\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "Endereço <abbr title=\"Controle de Acesso ao Meio\">MAC</abbr>"
 
@@ -254,7 +251,7 @@ msgstr ""
 "<br/>Nota: você precisa reiniciar manualmente o serviço da cron se o "
 "ficheiro crontab estava vazio antes da edição."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Já existe um diretório com o mesmo nome."
 
@@ -284,6 +281,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -346,12 +347,12 @@ msgstr "Ponto de Acesso"
 msgid "Actions"
 msgstr "Ações"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Rotas-<abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr> Ativas"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Rotas-<abbr title=\"Protocolo de Internet Versão 6\">IPv6</abbr> Ativas"
@@ -376,11 +377,11 @@ msgstr "Concessões DHCPv6 Ativas"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -487,7 +488,7 @@ msgid "Alert"
 msgstr "Alerta"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Interface Adicional"
@@ -671,16 +672,16 @@ msgstr "Qualquer zona"
 msgid "Apply backup?"
 msgstr "Aplicar backup?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Pedido para aplicar falhou com o estado <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Aplicar desmarcado"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Aplicando alterações de configuração... %ds"
 
@@ -896,7 +897,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Substituir Domínios NX Falsos"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Bridge"
 
@@ -913,8 +914,8 @@ msgstr "Número de unidade da bridge"
 msgid "Bring up on boot"
 msgstr "Ativar com o arranque"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Navegar…"
 
@@ -946,8 +947,8 @@ msgstr "Em cache"
 msgid "Call failed"
 msgstr "A chamada falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -963,17 +964,17 @@ msgstr "Cancelar"
 msgid "Category"
 msgstr "Categoria"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Cadeia"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Alterações"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "As alterações foram revertidas."
 
@@ -1093,7 +1094,8 @@ msgstr "Fechar lista..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "A recolher dados..."
@@ -1110,7 +1112,7 @@ msgstr "Comando OK"
 msgid "Command failed"
 msgstr "O comando falhou"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Comentário"
 
@@ -1127,16 +1129,16 @@ msgstr ""
 "a robustez da negociação de chaves, especialmente em ambientes com muito "
 "tráfego."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configuração"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "A configuração foi aplicada."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "A configuração foi revertida!"
 
@@ -1167,7 +1169,7 @@ msgstr "A tentativa de ligação falhou"
 msgid "Connection lost"
 msgstr "Ligação perdida"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Ligações"
 
@@ -1183,7 +1185,7 @@ msgstr "Os conteúdos foram gravados."
 msgid "Continue"
 msgstr "Continuar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1275,7 +1277,7 @@ msgstr "DHCP e DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Cliente DHCP"
 
@@ -1402,11 +1404,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" informa os clientes de diferentes "
 "servidores DNS."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1418,7 +1420,7 @@ msgstr "Apagar"
 msgid "Delete key"
 msgstr "Apagar chave"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Pedido de apagar falhou: %s"
 
@@ -1434,7 +1436,7 @@ msgstr "Intervalo da Mensagem Indicativa de Envio de Tráfego (DTIM)"
 msgid "Description"
 msgstr "Descrição"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Desmarcar"
 
@@ -1443,7 +1445,7 @@ msgid "Design"
 msgstr "Tema"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destino"
 
@@ -1479,7 +1481,7 @@ msgstr "O aparelho não está ativo"
 msgid "Device is restarting…"
 msgstr "O aparelho está a reiniciar…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Aparelho não alcançável!"
 
@@ -1496,7 +1498,7 @@ msgstr "Diagnósticos"
 msgid "Dial number"
 msgstr "Número de discagem"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Diretório"
 
@@ -1563,10 +1565,10 @@ msgstr "Desconectar"
 msgid "Disconnection attempt failed"
 msgstr "A tentativa de desconexão falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1606,7 +1608,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Não encaminhar lookups reversos para as redes locais"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Quer mesmo apagar \"%s\"?"
 
@@ -1618,7 +1620,7 @@ msgstr "Deseja mesmo apagar a seguinte chave SSH?"
 msgid "Do you really want to erase all settings?"
 msgstr "Quer mesmo apagar todas as configurações?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Deseja mesmo apagar recursivamente o diretório \"%s\"?"
 
@@ -1660,7 +1662,7 @@ msgstr ""
 "Deslocamento <abbr title=\"Signal to Noise Ratio\">SNR</abbr> do sinal "
 "recebido"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
@@ -1706,9 +1708,9 @@ msgstr "Comprimento dos bits EA"
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1903,12 +1905,12 @@ msgid "Errored seconds (ES)"
 msgstr "Segundos com erro (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
 
@@ -1989,7 +1991,7 @@ msgstr "Protocolo FT"
 msgid "Failed to change the system password."
 msgstr "Falha ao alterar a palavra-passe do sistema."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "Não foi possível confirmar a aplicação das configurações dentro de %ds, "
@@ -1999,15 +2001,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Falha ao executar \"/etc/init.d/%s %s\" ação: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Ficheiro"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Ficheiro não acessível"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Nome do ficheiro"
 
@@ -2061,7 +2063,7 @@ msgstr "Marca da Firewall"
 msgid "Firewall Settings"
 msgstr "Definições da Firewall"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Estado da Firewall"
 
@@ -2252,8 +2254,8 @@ msgstr "Opções de rede globais"
 msgid "Go to password configuration..."
 msgstr "Ir para a configuração da palavra-passe…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2299,8 +2301,8 @@ msgstr ""
 "Ocultar <abbr title=\"Identificador de Conjunto de Serviços Estendidos"
 "\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Esconder cadeias vazias"
 
@@ -2390,7 +2392,7 @@ msgstr "O endereço IP está ausente"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Firewall IPv4"
 
@@ -2441,8 +2443,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Endereço-IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2469,11 +2476,11 @@ msgstr "IPv4/IPv6 (ambos - padrão é IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Firewall IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "Vizinhos IPv6"
 
@@ -2536,7 +2543,7 @@ msgstr "Sufixo IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Endereço-IPv6"
 
@@ -2652,7 +2659,7 @@ msgstr "Ignorar o ficheiro resolv.conf"
 msgid "Image"
 msgstr "Imagem"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Entrada"
 
@@ -2707,8 +2714,8 @@ msgstr "Instalar extensões do protocolo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
@@ -2840,8 +2847,8 @@ msgstr "A associar à rede: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Manter as definições e manter a configuração atual"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Logs da Kernel"
 
@@ -2923,18 +2930,15 @@ msgid "Lease time"
 msgstr "Tempo de concessão"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Tempo de concessão restante"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Ficheiro de concessões"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2949,7 +2953,7 @@ msgstr "Deixar em branco para auto-detecção"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deixar em branco para usar o endereço WAN actual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -3055,7 +3059,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Porta de escuta para entrada de consultas DNS"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Carregar"
 
@@ -3063,7 +3067,7 @@ msgstr "Carregar"
 msgid "Load Average"
 msgstr "Carga Média"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Carregando o conteúdo do diretório…"
 
@@ -3183,7 +3187,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "Endereço-MAC"
 
@@ -3328,8 +3333,8 @@ msgid "Method not found"
 msgstr "Método não encontrado"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Métrica"
@@ -3400,7 +3405,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr "Mais Caracteres"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Mais…"
 
@@ -3491,8 +3496,8 @@ msgstr "Domínio NT"
 msgid "NTP server candidates"
 msgstr "Candidatos a servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3513,8 +3518,8 @@ msgstr "Navegação"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Rede"
@@ -3540,7 +3545,7 @@ msgstr "Novo nome de interface…"
 msgid "Next »"
 msgstr "Seguinte »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Não"
@@ -3561,7 +3566,7 @@ msgstr "Sem NAT-T"
 msgid "No data received"
 msgstr "Nenhuns dados recebidos"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "Não há entradas neste diretório"
 
@@ -3601,7 +3606,7 @@ msgstr "Ainda não há pares definidos"
 msgid "No public keys present yet."
 msgstr "Ainda não há chaves públicas presentes."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Não há regras nesta cadeia."
 
@@ -3767,11 +3772,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Frequência de Operação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Opção alterada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Opção removida"
 
@@ -3845,7 +3850,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Opcional. Porta UDP usada para pacotes saintes ou entrantes."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Opções"
 
@@ -3853,7 +3858,7 @@ msgstr "Opções"
 msgid "Other:"
 msgstr "Outro:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Saída"
 
@@ -3928,7 +3933,7 @@ msgstr "Sobrescrever a tabela usada para as rotas internas"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Sustituir o ficheiro existente \"%s\" ?"
 
@@ -4029,7 +4034,7 @@ msgstr "Comprimento dos bits PSID"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Modo de Transferência de Pacotes)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pacotes"
 
@@ -4163,7 +4168,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pcts."
 
@@ -4171,11 +4176,11 @@ msgstr "Pcts."
 msgid "Please enter your username and password."
 msgstr "Insira o seu username e password."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Por favor selecione o ficheiro para upload."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Política"
 
@@ -4246,7 +4251,7 @@ msgid "Private Key"
 msgstr "Chave Privada"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Processos"
 
@@ -4254,7 +4259,7 @@ msgstr "Processos"
 msgid "Profile"
 msgstr "Perfil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4391,7 +4396,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Deseja mesmo trocar o protocolo?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Gráficos em Tempo Real"
 
@@ -4431,7 +4436,7 @@ msgstr "Recomendado. Endereços IP da interface do WireGuard."
 msgid "Reconnect this interface"
 msgstr "Reconetar esta interface"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referências"
 
@@ -4577,7 +4582,7 @@ msgstr "Requer wpa-supplicant com suporte de SAE"
 msgid "Reset"
 msgstr "Reset"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Limpar contadores"
 
@@ -4604,7 +4609,7 @@ msgstr "Recurso não encontrado"
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Reiniciar Firewall"
 
@@ -4625,20 +4630,20 @@ msgstr "Restaurar backup"
 msgid "Reveal/hide password"
 msgstr "Revelar/esconder password"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Reverter"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Reverter as mudanças"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 "O pedido para reverter as configurações falhou com o estado <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Revertendo configurações…"
 
@@ -4672,8 +4677,8 @@ msgid "Router Password"
 msgstr "Password do Router"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Rotas"
 
@@ -4685,7 +4690,7 @@ msgstr ""
 "As rotas especificam através de que interfaces ou gateways podem ser "
 "alcançados determinadas redes ou hosts."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Regra"
 
@@ -4743,7 +4748,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4754,7 +4759,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Gravar & Aplicar"
@@ -4776,11 +4781,11 @@ msgstr "Procurar"
 msgid "Scheduled Tasks"
 msgstr "Tarefas Agendadas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Secção adicionada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Secção removida"
 
@@ -4798,9 +4803,9 @@ msgstr ""
 "do formato da imagem falhar. Use somente se você estiver confiante que a "
 "firmware está correta e é destinada para seu aparelho!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Selecione o ficheiro.…"
 
@@ -4893,7 +4898,7 @@ msgstr "Preâmbulo curto"
 msgid "Show current backup file list"
 msgstr "Mostrar lista ficheiros para backup"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Mostrar correntes vazias"
 
@@ -4923,7 +4928,7 @@ msgstr "Atenuação do Sinal (<abbr title=\"Signal Attenuation\">SATN</abbr>)"
 msgid "Signal:"
 msgstr "Sinal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Tamanho"
@@ -4950,7 +4955,7 @@ msgid "Skip to navigation"
 msgstr "Ir para a navegação"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "VLAN em Software"
 
@@ -4977,8 +4982,8 @@ msgstr ""
 "instruções específicas da instalação deste aparelho."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Origem"
 
@@ -5050,7 +5055,7 @@ msgstr "Iniciar"
 msgid "Start priority"
 msgstr "Prioridade de inicialização"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Iniciando a aplicação da configuração…"
 
@@ -5081,7 +5086,7 @@ msgstr "Rotas Estáticas"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Endereço estático"
 
@@ -5163,7 +5168,7 @@ msgid "Switch Speed Mask"
 msgstr "Máscara da velocidade do Switch"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Mudar VLAN"
 
@@ -5177,7 +5182,7 @@ msgstr "Trocar o protocolo"
 msgid "Switch to CIDR list notation"
 msgstr "Mudar para a notação CIDR de listas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Ligação simbólica"
 
@@ -5196,8 +5201,8 @@ msgstr "Sincronizar com o browser"
 msgid "System"
 msgstr "Sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Registo do Sistema"
 
@@ -5230,16 +5235,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Taxa de TX"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabela"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Destino"
 
@@ -5289,7 +5294,7 @@ msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 "O ficheiros de configuração não pode ser carregado devido ao seguinte erro:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5335,7 +5340,7 @@ msgstr ""
 "integridade dos dados. <br /> Clique em \"Continuar\" abaixo para iniciar o "
 "procedimento flash."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "As seguintes regras estão actualmente acivas neste sistema."
 
@@ -5486,7 +5491,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Não há arrendamentos ativos"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Não há alterações a serem aplicadas"
 
@@ -5596,8 +5601,8 @@ msgid ""
 msgstr ""
 "Esta lista fornece uma visão geral sobre os processos em execução no sistema."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5643,9 +5648,9 @@ msgstr "Total Disponível"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Tráfego"
 
@@ -5670,7 +5675,7 @@ msgid "Tunnel ID"
 msgstr "ID do Túnel"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Interface de Túnel"
 
@@ -5737,6 +5742,11 @@ msgstr "Não foi possível determinar a interface com a rede externa"
 msgid "Unable to dispatch"
 msgstr "Não é possível a expedição"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5748,6 +5758,14 @@ msgstr "Não foi possível obter o identificador do cliente"
 msgid "Unable to obtain mount information"
 msgstr "Não é possível obter informações sobre o mount"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5757,6 +5775,10 @@ msgstr "Não foi possível resolver o nome do AFTR"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Não foi possível resolver o nome do parceiro"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5775,12 +5797,12 @@ msgid "Unexpected reply data format"
 msgstr "Formato de dados de resposta inesperado"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Desconhecido"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Erro desconhecido (%s)"
 
@@ -5790,7 +5812,7 @@ msgstr "Código de erro desconhecido"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Não gerido"
 
@@ -5804,7 +5826,7 @@ msgstr "Desmontar"
 msgid "Unnamed key"
 msgstr "Chave sem nome"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Alterações não Guardadas"
 
@@ -5832,7 +5854,7 @@ msgstr "Tipo de protocolo não suportado."
 msgid "Up"
 msgstr "Acima"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Enviar"
 
@@ -5849,21 +5871,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Enviar arquivo..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Enviar ficheiro"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Enviar ficheiro…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Pedido de envio falhou: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Enviando o ficheiro…"
 
@@ -6172,19 +6194,19 @@ msgstr "VPN WireGuard"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Wireless"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Adaptador Wireless"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Rede Wireless"
 
@@ -6228,7 +6250,7 @@ msgstr "Escrever os pedidos de DNS para o syslog"
 msgid "Write system log to file"
 msgstr "Escrever registro do sistema (log) no ficheiro"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Sim"
@@ -6454,7 +6476,7 @@ msgstr "sem link"
 msgid "non-empty value"
 msgstr "valor não vazio"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "nenhum"
 
@@ -6562,7 +6584,7 @@ msgstr "desconhecido"
 msgid "unlimited"
 msgstr "ilimitado"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -58,11 +58,11 @@ msgid "-- Additional Field --"
 msgstr "-- Camp suplimentar --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -70,7 +70,7 @@ msgstr "-- Te rog sa alegi --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- particularizat --"
@@ -169,12 +169,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "Adresa <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Poarta Acces "
 
@@ -208,7 +206,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Nume"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-Addresa"
 
@@ -240,7 +237,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Un director cu acelaşi nume există deja."
 
@@ -270,6 +267,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -332,11 +333,11 @@ msgstr "Punct de Acces"
 msgid "Actions"
 msgstr "Actiune"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Rute active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Rute active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
@@ -360,11 +361,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -468,7 +469,7 @@ msgid "Alert"
 msgstr "Alerta"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -644,16 +645,16 @@ msgstr "Orice Zona"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -856,7 +857,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Bogus NX Domain Override"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Punte"
 
@@ -873,8 +874,8 @@ msgstr "Numarul unitatii in punte"
 msgid "Bring up on boot"
 msgstr "Activeaza la pornire"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -905,8 +906,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -922,17 +923,17 @@ msgstr "Anulare"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Lant"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Modificari"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1043,7 +1044,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Colectare date..."
@@ -1060,7 +1062,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1072,16 +1074,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Configurare"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1112,7 +1114,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Conexiuni"
 
@@ -1128,7 +1130,7 @@ msgstr "Conţinutul a fost salvat."
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1212,7 +1214,7 @@ msgstr "DHCP si DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1336,11 +1338,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1352,7 +1354,7 @@ msgstr "Sterge"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1368,7 +1370,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descriere"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1377,7 +1379,7 @@ msgid "Design"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Destinatie"
 
@@ -1413,7 +1415,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1430,7 +1432,7 @@ msgstr "Diagnosticuri"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Director"
 
@@ -1497,10 +1499,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1534,7 +1536,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1546,7 +1548,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1584,7 +1586,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1625,9 +1627,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1814,12 +1816,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Adaptor de retea ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Switch-ul ethernet"
 
@@ -1899,7 +1901,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1907,15 +1909,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Fisier"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1967,7 +1969,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "Setarile firewall-ului"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Status la firewall"
 
@@ -2154,8 +2156,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2197,8 +2199,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Ascunde <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2288,7 +2290,7 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Firewall IPv4"
 
@@ -2339,8 +2341,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Adresa IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2367,11 +2374,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Firewall IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2434,7 +2441,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2540,7 +2547,7 @@ msgstr ""
 msgid "Image"
 msgstr "Imagine"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2593,8 +2600,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfata"
@@ -2726,8 +2733,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Log-ul kernelului"
 
@@ -2809,17 +2816,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2835,7 +2839,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -2924,7 +2928,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Incarcarea"
 
@@ -2932,7 +2936,7 @@ msgstr "Incarcarea"
 msgid "Load Average"
 msgstr "Incarcarea medie"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3043,7 +3047,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3183,8 +3188,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrica"
@@ -3255,7 +3260,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3344,8 +3349,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3366,8 +3371,8 @@ msgstr "Navigare"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Retea"
@@ -3393,7 +3398,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Mai departe »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3414,7 +3419,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3454,7 +3459,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3615,11 +3620,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Optiunea schimbata"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Optiunea eliminata"
 
@@ -3680,7 +3685,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Optiuni"
 
@@ -3688,7 +3693,7 @@ msgstr "Optiuni"
 msgid "Other:"
 msgstr "Altele:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Iesire"
 
@@ -3758,7 +3763,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generala"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3859,7 +3864,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Pachete"
 
@@ -3993,7 +3998,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Packete."
 
@@ -4001,11 +4006,11 @@ msgstr "Packete."
 msgid "Please enter your username and password."
 msgstr "Introdu utilizatorul si parola."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4073,7 +4078,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Procese"
 
@@ -4081,7 +4086,7 @@ msgstr "Procese"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4209,7 +4214,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Grafice in timp real"
 
@@ -4249,7 +4254,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "Reconecteaza aceasta interfata"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referinte"
 
@@ -4388,7 +4393,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Reset"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Reseteaza counterii"
 
@@ -4415,7 +4420,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Restart"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Restarteaza firewallul"
 
@@ -4436,19 +4441,19 @@ msgstr "Reface backup-ul"
 msgid "Reveal/hide password"
 msgstr "Arata / ascunde parola"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4482,8 +4487,8 @@ msgid "Router Password"
 msgstr "Parola routerului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Rute"
 
@@ -4493,7 +4498,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4550,7 +4555,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4561,7 +4566,7 @@ msgid "Save"
 msgstr "Salveaza"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salveaza si aplica"
@@ -4583,11 +4588,11 @@ msgstr "Scan"
 msgid "Scheduled Tasks"
 msgstr "Operatiuni programate"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Sectiune adaugata"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Sectiune eliminata"
 
@@ -4602,9 +4607,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4688,7 +4693,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4718,7 +4723,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Semnal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Marime"
@@ -4745,7 +4750,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4769,8 +4774,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Sursa"
 
@@ -4831,7 +4836,7 @@ msgstr "Start"
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4862,7 +4867,7 @@ msgstr "Rute statice"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4938,7 +4943,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4952,7 +4957,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4971,8 +4976,8 @@ msgstr ""
 msgid "System"
 msgstr "Sistem"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Log de sistem"
 
@@ -5005,16 +5010,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabel"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Tinta"
 
@@ -5057,7 +5062,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5088,7 +5093,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5217,7 +5222,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5307,8 +5312,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5351,9 +5356,9 @@ msgstr "Total disponibil"
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Trafic"
 
@@ -5378,7 +5383,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Interfata de tunel"
 
@@ -5445,6 +5450,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5456,6 +5466,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5464,6 +5482,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5481,12 +5503,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Necunoscut"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5496,7 +5518,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Neadministrate"
 
@@ -5510,7 +5532,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Modificari nesalvate"
 
@@ -5536,7 +5558,7 @@ msgstr "Tipul de protocol neacceptat."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5551,21 +5573,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5857,19 +5879,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Wireless"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Adaptorul wireless"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Retea wireless"
 
@@ -5913,7 +5935,7 @@ msgstr "Scrie cererile DNS primite in syslog"
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6127,7 +6149,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr ""
 
@@ -6235,7 +6257,7 @@ msgstr "necunoscut"
 msgid "unlimited"
 msgstr "nelimitat"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -25,7 +25,7 @@ msgstr "%.1f дБ"
 msgid "%d Bit"
 msgstr "%d бит"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d неверных полей"
 
@@ -61,11 +61,11 @@ msgid "-- Additional Field --"
 msgstr "-- Дополнительно --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -73,7 +73,7 @@ msgstr "-- Сделайте выбор --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- пользовательский --"
@@ -174,12 +174,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Расширенный идентификатор обслуживания\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-адрес"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-шлюз"
 
@@ -213,7 +211,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Имя <abbr title=\"Светодиод\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Управление доступом к носителю\">MAC</abbr>-адрес"
 
@@ -250,7 +247,7 @@ msgstr ""
 "<br />Внимание: вы должны вручную перезапустить службу cron, если этот файл "
 "был пустым перед внесением ваших изменений."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Директория с таким же именем уже существует."
 
@@ -280,6 +277,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -342,12 +343,12 @@ msgstr "Точка доступа"
 msgid "Actions"
 msgstr "Действия"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Активные <abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-маршруты"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Активные <abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-маршруты"
@@ -372,11 +373,11 @@ msgstr "Активные DHCPv6 аренды"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -481,7 +482,7 @@ msgid "Alert"
 msgstr "Тревога"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Псевдоним"
@@ -669,16 +670,16 @@ msgstr "Любая зона"
 msgid "Apply backup?"
 msgstr "Восстановить резервную копию?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Ошибка <code>%h</code> запроса на применение"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Применить без проверки"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Ожидание применения конфигурации... %d сек"
 
@@ -897,7 +898,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Переопределение поддельного NX-домена"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Мост"
 
@@ -914,8 +915,8 @@ msgstr "Номер моста"
 msgid "Bring up on boot"
 msgstr "Запустить при загрузке"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Обзор…"
 
@@ -947,8 +948,8 @@ msgstr "Кешировано"
 msgid "Call failed"
 msgstr "Ошибка вызова"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -964,17 +965,17 @@ msgstr "Отменить"
 msgid "Category"
 msgstr "Категория"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Цепочка"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Изменения"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Изменения были возвращены назад."
 
@@ -1097,7 +1098,8 @@ msgstr "Закрыть список..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Сбор данных..."
@@ -1114,7 +1116,7 @@ msgstr "Успешное выполнение"
 msgid "Command failed"
 msgstr "Ошибка команды"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -1130,16 +1132,16 @@ msgstr ""
 "Может вызвать проблемы совместимости и снижение надежности согласования "
 "нового ключа, при наличии большого трафика."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Настройка config файла"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "Конфигурация применена."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "Конфигурация возвращена назад!"
 
@@ -1170,7 +1172,7 @@ msgstr "Ошибка попытки соединения"
 msgid "Connection lost"
 msgstr "Подключение потеряно"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Соединения"
 
@@ -1186,7 +1188,7 @@ msgstr "Содержимое сохранено."
 msgid "Continue"
 msgstr "Продолжить"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1277,7 +1279,7 @@ msgstr "DHCP и DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP-клиент"
 
@@ -1404,11 +1406,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\", чтобы известить клиентов о DNS-"
 "серверах."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1420,7 +1422,7 @@ msgstr "Удалить"
 msgid "Delete key"
 msgstr "Удалить ключ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Ошибка запроса на удаление: %s"
 
@@ -1436,7 +1438,7 @@ msgstr "Интервал сообщений, регламентирующий д
 msgid "Description"
 msgstr "Описание"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Отменить выбор"
 
@@ -1445,7 +1447,7 @@ msgid "Design"
 msgstr "Тема оформления"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Направление"
 
@@ -1481,7 +1483,7 @@ msgstr "Устройство не активно"
 msgid "Device is restarting…"
 msgstr "Устройство перезапускается…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Устройство недоступно!"
 
@@ -1498,7 +1500,7 @@ msgstr "Диагностика"
 msgid "Dial number"
 msgstr "Dial номер"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Папка"
 
@@ -1565,10 +1567,10 @@ msgstr "Отключить"
 msgid "Disconnection attempt failed"
 msgstr "Ошибка попытки отключения"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1608,7 +1610,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Не перенаправлять обратные DNS-запросы для локальных сетей"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Вы действительно хотите удалить «%s»?"
 
@@ -1620,7 +1622,7 @@ msgstr "Вы действительно хотите удалить следую
 msgid "Do you really want to erase all settings?"
 msgstr "Вы действительно хотите стереть все настройки?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Вы действительно хотите рекурсивно удалить директорию «%s»?"
 
@@ -1660,7 +1662,7 @@ msgstr "Скачать MTD раздел"
 msgid "Downstream SNR offset"
 msgstr "SNR offset внутренней сети"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Перетащите, чтобы изменить порядок"
 
@@ -1706,9 +1708,9 @@ msgstr "EA-bits длина"
 msgid "EAP-Method"
 msgstr "Метод EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1901,12 +1903,12 @@ msgid "Errored seconds (ES)"
 msgstr "Ошибочные секунды (ES)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernet-адаптер"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet-коммутатор"
 
@@ -1988,7 +1990,7 @@ msgstr "FT протокол"
 msgid "Failed to change the system password."
 msgstr "Не удалось изменить системный пароль."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "Не удалось подтвердить применение в течении %d сек., ожидание отката…"
 
@@ -1996,15 +1998,15 @@ msgstr "Не удалось подтвердить применение в те�
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Не удалось выполнить действие «/etc/init.d/%s %s»: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Файл не доступен"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Имя файла"
 
@@ -2059,7 +2061,7 @@ msgstr "Метка межсетевого экрана"
 msgid "Firewall Settings"
 msgstr "Настройки межсетевого экрана"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Состояние межсетевого экрана"
 
@@ -2247,8 +2249,8 @@ msgstr "Основные настройки сети"
 msgid "Go to password configuration..."
 msgstr "Перейти к настройке пароля..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2290,8 +2292,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Скрыть <abbr title=\"Расширенный идентификатор сети\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Скрыть пустые цепочки"
 
@@ -2381,7 +2383,7 @@ msgstr "IP-адрес не указан"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Межсетевой экран IPv4"
 
@@ -2432,8 +2434,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-адрес"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2460,11 +2467,11 @@ msgstr "IPv4 / IPv6 (оба - по умолчанию для IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Межсетевой экран IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "IPv6 соседи (neighbours)"
 
@@ -2527,7 +2534,7 @@ msgstr "IPv6 суффикс"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-адрес"
 
@@ -2643,7 +2650,7 @@ msgstr "Игнорировать файл resolv"
 msgid "Image"
 msgstr "Образ"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "В"
 
@@ -2699,8 +2706,8 @@ msgstr "Установить расширения протокола..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Интерфейс"
@@ -2833,8 +2840,8 @@ msgstr "Подключение к сети: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Сохранить настройки и оставить текущую конфигурацию"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Журнал ядра"
 
@@ -2916,18 +2923,15 @@ msgid "Lease time"
 msgstr "Время аренды адреса"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Оставшееся время аренды"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Файл аренд"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2942,7 +2946,7 @@ msgstr "Оставьте поле пустым для автоопределен
 msgid "Leave empty to use the current WAN address"
 msgstr "Оставьте пустым для использования текущего адреса WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "События:"
 
@@ -3045,7 +3049,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Порт для входящих DNS-запросов"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Загрузка"
 
@@ -3053,7 +3057,7 @@ msgstr "Загрузка"
 msgid "Load Average"
 msgstr "Средняя загрузка"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Загрузка содержимого директории…"
 
@@ -3171,7 +3175,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-адрес"
 
@@ -3313,8 +3318,8 @@ msgid "Method not found"
 msgstr "Метод не найден"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Метрика"
@@ -3385,7 +3390,7 @@ msgstr "Монитор"
 msgid "More Characters"
 msgstr "Слишком мало символов"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Больше…"
 
@@ -3476,8 +3481,8 @@ msgstr "NT домен"
 msgid "NTP server candidates"
 msgstr "Список NTP-серверов"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3498,8 +3503,8 @@ msgstr "Навигация"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Сеть"
@@ -3525,7 +3530,7 @@ msgstr "Новое имя интерфейса…"
 msgid "Next »"
 msgstr "Следующий »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Нет"
@@ -3546,7 +3551,7 @@ msgstr "Без NAT-T"
 msgid "No data received"
 msgstr "Данные не получены"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "Нет элементов в этом каталоге"
 
@@ -3586,7 +3591,7 @@ msgstr "Узлы ещё не определены"
 msgid "No public keys present yet."
 msgstr "Нет публичных ключей."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Нет правил в данной цепочке."
 
@@ -3749,11 +3754,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Настройка частоты"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Опция изменена"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Опция удалена"
 
@@ -3828,7 +3833,7 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 "Необязательно. Udp-порт, используемый для исходящих и входящих пакетов."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Опции"
 
@@ -3836,7 +3841,7 @@ msgstr "Опции"
 msgid "Other:"
 msgstr "Другие:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Вне"
 
@@ -3908,7 +3913,7 @@ msgstr "Назначить таблицу внутренних маршруто�
 msgid "Overview"
 msgstr "Главное меню"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Перезаписать существующий файл «%s»?"
 
@@ -4009,7 +4014,7 @@ msgstr "PSID длина в битах"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Режим передачи пакетов)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Пакеты"
 
@@ -4143,7 +4148,7 @@ msgstr "Пинг-запрос"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "пакетов"
 
@@ -4151,11 +4156,11 @@ msgstr "пакетов"
 msgid "Please enter your username and password."
 msgstr "Введите логин и пароль."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Пожалуйста, выберите файл для загрузки."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Политика"
 
@@ -4225,7 +4230,7 @@ msgid "Private Key"
 msgstr "Приватный ключ"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Процессы"
 
@@ -4233,7 +4238,7 @@ msgstr "Процессы"
 msgid "Profile"
 msgstr "Профиль"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Прот."
 
@@ -4371,7 +4376,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Вы действительно хотите изменить протокол?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Графики в реальном времени"
 
@@ -4412,7 +4417,7 @@ msgstr "Рекомендуемый. IP адреса интерфейса WireGua
 msgid "Reconnect this interface"
 msgstr "Переподключить этот интерфейс"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Ссылки"
 
@@ -4558,7 +4563,7 @@ msgstr "Требуется wpa-supplicant с поддержкой SAE"
 msgid "Reset"
 msgstr "Сбросить"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Сбросить счётчики"
 
@@ -4585,7 +4590,7 @@ msgstr "Ресурс не найден"
 msgid "Restart"
 msgstr "Перезапустить"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Перезапустить межсетевой экран"
 
@@ -4606,19 +4611,19 @@ msgstr "Восстановить резервную копию"
 msgid "Reveal/hide password"
 msgstr "Показать/скрыть пароль"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Вернуть"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Вернуть изменения"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Ошибка <code>%h</code> отмены конфигурации"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Отмена конфигурации…"
 
@@ -4652,8 +4657,8 @@ msgid "Router Password"
 msgstr "Пароль маршрутизатора"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Маршруты"
 
@@ -4665,7 +4670,7 @@ msgstr ""
 "Маршрутизация служит для определения через, какой интерфейс и шлюз можно "
 "достичь определенного хоста или сети."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Правило"
 
@@ -4722,7 +4727,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "Разделы подкачки (swap)"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4733,7 +4738,7 @@ msgid "Save"
 msgstr "Сохранить"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Сохранить и применить"
@@ -4755,11 +4760,11 @@ msgstr "Поиск"
 msgid "Scheduled Tasks"
 msgstr "Запланированные задания"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Строки добавлены"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Строки удалены"
 
@@ -4777,9 +4782,9 @@ msgstr ""
 "формата завершается с ошибкой. Используйте эту опцию только если уверены, "
 "что файл образа корректный и предназначен именно для данного устройства!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Выбрать файл…"
 
@@ -4866,7 +4871,7 @@ msgstr "Короткая преамбула"
 msgid "Show current backup file list"
 msgstr "Показать текущий список файлов резервной копии"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Показать пустые цепочки"
 
@@ -4896,7 +4901,7 @@ msgstr "Затухание сигнала (SATN)"
 msgid "Signal:"
 msgstr "Сигнал:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Размер"
@@ -4923,7 +4928,7 @@ msgid "Skip to navigation"
 msgstr "Перейти к навигации"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "Программное обеспечение VLAN"
 
@@ -4950,8 +4955,8 @@ msgstr ""
 "инструкций для вашего устройства."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Источник"
 
@@ -5023,7 +5028,7 @@ msgstr "Старт"
 msgid "Start priority"
 msgstr "Приоритет"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Применение конфигурации…"
 
@@ -5054,7 +5059,7 @@ msgstr "Статические маршруты"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Статический адрес"
 
@@ -5135,7 +5140,7 @@ msgid "Switch Speed Mask"
 msgstr "Маска скорости комутатора"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Изменить VLAN"
 
@@ -5149,7 +5154,7 @@ msgstr "Изменить протокол"
 msgid "Switch to CIDR list notation"
 msgstr "Переключить в формат CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Символическая ссылка"
 
@@ -5168,8 +5173,8 @@ msgstr "Синхронизировать с браузером"
 msgid "System"
 msgstr "Система"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Системный журнал"
 
@@ -5202,16 +5207,16 @@ msgstr "Передача (TX)"
 msgid "TX Rate"
 msgstr "Cкорость передачи"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Таблица"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Назначение"
 
@@ -5259,7 +5264,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "Не удалось загрузить config файл из-за следующей ошибки:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5303,7 +5308,7 @@ msgstr ""
 "сравните их с оригинальным файлом для обеспечения целостности данных.<br /"
 ">Нажмите кнопку «Продолжить» ниже, чтобы начать процедуру прошивки."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "На данном устройстве активны следующие правила."
 
@@ -5452,7 +5457,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Нет активных арендованных адресов"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Нет изменений для применения"
 
@@ -5485,9 +5490,9 @@ msgid ""
 "'server=1.2.3.4' for domain-specific or full upstream <abbr title=\"Domain "
 "Name System\">DNS</abbr> servers."
 msgstr ""
-"Этот файл может содержать такие строки, как <code>server=/domain/"
-"1.2.3.4</code> или <code>server=1.2.3.4</code> для каждого отдельного домена "
-"или общий <abbr title=\"Система доменных имен\">DNS</abbr> сервер."
+"Этот файл может содержать такие строки, как <code>server=/domain/1.2.3.4</"
+"code> или <code>server=1.2.3.4</code> для каждого отдельного домена или "
+"общий <abbr title=\"Система доменных имен\">DNS</abbr> сервер."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
@@ -5560,8 +5565,8 @@ msgid ""
 "their status."
 msgstr "Страница содержит работающие процессы и их состояние."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5608,9 +5613,9 @@ msgstr "Всего доступно"
 msgid "Traceroute"
 msgstr "Трассировка"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Трафик"
 
@@ -5635,7 +5640,7 @@ msgid "Tunnel ID"
 msgstr "Идентификатор туннеля"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Интерфейс туннеля"
 
@@ -5702,6 +5707,11 @@ msgstr "Невозможно определить основной интерф�
 msgid "Unable to dispatch"
 msgstr "Невозможно обработать запрос для"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5713,6 +5723,14 @@ msgstr "Невозможно получить идентификатор кли�
 msgid "Unable to obtain mount information"
 msgstr "Невозможно получить информацию о точках монтирования"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5722,6 +5740,10 @@ msgstr "Не удалось разрешить AFTR имя хоста"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Не удалось разрешить имя хоста пира"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5738,12 +5760,12 @@ msgid "Unexpected reply data format"
 msgstr "Не ожидаемый формат данных ответа"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Неизвестно"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Неизвестная ошибка (%s)"
 
@@ -5753,7 +5775,7 @@ msgstr "Неизвестный код ошибки"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Неуправляемый"
 
@@ -5767,7 +5789,7 @@ msgstr "Отмонтировать"
 msgid "Unnamed key"
 msgstr "Ключ без имени"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Не принятые изменения"
 
@@ -5793,7 +5815,7 @@ msgstr "Не поддерживаемый тип протокола."
 msgid "Up"
 msgstr "Вверх"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Загрузить"
 
@@ -5809,21 +5831,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Загрузка архива..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Загрузка файла"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Загрузка файла…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Ошибка запроса на загрузку: %d %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Загрузка файла…"
 
@@ -6132,19 +6154,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Wi-Fi"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Беспроводной адаптер"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Беспроводная сеть"
 
@@ -6188,7 +6210,7 @@ msgstr "Записывать полученные DNS-запросы в сист
 msgid "Write system log to file"
 msgstr "Записывать системные события в файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Да"
@@ -6208,10 +6230,9 @@ msgid ""
 "scripts like \"network\", your device might become inaccessible!</strong>"
 msgstr ""
 "Здесь вы можете включить или выключить установленные скрипты инициализации. "
-"Изменения вступят в силу после перезагрузки устройства.<br "
-"/><strong>Внимание: если вы выключите один из основных скриптов "
-"инициализации (например \"network\"), ваше устройство может оказаться "
-"недоступным!</strong>"
+"Изменения вступят в силу после перезагрузки устройства.<br /"
+"><strong>Внимание: если вы выключите один из основных скриптов инициализации "
+"(например \"network\"), ваше устройство может оказаться недоступным!</strong>"
 
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:73
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:223
@@ -6413,7 +6434,7 @@ msgstr "нет соединения"
 msgid "non-empty value"
 msgstr "не пустое значение"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "ничего"
 
@@ -6521,7 +6542,7 @@ msgstr "неизвестный"
 msgid "unlimited"
 msgstr "неограниченный"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -18,7 +18,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -54,11 +54,11 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -66,7 +66,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -163,12 +163,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 
@@ -201,7 +199,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 
@@ -231,7 +228,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -260,6 +257,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -320,11 +321,11 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
@@ -348,11 +349,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -456,7 +457,7 @@ msgid "Alert"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -630,16 +631,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -842,7 +843,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr ""
 
@@ -859,8 +860,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -891,8 +892,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -908,17 +909,17 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1026,7 +1027,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr ""
@@ -1043,7 +1045,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1055,16 +1057,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1095,7 +1097,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr ""
 
@@ -1111,7 +1113,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1195,7 +1197,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1319,11 +1321,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1335,7 +1337,7 @@ msgstr ""
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1351,7 +1353,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1360,7 +1362,7 @@ msgid "Design"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr ""
 
@@ -1396,7 +1398,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1413,7 +1415,7 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1478,10 +1480,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1515,7 +1517,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1527,7 +1529,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1565,7 +1567,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1606,9 +1608,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1795,12 +1797,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1880,7 +1882,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1888,15 +1890,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1948,7 +1950,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr ""
 
@@ -2134,8 +2136,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2175,8 +2177,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2266,7 +2268,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2317,7 +2319,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2345,11 +2352,11 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2412,7 +2419,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2518,7 +2525,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2571,8 +2578,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
@@ -2701,8 +2708,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr ""
 
@@ -2784,17 +2791,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2810,7 +2814,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2899,7 +2903,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr ""
 
@@ -2907,7 +2911,7 @@ msgstr ""
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3018,7 +3022,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3158,8 +3163,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3230,7 +3235,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3319,8 +3324,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3341,8 +3346,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr ""
@@ -3368,7 +3373,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3389,7 +3394,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3429,7 +3434,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3590,11 +3595,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3655,7 +3660,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3663,7 +3668,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3733,7 +3738,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3834,7 +3839,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -3968,7 +3973,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -3976,11 +3981,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4048,7 +4053,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr ""
 
@@ -4056,7 +4061,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4182,7 +4187,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4222,7 +4227,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4361,7 +4366,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr ""
 
@@ -4388,7 +4393,7 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr ""
 
@@ -4409,19 +4414,19 @@ msgstr ""
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4455,8 +4460,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr ""
 
@@ -4466,7 +4471,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4523,7 +4528,7 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4534,7 +4539,7 @@ msgid "Save"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4556,11 +4561,11 @@ msgstr ""
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4575,9 +4580,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4661,7 +4666,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4691,7 +4696,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr ""
@@ -4718,7 +4723,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4742,8 +4747,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr ""
 
@@ -4804,7 +4809,7 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4835,7 +4840,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4911,7 +4916,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4925,7 +4930,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4944,8 +4949,8 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr ""
 
@@ -4978,16 +4983,16 @@ msgstr ""
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr ""
 
@@ -5030,7 +5035,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5061,7 +5066,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5190,7 +5195,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5278,8 +5283,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5322,9 +5327,9 @@ msgstr ""
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr ""
 
@@ -5349,7 +5354,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5416,6 +5421,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5427,6 +5437,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5435,6 +5453,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5452,12 +5474,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5467,7 +5489,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5481,7 +5503,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5507,7 +5529,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5522,21 +5544,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5826,19 +5848,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr ""
 
@@ -5882,7 +5904,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6096,7 +6118,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr ""
 
@@ -6204,7 +6226,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -57,11 +57,11 @@ msgid "-- Additional Field --"
 msgstr "-- Ytterligare fält --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -69,7 +69,7 @@ msgstr "-- Vänligen välj --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- anpassad --"
@@ -166,13 +166,11 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-adress"
 
 # I don't think "Gateway" is commonly translated.
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-gateway"
 
@@ -207,7 +205,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 
@@ -239,7 +236,7 @@ msgstr ""
 "<br/>Notera att: du måste starta om cron-tjänsten om crontab-filen var tom "
 "innan den ändrades."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -269,6 +266,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -328,11 +329,11 @@ msgstr "Accesspunkt"
 msgid "Actions"
 msgstr "Åtgärder"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "Aktiva <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-rutter"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktiva <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-rutter"
 
@@ -356,11 +357,11 @@ msgstr "Aktiva DHCPv6-kontrakt"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -464,7 +465,7 @@ msgid "Alert"
 msgstr "Varning"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -641,16 +642,16 @@ msgstr "Någon zon"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -853,7 +854,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Brygga"
 
@@ -870,8 +871,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Bläddra…"
 
@@ -903,8 +904,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -920,17 +921,17 @@ msgstr "Avbryt"
 msgid "Category"
 msgstr "Kategori"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Kedja"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Ändringar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Ändringar har återställts."
 
@@ -1040,7 +1041,8 @@ msgstr "Stäng ner lista..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Samlar in data..."
@@ -1057,7 +1059,7 @@ msgstr ""
 msgid "Command failed"
 msgstr "Kommandot misslyckades"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Kommentera"
 
@@ -1069,16 +1071,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1109,7 +1111,7 @@ msgstr "Anslutningsförsök misslyckades"
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Anslutningar"
 
@@ -1125,7 +1127,7 @@ msgstr "Innehåll har sparats."
 msgid "Continue"
 msgstr "Fortsätt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1209,7 +1211,7 @@ msgstr "DHCP och DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP-klient"
 
@@ -1333,11 +1335,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1349,7 +1351,7 @@ msgstr "Radera"
 msgid "Delete key"
 msgstr "Radera nyckel"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1365,7 +1367,7 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivning"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1374,7 +1376,7 @@ msgid "Design"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Plats"
 
@@ -1410,7 +1412,7 @@ msgstr "Enheten är ej aktiv"
 msgid "Device is restarting…"
 msgstr "Enheten startas om…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Enheten kan inte nås!"
 
@@ -1427,7 +1429,7 @@ msgstr "Diagnostik"
 msgid "Dial number"
 msgstr "Slå nummer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Mapp"
 
@@ -1494,10 +1496,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1533,7 +1535,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Vill du verkligen radera \"%s\" ?"
 
@@ -1545,7 +1547,7 @@ msgstr "Vill du verkligen ta bort följande SSH-nyckel?"
 msgid "Do you really want to erase all settings?"
 msgstr "Vill du verkligen radera alla inställningar?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1585,7 +1587,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1627,9 +1629,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-metod"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1816,12 +1818,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernet-adapter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1901,7 +1903,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr "Byte av systemlösenord misslyckades."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1909,15 +1911,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Filnamn"
 
@@ -1969,7 +1971,7 @@ msgstr "Brandväggsmarkering"
 msgid "Firewall Settings"
 msgstr "Inställningar för brandvägg"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Status för brandvägg"
 
@@ -2155,8 +2157,8 @@ msgstr "Globala nätverksalternativ"
 msgid "Go to password configuration..."
 msgstr "Gå till lösenordskonfiguration..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2196,8 +2198,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Göm <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2287,7 +2289,7 @@ msgstr ""
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4-brandvägg"
 
@@ -2338,8 +2340,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-Adress"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2366,11 +2373,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6-brandvägg"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "IPV6-grannar"
 
@@ -2433,7 +2440,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-adress"
 
@@ -2539,7 +2546,7 @@ msgstr "Ignorera resolv-fil"
 msgid "Image"
 msgstr "Bild"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "I"
 
@@ -2592,8 +2599,8 @@ msgstr "Installera protokoll-förlängningar..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Gränssnitt"
@@ -2722,8 +2729,8 @@ msgstr "Ansluter till nätverk: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Kernel-logg"
 
@@ -2805,18 +2812,15 @@ msgid "Lease time"
 msgstr "Kontraktstid"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Återstående kontraktstid"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Kontraktsfil"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2831,7 +2835,7 @@ msgstr "Lämna tom för att upptäcka automatiskt"
 msgid "Leave empty to use the current WAN address"
 msgstr "Lämna tom för att använda den nuvarande WAN-adressen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2921,7 +2925,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Lyssningsportar för ankommande DNS-förfrågningar"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Belastning"
 
@@ -2929,7 +2933,7 @@ msgstr "Belastning"
 msgid "Load Average"
 msgstr "Snitt-belastning"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3040,7 +3044,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-adress"
 
@@ -3180,8 +3185,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrisk"
@@ -3252,7 +3257,7 @@ msgstr "Övervaka"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3341,8 +3346,8 @@ msgstr "NT-domän"
 msgid "NTP server candidates"
 msgstr "NTP-serverkandidater"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3363,8 +3368,8 @@ msgstr "Navigering"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Nätverk"
@@ -3390,7 +3395,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Nästa »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Nej"
@@ -3411,7 +3416,7 @@ msgstr "Ingen NAT-T"
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3451,7 +3456,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Inga regler i den här kedjan."
 
@@ -3612,11 +3617,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Alternativet ändrades"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Alternativet togs bort"
 
@@ -3677,7 +3682,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Alternativ"
 
@@ -3685,7 +3690,7 @@ msgstr "Alternativ"
 msgid "Other:"
 msgstr "Andra:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Ut"
 
@@ -3755,7 +3760,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Översikt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3856,7 +3861,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Paket"
 
@@ -3990,7 +3995,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "Pkt."
 
@@ -3998,11 +4003,11 @@ msgstr "Pkt."
 msgid "Please enter your username and password."
 msgstr "Vänligen ange ditt användarnamn och lösenord."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Villkor"
 
@@ -4070,7 +4075,7 @@ msgid "Private Key"
 msgstr "Privat nyckel"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Processer"
 
@@ -4078,7 +4083,7 @@ msgstr "Processer"
 msgid "Profile"
 msgstr "Profil"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Prot."
 
@@ -4206,7 +4211,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Verkligen byta protokoll?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Realtidsgrafer"
 
@@ -4246,7 +4251,7 @@ msgstr "Rekommenderad. WireGuard-gränssnittets IP-adresser."
 msgid "Reconnect this interface"
 msgstr "Återanslut det här gränssnittet"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Referens"
 
@@ -4385,7 +4390,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Återställ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Återställ räknare"
 
@@ -4412,7 +4417,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Starta om"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Starta om brandvägg"
 
@@ -4433,19 +4438,19 @@ msgstr "Återställ säkerhetskopian"
 msgid "Reveal/hide password"
 msgstr "Visa/göm lösenord"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Återgå"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4479,8 +4484,8 @@ msgid "Router Password"
 msgstr "Router-lösenord"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Rutter"
 
@@ -4490,7 +4495,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4547,7 +4552,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4558,7 +4563,7 @@ msgid "Save"
 msgstr "Spara"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Spara och Verkställ"
@@ -4580,11 +4585,11 @@ msgstr "Skanna"
 msgid "Scheduled Tasks"
 msgstr "Schemalagda uppgifter"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Sektionen lades till"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Sektionen togs bort"
 
@@ -4599,9 +4604,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4685,7 +4690,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4715,7 +4720,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Signal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Storlek"
@@ -4742,7 +4747,7 @@ msgid "Skip to navigation"
 msgstr "Hoppa över till navigering"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4766,8 +4771,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Källa"
 
@@ -4828,7 +4833,7 @@ msgstr "Starta"
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4859,7 +4864,7 @@ msgstr "Statiska rutter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Statiska adresser"
 
@@ -4935,7 +4940,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Byt VLAN"
 
@@ -4949,7 +4954,7 @@ msgstr "Byt protokoll"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4968,8 +4973,8 @@ msgstr "Synkronisera med webbläsare"
 msgid "System"
 msgstr "System"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Systemlogg"
 
@@ -5002,16 +5007,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "TX-hastighet"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Tabell"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Mål"
 
@@ -5054,7 +5059,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5085,7 +5090,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5214,7 +5219,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5304,8 +5309,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5350,9 +5355,9 @@ msgstr "Totalt tillgängligt"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Trafik"
 
@@ -5377,7 +5382,7 @@ msgid "Tunnel ID"
 msgstr "Tunnel-ID"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Tunnelgränssnitt"
 
@@ -5444,6 +5449,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr "Det går inte att skicka"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5455,6 +5465,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5463,6 +5481,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5480,12 +5502,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Okänd"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5495,7 +5517,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5509,7 +5531,7 @@ msgstr "Avmontera"
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Osparade ändringar"
 
@@ -5535,7 +5557,7 @@ msgstr "Protokolltypen stöds inte."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5550,21 +5572,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Ladda upp arkiv..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5855,19 +5877,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Trådlöst"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Trådlös adapter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Trådlöst nätverk"
 
@@ -5911,7 +5933,7 @@ msgstr "Skriv mottagna DNS-förfrågningar till syslogg"
 msgid "Write system log to file"
 msgstr "Skriv systemlogg till fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Ja"
@@ -6127,7 +6149,7 @@ msgstr "ingen länk"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "ingen"
 
@@ -6235,7 +6257,7 @@ msgstr "okänd"
 msgid "unlimited"
 msgstr "obegränsat"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -10,7 +10,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -46,11 +46,11 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -155,12 +155,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr ""
 
@@ -193,7 +191,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 
@@ -223,7 +220,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -252,6 +249,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -312,11 +313,11 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
@@ -340,11 +341,11 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -448,7 +449,7 @@ msgid "Alert"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -622,16 +623,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -834,7 +835,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr ""
 
@@ -851,8 +852,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -883,8 +884,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -900,17 +901,17 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1018,7 +1019,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr ""
@@ -1035,7 +1037,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1047,16 +1049,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1087,7 +1089,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr ""
 
@@ -1103,7 +1105,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1187,7 +1189,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1311,11 +1313,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1327,7 +1329,7 @@ msgstr ""
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1343,7 +1345,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1352,7 +1354,7 @@ msgid "Design"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr ""
 
@@ -1388,7 +1390,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1405,7 +1407,7 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr ""
 
@@ -1470,10 +1472,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1507,7 +1509,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1519,7 +1521,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1557,7 +1559,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1598,9 +1600,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1787,12 +1789,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1872,7 +1874,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1880,15 +1882,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1940,7 +1942,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr ""
 
@@ -2126,8 +2128,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2167,8 +2169,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2258,7 +2260,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2309,7 +2311,12 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
 msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
@@ -2337,11 +2344,11 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2404,7 +2411,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2510,7 +2517,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2563,8 +2570,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
@@ -2693,8 +2700,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr ""
 
@@ -2776,17 +2783,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2802,7 +2806,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2891,7 +2895,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr ""
 
@@ -2899,7 +2903,7 @@ msgstr ""
 msgid "Load Average"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3010,7 +3014,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr ""
 
@@ -3150,8 +3155,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3222,7 +3227,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3311,8 +3316,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3333,8 +3338,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr ""
@@ -3360,7 +3365,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3381,7 +3386,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3421,7 +3426,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3582,11 +3587,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3647,7 +3652,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3655,7 +3660,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3725,7 +3730,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3826,7 +3831,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -3960,7 +3965,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -3968,11 +3973,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4040,7 +4045,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr ""
 
@@ -4048,7 +4053,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4174,7 +4179,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4214,7 +4219,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4353,7 +4358,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr ""
 
@@ -4380,7 +4385,7 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr ""
 
@@ -4401,19 +4406,19 @@ msgstr ""
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4447,8 +4452,8 @@ msgid "Router Password"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr ""
 
@@ -4458,7 +4463,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4515,7 +4520,7 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4526,7 +4531,7 @@ msgid "Save"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4548,11 +4553,11 @@ msgstr ""
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr ""
 
@@ -4567,9 +4572,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4653,7 +4658,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4683,7 +4688,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr ""
@@ -4710,7 +4715,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4734,8 +4739,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr ""
 
@@ -4796,7 +4801,7 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4827,7 +4832,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4903,7 +4908,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4917,7 +4922,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4936,8 +4941,8 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr ""
 
@@ -4970,16 +4975,16 @@ msgstr ""
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr ""
 
@@ -5022,7 +5027,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5053,7 +5058,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5182,7 +5187,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5270,8 +5275,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5314,9 +5319,9 @@ msgstr ""
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr ""
 
@@ -5341,7 +5346,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5408,6 +5413,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5419,6 +5429,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5427,6 +5445,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5444,12 +5466,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5459,7 +5481,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5473,7 +5495,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5499,7 +5521,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5514,21 +5536,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5818,19 +5840,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr ""
 
@@ -5874,7 +5896,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6088,7 +6110,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr ""
 
@@ -6196,7 +6218,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -24,7 +24,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d geçersiz alan(lar)"
 
@@ -60,11 +60,11 @@ msgid "-- Additional Field --"
 msgstr "-- Ek Alan--"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -72,7 +72,7 @@ msgstr "-- Lütfen seçiniz --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- özel --"
@@ -170,12 +170,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protokolü Sürüm 4\">IPv4</abbr>-Adres"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protokolü Sürüm 4\">IPv4</abbr>-Gateway"
 
@@ -210,7 +208,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Adı"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-Adresi"
 
@@ -244,7 +241,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -274,6 +271,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -333,12 +334,12 @@ msgstr "Erişim Noktası"
 msgid "Actions"
 msgstr "Eylemler"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Aktif <abbr title=\"İnternet Protokolü Sürüm 4\">IPv4</abbr>-Yönlendiricileri"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Aktif <abbr title=\"İnternet Protokolü Sürüm 4\">IPv6</abbr>-Yönlendiricileri"
@@ -365,11 +366,11 @@ msgstr "Aktif DHCPv6 Kiraları"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -473,7 +474,7 @@ msgid "Alert"
 msgstr "Uyarı"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -652,16 +653,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -864,7 +865,7 @@ msgid "Bogus NX Domain Override"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Köprü"
 
@@ -881,8 +882,8 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -913,8 +914,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -930,17 +931,17 @@ msgstr "İptal"
 msgid "Category"
 msgstr "Kategori"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Zincir"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Değişiklikler"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr ""
 
@@ -1050,7 +1051,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Veri alınıyor..."
@@ -1067,7 +1069,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1079,16 +1081,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr ""
 
@@ -1119,7 +1121,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Bağlantılar"
 
@@ -1135,7 +1137,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1219,7 +1221,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr ""
 
@@ -1343,11 +1345,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1359,7 +1361,7 @@ msgstr "Sil"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1375,7 +1377,7 @@ msgstr ""
 msgid "Description"
 msgstr "Açıklama"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1384,7 +1386,7 @@ msgid "Design"
 msgstr "Tasarım"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Hedef"
 
@@ -1420,7 +1422,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Cihaz ulaşılamaz!"
 
@@ -1437,7 +1439,7 @@ msgstr "Tanı"
 msgid "Dial number"
 msgstr "Arama numarası"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Dizin"
 
@@ -1504,10 +1506,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr "Bağlantı kesme girişimi başarısız oldu"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1541,7 +1543,7 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1553,7 +1555,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1591,7 +1593,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1632,9 +1634,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1821,12 +1823,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr ""
 
@@ -1906,7 +1908,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1914,15 +1916,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1974,7 +1976,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr ""
 
@@ -2160,8 +2162,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2201,8 +2203,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2292,7 +2294,7 @@ msgstr ""
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr ""
 
@@ -2343,8 +2345,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-Adres"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2371,11 +2378,11 @@ msgstr ""
 msgid "IPv6"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2438,7 +2445,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-Adres"
 
@@ -2544,7 +2551,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr ""
 
@@ -2597,8 +2604,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
@@ -2727,8 +2734,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr ""
 
@@ -2810,17 +2817,14 @@ msgid "Lease time"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Kalan kira süresi"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
@@ -2836,7 +2840,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -2925,7 +2929,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr ""
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr ""
 
@@ -2933,7 +2937,7 @@ msgstr ""
 msgid "Load Average"
 msgstr "Ortalama Yük"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3044,7 +3048,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-Adres"
 
@@ -3184,8 +3189,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
@@ -3256,7 +3261,7 @@ msgstr ""
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3345,8 +3350,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3367,8 +3372,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Ağ"
@@ -3394,7 +3399,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3415,7 +3420,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3455,7 +3460,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr ""
 
@@ -3616,11 +3621,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr ""
 
@@ -3681,7 +3686,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr ""
 
@@ -3689,7 +3694,7 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr ""
 
@@ -3759,7 +3764,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel Bakış"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3860,7 +3865,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr ""
 
@@ -3994,7 +3999,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -4002,11 +4007,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr ""
 
@@ -4074,7 +4079,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr ""
 
@@ -4082,7 +4087,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr ""
 
@@ -4208,7 +4213,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr ""
 
@@ -4248,7 +4253,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr ""
 
@@ -4387,7 +4392,7 @@ msgstr ""
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Sayaçları Sıfırla"
 
@@ -4414,7 +4419,7 @@ msgstr ""
 msgid "Restart"
 msgstr "Tekrar başlat"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr ""
 
@@ -4435,19 +4440,19 @@ msgstr "Yedeklemeyi geri yükle"
 msgid "Reveal/hide password"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Dönmek"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Değişiklikleri geri al"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4481,8 +4486,8 @@ msgid "Router Password"
 msgstr "Yönlendirici Parolası"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Yönlendirmeler"
 
@@ -4492,7 +4497,7 @@ msgid ""
 "can be reached."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4550,7 +4555,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "TAKAS"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4561,7 +4566,7 @@ msgid "Save"
 msgstr "Kaydet"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Kaydet & Uygula"
@@ -4583,11 +4588,11 @@ msgstr "Tara"
 msgid "Scheduled Tasks"
 msgstr "Zamanlanmış Görevler"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Bölüm eklendi"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Bölüm kaldırıldı"
 
@@ -4602,9 +4607,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4688,7 +4693,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4718,7 +4723,7 @@ msgstr "Sinyal Zayıflama (SATN)"
 msgid "Signal:"
 msgstr "Sinyal:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Boyut"
@@ -4745,7 +4750,7 @@ msgid "Skip to navigation"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4769,8 +4774,8 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Kaynak"
 
@@ -4831,7 +4836,7 @@ msgstr "Başlat"
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr ""
 
@@ -4862,7 +4867,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr ""
 
@@ -4938,7 +4943,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4952,7 +4957,7 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4971,8 +4976,8 @@ msgstr ""
 msgid "System"
 msgstr "Sistem"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr ""
 
@@ -5005,16 +5010,16 @@ msgstr ""
 msgid "TX Rate"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr ""
 
@@ -5057,7 +5062,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5088,7 +5093,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr ""
 
@@ -5217,7 +5222,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5305,8 +5310,8 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5349,9 +5354,9 @@ msgstr "Toplam Mevcut"
 msgid "Traceroute"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr ""
 
@@ -5376,7 +5381,7 @@ msgid "Tunnel ID"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr ""
 
@@ -5443,6 +5448,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5454,6 +5464,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5462,6 +5480,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5479,12 +5501,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5494,7 +5516,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr ""
 
@@ -5508,7 +5530,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5534,7 +5556,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5549,21 +5571,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5853,19 +5875,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Kablosuz"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr ""
 
@@ -5909,7 +5931,7 @@ msgstr ""
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6125,7 +6147,7 @@ msgstr "bağlantı yok"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "hiçbiri"
 
@@ -6233,7 +6255,7 @@ msgstr "bilinmeyen"
 msgid "unlimited"
 msgstr "sınırsız"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -22,7 +22,7 @@ msgstr "%.1f дБ"
 msgid "%d Bit"
 msgstr "%d біт"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d неприпустимі поля"
 
@@ -58,11 +58,11 @@ msgid "-- Additional Field --"
 msgstr "-- Додаткові поля --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -70,7 +70,7 @@ msgstr "-- Оберіть --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- нетипово --"
@@ -179,12 +179,10 @@ msgstr ""
 "служби послуг\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Інтернет-протокол версії 4\">IPv4</abbr>-адреса"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Інтернет-протокол версії 4\">IPv4</abbr>-шлюз"
 
@@ -220,7 +218,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "Назва <abbr title=\"Light Emitting Diode — світлодіод\">LED</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 "<abbr title=\"Media Access Control — управління доступом до носія\">MAC</"
@@ -259,7 +256,7 @@ msgstr ""
 "<br/>Примітка: якщо перед редагуванням, файл crontab був порожній, вам "
 "потрібно вручну перезапустити служби cron."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "Каталог з такою ж назвою вже існує."
 
@@ -291,6 +288,10 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr ""
 "<abbr title=\"Access Point Name — символічна назва точки доступу\">APN</abbr>"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -359,11 +360,11 @@ msgstr "Точка доступу"
 msgid "Actions"
 msgstr "Дії"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "<abbr title=\"Інтернет-протокол версії 4\">IPv4</abbr>-маршрути"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "<abbr title=\"Інтернет-протокол версії 6\">IPv6</abbr>-маршрути"
 
@@ -387,11 +388,11 @@ msgstr "Активні оренди DHCPv6"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -495,7 +496,7 @@ msgid "Alert"
 msgstr "Тривога"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Інтерфейс псевдоніма"
@@ -683,16 +684,16 @@ msgstr "Будь-яка зона"
 msgid "Apply backup?"
 msgstr "Застосувати резервну копію?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Сталася помилка запиту на застосування зі статусом <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Застосувати без перевірки"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Очікування на застосування конфігурації… %d c"
 
@@ -906,7 +907,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Відкидати підробки NX-домену"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Міст"
 
@@ -923,8 +924,8 @@ msgstr "Номер моста"
 msgid "Bring up on boot"
 msgstr "Піднімати при завантаженні"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Огляд…"
 
@@ -956,8 +957,8 @@ msgstr "Кешовано"
 msgid "Call failed"
 msgstr "Не вдалося здійснити виклик"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -973,17 +974,17 @@ msgstr "Скасувати"
 msgid "Category"
 msgstr "Категорія"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "Ланцюжок"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Зміни"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Зміни було скасовано."
 
@@ -1103,7 +1104,8 @@ msgstr "Згорнути список..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Збирання даних..."
@@ -1120,7 +1122,7 @@ msgstr "Команду виконано успішно"
 msgid "Command failed"
 msgstr "Не вдалося виконати команду"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Примітка"
 
@@ -1136,16 +1138,16 @@ msgstr ""
 "Може викликати проблеми сумісності та зниження стійкості узгодження ключа, "
 "особливо в середовищах з великою завантаженістю трафіку."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Конфігурація"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "Зміни конфігурації застосовано."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "Зміни конфігурації було скасовано!"
 
@@ -1176,7 +1178,7 @@ msgstr "Невдала спроба підключення"
 msgid "Connection lost"
 msgstr "З'єднання втрачено"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Підключення"
 
@@ -1192,7 +1194,7 @@ msgstr "Вміст збережено."
 msgid "Continue"
 msgstr "Продовжити"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1285,7 +1287,7 @@ msgstr "DHCP та DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Клієнт DHCP"
 
@@ -1414,11 +1416,11 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\", щоб оголошувати різні DNS-"
 "сервери для клієнтів."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1430,7 +1432,7 @@ msgstr "Видалити"
 msgid "Delete key"
 msgstr "Видалити ключ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Помилка запиту на видалення: %s"
 
@@ -1446,7 +1448,7 @@ msgstr "Інтервал повідомлень індикації доправ�
 msgid "Description"
 msgstr "Опис"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Скасувати вибір"
 
@@ -1455,7 +1457,7 @@ msgid "Design"
 msgstr "Стиль"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Призначення"
 
@@ -1491,7 +1493,7 @@ msgstr "Пристрій не є активним"
 msgid "Device is restarting…"
 msgstr "Пристрій перезавантажується…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Пристрій недосяжний!"
 
@@ -1508,7 +1510,7 @@ msgstr "Діагностика"
 msgid "Dial number"
 msgstr "Набір номера"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Каталог"
 
@@ -1575,10 +1577,10 @@ msgstr "Від’єднати"
 msgid "Disconnection attempt failed"
 msgstr "Спроба від'єднання не вдалася"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1621,7 +1623,7 @@ msgstr ""
 "Не переспрямовувати зворотні <abbr title=\"Domain Name System — система "
 "доменних імен\">DNS</abbr>-запити для локальних мереж"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Справді видалити \"%s\"?"
 
@@ -1633,7 +1635,7 @@ msgstr "Справді видалити такий SSH ключ?"
 msgid "Do you really want to erase all settings?"
 msgstr "Справді стерти всі налаштування?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Справді рекурсивно видалити каталог \"%s\"?"
 
@@ -1674,7 +1676,7 @@ msgstr "Завантажити mtdblock"
 msgid "Downstream SNR offset"
 msgstr "Низхідний зсув SNR"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Перетягніть, щоб змінити порядок"
 
@@ -1721,9 +1723,9 @@ msgstr "Довжина EA-бітів"
 msgid "EAP-Method"
 msgstr "Метод EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1917,12 +1919,12 @@ msgid "Errored seconds (ES)"
 msgstr "Секунд з помилками (<abbr title=\"Errored seconds\">ES</abbr>)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Ethernet-адаптер"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Ethernet-комутатор"
 
@@ -2002,7 +2004,7 @@ msgstr "Протокол FT"
 msgid "Failed to change the system password."
 msgstr "Не вдалося змінити системний пароль."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "Не вдалося підтвердити застосування на протязі %d с, очікуємо відкату…"
 
@@ -2010,15 +2012,15 @@ msgstr "Не вдалося підтвердити застосування на
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Не вдалося виконати дію \"/etc/init.d/%s %s\": %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Файл недоступний"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Ім'я файлу"
 
@@ -2072,7 +2074,7 @@ msgstr "Позначка брандмауера"
 msgid "Firewall Settings"
 msgstr "Налаштування брандмауера"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Стан брандмауера"
 
@@ -2260,8 +2262,8 @@ msgstr "Глобальні параметри мережі"
 msgid "Go to password configuration..."
 msgstr "Перейти до конфігурації пароля..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2307,8 +2309,8 @@ msgstr ""
 "Приховати <abbr title=\"Extended Service Set Identifier — ідентифікатор "
 "розширеної служби послуг\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Приховати порожні ланцюжки"
 
@@ -2398,7 +2400,7 @@ msgstr "Відсутня IP-адреса"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Брандмауер IPv4"
 
@@ -2449,8 +2451,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Адреса IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2477,11 +2484,11 @@ msgstr "IPv4/IPv6 (обидва - типово для IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Брандмауер IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "Сусіди IPv6"
 
@@ -2546,7 +2553,7 @@ msgstr "Суфікс IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "Адреса IPv6"
 
@@ -2662,7 +2669,7 @@ msgstr "Ігнорувати файли resolv"
 msgid "Image"
 msgstr "Образ"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Вх."
 
@@ -2718,8 +2725,8 @@ msgstr "Інсталяція розширень протоколу..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Інтерфейс"
@@ -2853,8 +2860,8 @@ msgstr "Приєднання до мережі: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Зберегти налаштування та поточну конфігурацію"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Журнал ядра"
 
@@ -2936,18 +2943,15 @@ msgid "Lease time"
 msgstr "Час оренди"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Час оренди, що лишився"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Файл оренд"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2962,7 +2966,7 @@ msgstr "Залиште поле порожнім для автовизначен
 msgid "Leave empty to use the current WAN address"
 msgstr "Залиште порожнім, щоб використовувати поточну адресу WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "Легенда:"
 
@@ -3073,7 +3077,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Порт прослуховування для вхідних DNS-запитів"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Навантаження"
 
@@ -3081,7 +3085,7 @@ msgstr "Навантаження"
 msgid "Load Average"
 msgstr "Середнє навантаження"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Завантаження вмісту каталогу…"
 
@@ -3201,7 +3205,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-адреса"
 
@@ -3343,8 +3348,8 @@ msgid "Method not found"
 msgstr "Метод не знайдено"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Метрика"
@@ -3415,7 +3420,7 @@ msgstr "Диспетчер"
 msgid "More Characters"
 msgstr "Більше символів"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "Докладніше…"
 
@@ -3506,8 +3511,8 @@ msgstr "Домен NT"
 msgid "NTP server candidates"
 msgstr "Сервери NTP – кандидати для синхронізації"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3528,8 +3533,8 @@ msgstr "Навігація"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Мережа"
@@ -3555,7 +3560,7 @@ msgstr "Нова назва інтерфейсу…"
 msgid "Next »"
 msgstr "Наступний »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Немає"
@@ -3576,7 +3581,7 @@ msgstr "Немає NAT-T"
 msgid "No data received"
 msgstr "Жодних даних не отримано"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "У цьому каталозі немає записів"
 
@@ -3616,7 +3621,7 @@ msgstr "Жодного вузла ще не визначено"
 msgid "No public keys present yet."
 msgstr "Відкритих ключів поки що немає."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "У цьму ланцюжку нема правил."
 
@@ -3777,11 +3782,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "Робоча частота"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Опція змінена"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Опція видалена"
 
@@ -3857,7 +3862,7 @@ msgstr ""
 "Необов'язково. UDP-порт, який використовується для вихідних та вхідних "
 "пакетів."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Опції"
 
@@ -3865,7 +3870,7 @@ msgstr "Опції"
 msgid "Other:"
 msgstr "Інше:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Вих."
 
@@ -3938,7 +3943,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Перезаписати існуючий файл \"%s\"?"
 
@@ -4041,7 +4046,7 @@ msgstr "Довжина PSID у бітах"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Режим передачі пакетів)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Пакети"
 
@@ -4175,7 +4180,7 @@ msgstr "Ехо-запит"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "пакетів"
 
@@ -4183,11 +4188,11 @@ msgstr "пакетів"
 msgid "Please enter your username and password."
 msgstr "Введіть ім'я користувача і пароль."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "Виберіть файл для відвантаження."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Політика"
 
@@ -4257,7 +4262,7 @@ msgid "Private Key"
 msgstr "Приватний ключ"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Процеси"
 
@@ -4265,7 +4270,7 @@ msgstr "Процеси"
 msgid "Profile"
 msgstr "Профіль"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Прот."
 
@@ -4402,7 +4407,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Дійсно змінити протокол?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Графіки у реальному часі"
 
@@ -4442,7 +4447,7 @@ msgstr "Рекомендовано. IP-адреси інтерфейсу WireGua
 msgid "Reconnect this interface"
 msgstr "Перепідключити цей інтерфейс"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Посилання"
 
@@ -4588,7 +4593,7 @@ msgstr "Потребує wpa-суплікатора з підтримкою SAE"
 msgid "Reset"
 msgstr "Скинути"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Скинути лічильники"
 
@@ -4615,7 +4620,7 @@ msgstr "Ресурс не знайдено"
 msgid "Restart"
 msgstr "Перезавантажити"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Перезавантажити брандмауер"
 
@@ -4636,19 +4641,19 @@ msgstr "Відновити з резервної копії"
 msgid "Reveal/hide password"
 msgstr "Показати/приховати пароль"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Скасувати"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Скасувати зміни"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Помилка запиту на скасування зі статусом <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Відкат конфігурації…"
 
@@ -4682,8 +4687,8 @@ msgid "Router Password"
 msgstr "Пароль маршрутизатора"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Маршрути"
 
@@ -4695,7 +4700,7 @@ msgstr ""
 "Маршрути визначають через який інтерфейс і шлюз можна досягнути певного "
 "вузла або мережі."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Правило"
 
@@ -4752,7 +4757,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4763,7 +4768,7 @@ msgid "Save"
 msgstr "Зберегти"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Зберегти і застосувати"
@@ -4785,11 +4790,11 @@ msgstr "Сканувати"
 msgid "Scheduled Tasks"
 msgstr "Заплановані завдання"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Секцію додано"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Секцію видалено"
 
@@ -4807,9 +4812,9 @@ msgstr ""
 "виберіть \"Примусове оновлення\". Використовуйте тільки якщо ви впевнені, що "
 "мікропрограма є правильною і призначена для вашого пристрою!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Виберіть файл…"
 
@@ -4899,7 +4904,7 @@ msgstr "Коротка преамбула"
 msgid "Show current backup file list"
 msgstr "Показати поточний список файлів резервного копіювання"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Показати порожні ланцюжки"
 
@@ -4929,7 +4934,7 @@ msgstr "Затухання сигналу (SATN)"
 msgid "Signal:"
 msgstr "Сигнал:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Розмір"
@@ -4956,7 +4961,7 @@ msgid "Skip to navigation"
 msgstr "Перейти до навігації"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "Програмово реалізований VLAN"
 
@@ -4983,8 +4988,8 @@ msgstr ""
 "конкретного пристрою."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Джерело"
 
@@ -5056,7 +5061,7 @@ msgstr "Запустити"
 msgid "Start priority"
 msgstr "Стартовий пріоритет"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Розпочато застосування конфігурації…"
 
@@ -5087,7 +5092,7 @@ msgstr "Статичні маршрути"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Статична адреса"
 
@@ -5169,7 +5174,7 @@ msgid "Switch Speed Mask"
 msgstr "Маска швидкості комутатора"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "VLAN комутатора"
 
@@ -5183,7 +5188,7 @@ msgstr "Протокол комутатора"
 msgid "Switch to CIDR list notation"
 msgstr "Перейти до позначення списку CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Символічне посилання"
 
@@ -5202,8 +5207,8 @@ msgstr "Синхронізувати з браузером"
 msgid "System"
 msgstr "Система"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Системний журнал"
 
@@ -5236,16 +5241,16 @@ msgstr "Передано"
 msgid "TX Rate"
 msgstr "Швидкість передавання"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Таблиця"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Ціль"
 
@@ -5294,7 +5299,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "Файл конфігурації не вдалося завантажити через таку помилку:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5338,7 +5343,7 @@ msgstr ""
 "Порівняйте їх з вихідним файлом, щоб переконатися в цілісності даних. <br /> "
 "Натисніть \"Продовжити\", щоб розпочати процедуру прошивання."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Наразі в цій системі активні такі правила."
 
@@ -5490,7 +5495,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Немає жодних активних оренд"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Немає жодних змін до застосування"
 
@@ -5600,8 +5605,8 @@ msgid ""
 "their status."
 msgstr "У цьому списку наведено працюючі наразі системні процеси та їх стан."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5648,9 +5653,9 @@ msgstr "Усього доступно"
 msgid "Traceroute"
 msgstr "Трасування"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "Трафік"
 
@@ -5675,7 +5680,7 @@ msgid "Tunnel ID"
 msgstr "Ідентифікатор тунелю"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Інтерфейс тунелю"
 
@@ -5742,6 +5747,11 @@ msgstr "Не вдається визначити висхідний інтерф
 msgid "Unable to dispatch"
 msgstr "Не вдається опрацювати запит"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5753,6 +5763,14 @@ msgstr "Не вдається отримати ідентифікатор клі
 msgid "Unable to obtain mount information"
 msgstr "Не вдалося отримати інформацію про монтування"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5762,6 +5780,10 @@ msgstr "Не вдається розрізнити ім'я хоста AFTR"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Не вдається розрізнити ім'я хоста вузла"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5778,12 +5800,12 @@ msgid "Unexpected reply data format"
 msgstr "Несподіваний формат даних відповіді"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Невідомо"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Невідома помилка (%s)"
 
@@ -5793,7 +5815,7 @@ msgstr "Невідомий код помилки"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Некерований"
 
@@ -5807,7 +5829,7 @@ msgstr "Демонтувати"
 msgid "Unnamed key"
 msgstr "Безіменний ключ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Незбережені зміни"
 
@@ -5833,7 +5855,7 @@ msgstr "Непідтримуваний тип протоколу."
 msgid "Up"
 msgstr "Вгору"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Відвантажити"
 
@@ -5850,21 +5872,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Відвантажити архів…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Відвантажити файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Відвантажити файл…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Не вдалося виконати запит на відвантаження: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Відвантаження файлу…"
 
@@ -6173,19 +6195,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Бездротові мережі"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Бездротовий адаптер"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Бездротова мережа"
 
@@ -6229,7 +6251,7 @@ msgstr "Записувати отримані DNS-запити до систем
 msgid "Write system log to file"
 msgstr "Записувати cистемний журнал до файлу"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Так"
@@ -6455,7 +6477,7 @@ msgstr "нема з'єднання"
 msgid "non-empty value"
 msgstr "непусте значення"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "нема нічого"
 
@@ -6563,7 +6585,7 @@ msgstr "невідомий"
 msgid "unlimited"
 msgstr "необмежений"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -23,7 +23,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d trường không hợp lệ"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "---Mục bổ sung---"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "--Hãy chọn--"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "--tùy chỉnh--"
@@ -170,12 +170,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Mở rộng dịch vụ đặt Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"giao thức internet phiên bản 4\">IPv4</abbr>-Address"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"giao thức internet phiên bản 4\">IPv4</abbr>-Gateway"
 
@@ -211,7 +209,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr ""
 "<abbr title=\"Kiểm soát kết nối phương tiện truyền thông\">MAC</abbr>-Address"
@@ -248,7 +245,7 @@ msgstr ""
 "<br/>Note: bạn cần tự khởi động lại dich vụ cron nếu file crontab rỗng trước "
 "khi được chỉnh sửa."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "thư mục có tên này đã tồn tại"
 
@@ -277,6 +274,10 @@ msgstr ""
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:86
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
 msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
@@ -340,13 +341,13 @@ msgstr "Điểm truy cập"
 msgid "Actions"
 msgstr "Hành động"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr ""
 "Active <abbr title=\"giao thức kết nối internet phiên bản 4\">IPv4</abbr>-"
 "Routes"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Active <abbr title=\"giao thức kết nối internet phiên bản 6\">IPv6</abbr>-"
@@ -372,11 +373,11 @@ msgstr "Khởi động xin id từ DHCPv6"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -480,7 +481,7 @@ msgid "Alert"
 msgstr "Cảnh báo"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "Giao diện bí danh"
@@ -658,16 +659,16 @@ msgstr ""
 msgid "Apply backup?"
 msgstr "Chấp nhận sao lưu?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Áp dụng yêu cầu không thành công với trạng thái <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "Áp dụng không kiểm tra"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "Đợi cấu hình được áp dụng... %ds"
 
@@ -880,7 +881,7 @@ msgid "Bogus NX Domain Override"
 msgstr "Ghi đè tên miền Bogus NX"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "Cầu nối"
 
@@ -897,8 +898,8 @@ msgstr "Số cầu nối"
 msgid "Bring up on boot"
 msgstr "Áp dụng khi khởi động"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "Duyệt..."
 
@@ -929,8 +930,8 @@ msgstr ""
 msgid "Call failed"
 msgstr "Liên lạc thất bại"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -946,17 +947,17 @@ msgstr "Hủy bỏ"
 msgid "Category"
 msgstr "Đề mục"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "chuỗi"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "Thay đổi"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "Những thay đổi đã được phục hồi"
 
@@ -1070,7 +1071,8 @@ msgstr "Danh sách đã đóng ..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "Đang lấy dữ liệu..."
@@ -1087,7 +1089,7 @@ msgstr "Lệnh thành công"
 msgid "Command failed"
 msgstr "Lệnh thất bại"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "Bình luận"
 
@@ -1103,16 +1105,16 @@ msgstr ""
 "khóa. Cách khắc phục này có thể gây ra các vấn đề về khả năng tương tác và "
 "giảm độ mạnh của khóa, đặc biệt là trong các môi trường có lưu lượng tải lớn."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "Cấu hình"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "Cấu hình đã được áp dụng"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "Cấu hình đã được hoàn lại!"
 
@@ -1143,7 +1145,7 @@ msgstr "Kết nối thất bại"
 msgid "Connection lost"
 msgstr "Mất kết nối"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "Kết nối"
 
@@ -1159,7 +1161,7 @@ msgstr "Nội dung đã được lưu"
 msgid "Continue"
 msgstr "Tiếp tục"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1250,7 +1252,7 @@ msgstr "DHCP và DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "Máy khách DHCP"
 
@@ -1374,11 +1376,11 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1390,7 +1392,7 @@ msgstr "Xóa"
 msgid "Delete key"
 msgstr "Xóa chìa khóa"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "Yêu cầu xóa thất bại: %s"
 
@@ -1406,7 +1408,7 @@ msgstr "Chu kỳ thông báo chỉ thị lưu thông"
 msgid "Description"
 msgstr "Mô tả"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "Bỏ chọn"
 
@@ -1415,7 +1417,7 @@ msgid "Design"
 msgstr "Thiết kế"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "Điểm đến"
 
@@ -1451,7 +1453,7 @@ msgstr "thiết bị chưa được kích hoạt"
 msgid "Device is restarting…"
 msgstr "Khởi động lại thiết bị ..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "Thiết bị không thể truy cập! "
 
@@ -1468,7 +1470,7 @@ msgstr "Phân tích"
 msgid "Dial number"
 msgstr "Quay số"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "Danh mục"
 
@@ -1535,10 +1537,10 @@ msgstr "Ngắt kết nối"
 msgid "Disconnection attempt failed"
 msgstr "Kết nối thất bại"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1577,7 +1579,7 @@ msgstr "Không chuyển tiếp yêu cầu mà máy chủ tên công cộng khôn
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Không chuyển tiếp tra cứu ngược cho các mạng cục bộ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Bạn thật sự muốn xóa \"%s\" ?"
 
@@ -1589,7 +1591,7 @@ msgstr "Bạn thật sự muốn xóa khóa SSH này?"
 msgid "Do you really want to erase all settings?"
 msgstr "Bạn có thật sự muốn xóa tất cả cài đặt này?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Bạn thật sự muốn xóa toàn bộ thư mục \"%s\" ?"
 
@@ -1629,7 +1631,7 @@ msgstr "Tải xuống mtdblock"
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "Kéo để tổ chức lại"
 
@@ -1675,9 +1677,9 @@ msgstr "Độ dài EA-bits"
 msgid "EAP-Method"
 msgstr "EAP-Method"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1869,12 +1871,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "Bộ tương hợp ethernet"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "Bộ chuyển đảo ethernet"
 
@@ -1954,7 +1956,7 @@ msgstr "Giao thức FT"
 msgid "Failed to change the system password."
 msgstr "Đổi mật khẩu hệ thống thất bại"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "Thất bại khi xác thực áp dụng %ds, đợi làm lại..."
 
@@ -1962,15 +1964,15 @@ msgstr "Thất bại khi xác thực áp dụng %ds, đợi làm lại..."
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Thất bại khi thực thi \"/etc/init.d/%s %s\" hành động: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "Tệp tin"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "Tệp tin không thể truy cập"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "Tên tệp"
 
@@ -2024,7 +2026,7 @@ msgstr "Dấu tường lửa"
 msgid "Firewall Settings"
 msgstr "Cấu hình tường lửa"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "Trạng thái tường lửa"
 
@@ -2213,8 +2215,8 @@ msgstr "Tùy chọn mạng toàn cầu"
 msgid "Go to password configuration..."
 msgstr "Tới trang cài đặt mật khẩu..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2256,8 +2258,8 @@ msgstr ""
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Giấu <abbr title=\"Chế độ mở rộng đặt Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "Giấu chuỗi rỗng"
 
@@ -2347,7 +2349,7 @@ msgstr "Mất địa chỉ IP"
 msgid "IPv4"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "Tường lửa địa chỉ IPv4"
 
@@ -2398,8 +2400,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "Địa chỉ IPv4"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2426,11 +2433,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "Tường lửa IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2493,7 +2500,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr ""
 
@@ -2608,7 +2615,7 @@ msgstr "Lờ đi tập tin resolve"
 msgid "Image"
 msgstr "tập tin ảnh"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "Trong"
 
@@ -2663,8 +2670,8 @@ msgstr "Đang cài đặt bản mở rộng cho giao thức..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Giao diện "
@@ -2798,8 +2805,8 @@ msgstr "Hòa mạng: %q"
 msgid "Keep settings and retain the current configuration"
 msgstr "Giữ cài đặt và cấu hình hiện tại"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "Nhật ký lõi"
 
@@ -2881,18 +2888,15 @@ msgid "Lease time"
 msgstr "Thời gian được cấp một địa chỉ IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "Leasetime còn lại"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "Leasefile"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2907,7 +2911,7 @@ msgstr "Để trống để tự động phát hiện"
 msgid "Leave empty to use the current WAN address"
 msgstr "Để trống để sử dụng địa chỉ WAN hiện tại"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr ""
 
@@ -3008,7 +3012,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "Cổng để nghe cho các truy vấn DNS gửi đến"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "Tải "
 
@@ -3016,7 +3020,7 @@ msgstr "Tải "
 msgid "Load Average"
 msgstr "Tải trung bình"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "Đang tải nội dung thư mục..."
 
@@ -3130,7 +3134,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "Địa chỉ MAC"
 
@@ -3272,8 +3277,8 @@ msgid "Method not found"
 msgstr "Không thể tìm được phương pháp này"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metric"
@@ -3344,7 +3349,7 @@ msgstr "Monitor"
 msgid "More Characters"
 msgstr "Thêm đặc điểm"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "thêm ..."
 
@@ -3435,8 +3440,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3457,8 +3462,8 @@ msgstr "Điều hướng"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "Mạng "
@@ -3484,7 +3489,7 @@ msgstr "Tên giao diện mạng mới..."
 msgid "Next »"
 msgstr "Tiếp »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Không"
@@ -3505,7 +3510,7 @@ msgstr "Không NAT-T"
 msgid "No data received"
 msgstr "Không có data nhận được"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "Không có gì trong đường dẫn này"
 
@@ -3545,7 +3550,7 @@ msgstr "Không có máy ngang hàng được định nghĩa từ trước"
 msgid "No public keys present yet."
 msgstr "Không có khóa công khai"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "Không có quy luật trong chuỗi này"
 
@@ -3708,11 +3713,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr "Tần số hoạt động"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "Thay đổi tùy chỉnh"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "Xóa tùy chỉnh"
 
@@ -3786,7 +3791,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Không bắt buộc. Cổng UDP được sử dụng cho các gói đi và đến"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "Lựa chọn "
 
@@ -3794,7 +3799,7 @@ msgstr "Lựa chọn "
 msgid "Other:"
 msgstr "Khác:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "Ra khỏi"
 
@@ -3866,7 +3871,7 @@ msgstr "Ghi đè bảng được sử dụng cho định tuyến nội bộ"
 msgid "Overview"
 msgstr "Tổng quan"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Ghi đè tệp đã tồn tại \"%s\" ?"
 
@@ -3967,7 +3972,7 @@ msgstr "Độ dài(bit) PSID"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Chế độ chuyển gói)"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "Gói tin"
 
@@ -4101,7 +4106,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr ""
 
@@ -4109,11 +4114,11 @@ msgstr ""
 msgid "Please enter your username and password."
 msgstr "Nhập tên và mật mã"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "Chính sách"
 
@@ -4183,7 +4188,7 @@ msgid "Private Key"
 msgstr "Khóa riêng tư"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "Tiến trình"
 
@@ -4191,7 +4196,7 @@ msgstr "Tiến trình"
 msgid "Profile"
 msgstr "Hồ sơ"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "Giao thức"
 
@@ -4328,7 +4333,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "Bạn thật sự muốn đổi giao thức?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "Biểu đồ thời gian thực"
 
@@ -4368,7 +4373,7 @@ msgstr "Khuyến khích. Địa chỉ IP của giao diện mạng WireGuard"
 msgid "Reconnect this interface"
 msgstr "Tái kết nối giao diện mạng này"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "Tham khảo"
 
@@ -4516,7 +4521,7 @@ msgstr "Yêu cầu wpa-supplicant với SAE hỗ trợ"
 msgid "Reset"
 msgstr "Khởi động lại"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "Khởi động lại bộ đếm"
 
@@ -4543,7 +4548,7 @@ msgstr "Không tìm được nguồn"
 msgid "Restart"
 msgstr "Khởi động lại"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "Khởi động lại tường lửa"
 
@@ -4564,19 +4569,19 @@ msgstr "Phục hồi backup"
 msgid "Reveal/hide password"
 msgstr "Hiển thị/ẩn mật khẩu"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "Hoàn nguyên"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "Hoàn nguyên thay đổi"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Yêu cầu hoàn nguyên không thành công với trạng thái <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "Đang hoàn nguyên cấu hình .."
 
@@ -4610,8 +4615,8 @@ msgid "Router Password"
 msgstr "Mật khẩu bộ định tuyến"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "Định tuyến"
 
@@ -4623,7 +4628,7 @@ msgstr ""
 "Routes chỉ định trên giao diện và cổng một host nhất định hay network được "
 "tiếp cận."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "Luật"
 
@@ -4680,7 +4685,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4691,7 +4696,7 @@ msgid "Save"
 msgstr "Lưu"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Lưu & áp dụng "
@@ -4713,11 +4718,11 @@ msgstr "quét"
 msgid "Scheduled Tasks"
 msgstr "Nhiệm vụ theo lịch trình"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "Thêm mục"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "Xóa mục"
 
@@ -4735,9 +4740,9 @@ msgstr ""
 "phần mềm không thành công. Chỉ chọn nếu bạn có thể chắc chắc rằng phần mềm "
 "này tương thích với thiết bị của bạn"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "Chọn tệp"
 
@@ -4824,7 +4829,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr "Hiển thị danh sách tập tin lưu trữ"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "Hiển thị chuỗi trống"
 
@@ -4854,7 +4859,7 @@ msgstr "Độ suy hao tín hiệu (SATN)"
 msgid "Signal:"
 msgstr "Tín hiệu:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "Dung lượng "
@@ -4881,7 +4886,7 @@ msgid "Skip to navigation"
 msgstr "Chuyển đến mục định hướng"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "VLAN phần mềm"
 
@@ -4908,8 +4913,8 @@ msgstr ""
 "dẫn cài đặt cụ thể của thiết bị."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "Nguồn"
 
@@ -4977,7 +4982,7 @@ msgstr "Bắt đầu "
 msgid "Start priority"
 msgstr "Bắt đầu ưu tiên"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "Đang áp dụng cáu hình ..."
 
@@ -5008,7 +5013,7 @@ msgstr "Định tuyến tĩnh"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "Địa chỉ tĩnh"
 
@@ -5090,7 +5095,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "Đổi VLAN"
 
@@ -5104,7 +5109,7 @@ msgstr "Đổi giao thức"
 msgid "Switch to CIDR list notation"
 msgstr "Chuyển sang ký hiệu danh sách CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "Đường dẫn tham chiếu"
 
@@ -5123,8 +5128,8 @@ msgstr "Đồng bộ với trình duyệt web"
 msgid "System"
 msgstr "Hệ thống"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "Nhật ký hệ thống"
 
@@ -5157,16 +5162,16 @@ msgstr "TX"
 msgid "TX Rate"
 msgstr "Tốc độ truyền"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "Bảng"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "Mục tiêu"
 
@@ -5211,7 +5216,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5248,7 +5253,7 @@ msgstr ""
 "được liệt kê, so sánh chúng với tệp gốc để đảm bảo tính toàn vẹn dữ liệu. "
 "<br /> Nhấp vào \" Tiếp tục \"bên dưới để bắt đầu quy trình flash."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "Các quy tắc sau hiện đang hoạt động trên hệ thống"
 
@@ -5400,7 +5405,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr "Không có máy được cấp IP nào hoạt động"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "Không có thay đổi nào để áp dụng"
 
@@ -5506,8 +5511,8 @@ msgstr ""
 "Danh sách này đưa ra một tầm nhìn tổng quát về tiến trình hệ thống đang chạy "
 "và tình trạng của chúng."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5554,9 +5559,9 @@ msgstr "Tất cả có sẵn"
 msgid "Traceroute"
 msgstr "Theo dấu định tuyến"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr ""
 
@@ -5581,7 +5586,7 @@ msgid "Tunnel ID"
 msgstr "ID đường hầm dữ liệu"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "Giao diện đường hầm dữ liệu"
 
@@ -5648,6 +5653,11 @@ msgstr "Không thể xác định dòng dữ liệu giao diện mạng"
 msgid "Unable to dispatch"
 msgstr "Không thể gửi"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5659,6 +5669,14 @@ msgstr "Không thể có được ID máy khách"
 msgid "Unable to obtain mount information"
 msgstr "Không thể có được thông tin gắn kết"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5668,6 +5686,10 @@ msgstr "Không thể giải quyết tên máy chủ AFTR"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "Không thể giải quyết tên máy chủ ngang hàng"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5684,12 +5706,12 @@ msgid "Unexpected reply data format"
 msgstr "Định dạng dữ liệu trả lời bất ngờ"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "Không xác định"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "Lỗi không xác định (%s"
 
@@ -5699,7 +5721,7 @@ msgstr "Mã lỗi không xác định"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "Hủy quản lý"
 
@@ -5713,7 +5735,7 @@ msgstr "Hủy gắn kết"
 msgid "Unnamed key"
 msgstr "Khóa không tên"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "Thay đổi không lưu"
 
@@ -5739,7 +5761,7 @@ msgstr "Giao thức này không được hỗ trợ"
 msgid "Up"
 msgstr "Lên"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "Tải lên"
 
@@ -5756,21 +5778,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Tải dữ liệu lên ..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "Tải tập tin lên"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "Đang tải tin lên ..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "Yêu cầu tải thất bại: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "Đang tải tin lên ..."
 
@@ -6074,19 +6096,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "Không dây"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "Bộ tương hợp không dây"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "Mạng không dây"
 
@@ -6130,7 +6152,7 @@ msgstr "Viết yêu cầu DNS nhận được vào nhật ký hệ thống"
 msgid "Write system log to file"
 msgstr "Viết nhật ký hệ thống vào một tệp"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Có"
@@ -6355,7 +6377,7 @@ msgstr "Không có liên kết"
 msgid "non-empty value"
 msgstr "Giá trị không rỗng"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "không"
 
@@ -6463,7 +6485,7 @@ msgstr "Không xác định"
 msgid "unlimited"
 msgstr "Không giới hạn"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -23,7 +23,7 @@ msgstr "%.1f dB"
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr "%d 个无效字段"
 
@@ -59,11 +59,11 @@ msgid "-- Additional Field --"
 msgstr "-- 更多选项 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -71,7 +71,7 @@ msgstr "-- 请选择 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- 自定义 --"
@@ -170,12 +170,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr> 地址"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr> 网关"
 
@@ -210,7 +208,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 名称"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr> 地址"
 
@@ -245,7 +242,7 @@ msgid ""
 msgstr ""
 "<br/>注意：如果 crontab 文件在编辑前为空，则需要手动重新启动 cron 服务。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr "已存在同名的目录。"
 
@@ -275,6 +272,10 @@ msgstr "ANSI T1.413"
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -336,11 +337,11 @@ msgstr "接入点 AP"
 msgid "Actions"
 msgstr "动作"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "活动的 <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> 路由"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "活动的 <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> 路由"
 
@@ -364,11 +365,11 @@ msgstr "已分配的 DHCPv6 租约"
 msgid "Ad-Hoc"
 msgstr "点对点 Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -472,7 +473,7 @@ msgid "Alert"
 msgstr "警戒"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr "接口别名"
@@ -647,16 +648,16 @@ msgstr "任意区域"
 msgid "Apply backup?"
 msgstr "应用备份？"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "应用请求失败，状态 <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr "强制应用"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr "正在等待配置被应用… %ds"
 
@@ -861,7 +862,7 @@ msgid "Bogus NX Domain Override"
 msgstr "忽略虚假空域名解析"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "桥接"
 
@@ -878,8 +879,8 @@ msgstr "桥接号"
 msgid "Bring up on boot"
 msgstr "开机自动运行"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr "浏览…"
 
@@ -910,8 +911,8 @@ msgstr "已缓存"
 msgid "Call failed"
 msgstr "调用失败"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -927,17 +928,17 @@ msgstr "取消"
 msgid "Category"
 msgstr "分类"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "链"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "更改数"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "更改已恢复。"
 
@@ -1049,7 +1050,8 @@ msgstr "关闭列表…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "正在收集数据…"
@@ -1066,7 +1068,7 @@ msgstr "命令成功"
 msgid "Command failed"
 msgstr "执行命令失败"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr "备注"
 
@@ -1081,16 +1083,16 @@ msgstr ""
 "杂度。此解决方法可能会导致互操作性问题，并降低密钥协商的可靠性，特别是在流量"
 "负载较重的环境中。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "配置"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "配置已应用。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "配置已回滚！"
 
@@ -1121,7 +1123,7 @@ msgstr "尝试连接失败"
 msgid "Connection lost"
 msgstr "失去连接"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "连接"
 
@@ -1137,7 +1139,7 @@ msgstr "内容已保存。"
 msgid "Continue"
 msgstr "继续"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1224,7 +1226,7 @@ msgstr "DHCP/DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP 客户端"
 
@@ -1350,11 +1352,11 @@ msgstr ""
 "设置 DHCP 的附加选项，例如设定 \"<code>6,192.168.2.1,192.168.2.2</code>\" 表"
 "示通告不同的 DNS 服务器给客户端。"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1366,7 +1368,7 @@ msgstr "删除"
 msgid "Delete key"
 msgstr "删除密钥"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr "删除请求失败：%s"
 
@@ -1382,7 +1384,7 @@ msgstr "发送流量指示消息间隔"
 msgid "Description"
 msgstr "描述"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr "取消"
 
@@ -1391,7 +1393,7 @@ msgid "Design"
 msgstr "主题"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "目标地址"
 
@@ -1427,7 +1429,7 @@ msgstr "设备未激活"
 msgid "Device is restarting…"
 msgstr "设备正在重启…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "无法连接到设备！"
 
@@ -1444,7 +1446,7 @@ msgstr "网络诊断"
 msgid "Dial number"
 msgstr "拨号号码"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "目录"
 
@@ -1511,10 +1513,10 @@ msgstr "断开连接"
 msgid "Disconnection attempt failed"
 msgstr "尝试断开连接失败"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1551,7 +1553,7 @@ msgstr "不转发公共域名服务器无法回应的请求"
 msgid "Do not forward reverse lookups for local networks"
 msgstr "不转发本地网络的反向查询"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "您真的要删除“%s”吗？"
 
@@ -1563,7 +1565,7 @@ msgstr "您真的要删除以下 SSH 密钥吗？"
 msgid "Do you really want to erase all settings?"
 msgstr "您真的要清除所有设置吗？"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "您真的要删除目录“%s”吗？"
 
@@ -1602,7 +1604,7 @@ msgstr "下载 mtdblock"
 msgid "Downstream SNR offset"
 msgstr "下游 SNR 偏移"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr "拖动以重排"
 
@@ -1646,9 +1648,9 @@ msgstr "EA-位长"
 msgid "EAP-Method"
 msgstr "EAP 类型"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1836,12 +1838,12 @@ msgid "Errored seconds (ES)"
 msgstr "错误秒数（ES）"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "以太网适配器"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "以太网交换机"
 
@@ -1921,7 +1923,7 @@ msgstr "FT 协议"
 msgid "Failed to change the system password."
 msgstr "更改系统密码失败。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "在 %d 秒内确认应用失败，等待回滚…"
 
@@ -1929,15 +1931,15 @@ msgstr "在 %d 秒内确认应用失败，等待回滚…"
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "执行“/etc/init.d/%s %s”失败：%s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "文件"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr "文件无法访问"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr "文件名"
 
@@ -1989,7 +1991,7 @@ msgstr "防火墙标识"
 msgid "Firewall Settings"
 msgstr "防火墙设置"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "防火墙状态"
 
@@ -2177,8 +2179,8 @@ msgstr "全局网络选项"
 msgid "Go to password configuration..."
 msgstr "跳转到密码配置页…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2218,8 +2220,8 @@ msgstr "此处配置设备的基础信息，如主机名称或时区。"
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "隐藏 <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr "隐藏空链"
 
@@ -2309,7 +2311,7 @@ msgstr "IP 地址缺失"
 msgid "IPv4"
 msgstr "IPv4"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4 防火墙"
 
@@ -2360,8 +2362,13 @@ msgstr "IPv4+IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4 地址"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2388,11 +2395,11 @@ msgstr "IPv4/IPv6 (双栈 - 默认 IPv4)"
 msgid "IPv6"
 msgstr "IPv6"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6 防火墙"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr "IPv6 网上邻居"
 
@@ -2455,7 +2462,7 @@ msgstr "IPv6 后缀"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6 地址"
 
@@ -2565,7 +2572,7 @@ msgstr "忽略解析文件"
 msgid "Image"
 msgstr "固件文件"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "入口"
 
@@ -2620,8 +2627,8 @@ msgstr "安装扩展协议…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "接口"
@@ -2750,8 +2757,8 @@ msgstr "加入网络：%q"
 msgid "Keep settings and retain the current configuration"
 msgstr "保留当前配置"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "内核日志"
 
@@ -2833,18 +2840,15 @@ msgid "Lease time"
 msgstr "租期"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "剩余租期"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "租约文件"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr "剩余租赁时间"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2859,7 +2863,7 @@ msgstr "留空则自动探测"
 msgid "Leave empty to use the current WAN address"
 msgstr "留空则使用当前 WAN 地址"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "图例："
 
@@ -2956,7 +2960,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "入站 DNS 查询端口"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "负载"
 
@@ -2964,7 +2968,7 @@ msgstr "负载"
 msgid "Load Average"
 msgstr "平均负载"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr "正在载入目录内容…"
 
@@ -3075,7 +3079,8 @@ msgstr "MAC"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC 地址"
 
@@ -3215,8 +3220,8 @@ msgid "Method not found"
 msgstr "方法未找到"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "跃点数"
@@ -3287,7 +3292,7 @@ msgstr "监听"
 msgid "More Characters"
 msgstr "需要更多字符"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr "更多…"
 
@@ -3376,8 +3381,8 @@ msgstr "NT 域"
 msgid "NTP server candidates"
 msgstr "候选 NTP 服务器"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3398,8 +3403,8 @@ msgstr "导航"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "网络"
@@ -3425,7 +3430,7 @@ msgstr "新接口名称…"
 msgid "Next »"
 msgstr "前进 »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "否"
@@ -3446,7 +3451,7 @@ msgstr "无 NAT-T"
 msgid "No data received"
 msgstr "没有接收到数据"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr "此目录中没有内容"
 
@@ -3486,7 +3491,7 @@ msgstr "尚未定义对等点"
 msgid "No public keys present yet."
 msgstr "当前还没有公钥。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "本链没有规则。"
 
@@ -3647,11 +3652,11 @@ msgstr "OpenConnect (CISCO AnyConnect)"
 msgid "Operating frequency"
 msgstr "工作频率"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "选项已更改"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "选项已移除"
 
@@ -3718,7 +3723,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "可选，用于传出和传入数据包的 UDP 端口。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "选项"
 
@@ -3726,7 +3731,7 @@ msgstr "选项"
 msgid "Other:"
 msgstr "其余："
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "出口"
 
@@ -3796,7 +3801,7 @@ msgstr "重设内部路由表"
 msgid "Overview"
 msgstr "概览"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "覆盖已存在的文件“%s”吗？"
 
@@ -3897,7 +3902,7 @@ msgstr "PSID-位长"
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM（分组传输模式）"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "数据包"
 
@@ -4031,7 +4036,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "数据包"
 
@@ -4039,11 +4044,11 @@ msgstr "数据包"
 msgid "Please enter your username and password."
 msgstr "请输入用户名和密码。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr "请选择要上传的文件。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "策略"
 
@@ -4111,7 +4116,7 @@ msgid "Private Key"
 msgstr "私钥"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "系统进程"
 
@@ -4119,7 +4124,7 @@ msgstr "系统进程"
 msgid "Profile"
 msgstr "配置文件"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "协议"
 
@@ -4250,7 +4255,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "确定要切换协议？"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "实时信息"
 
@@ -4290,7 +4295,7 @@ msgstr "推荐，WireGuard 接口的 IP 地址。"
 msgid "Reconnect this interface"
 msgstr "重连此接口"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "引用"
 
@@ -4433,7 +4438,7 @@ msgstr "需要带 SAE 支持的 wpa-supplicant"
 msgid "Reset"
 msgstr "复位"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "复位计数器"
 
@@ -4460,7 +4465,7 @@ msgstr "未找到资源"
 msgid "Restart"
 msgstr "重启"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "重启防火墙"
 
@@ -4481,19 +4486,19 @@ msgstr "恢复配置"
 msgid "Reveal/hide password"
 msgstr "显示/隐藏 密码"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "恢复"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr "恢复更改"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "恢复请求失败，状态 <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "正在恢复配置…"
 
@@ -4527,8 +4532,8 @@ msgid "Router Password"
 msgstr "主机密码"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "路由表"
 
@@ -4538,7 +4543,7 @@ msgid ""
 "can be reached."
 msgstr "路由表描述了数据包的可达路径。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr "规则"
 
@@ -4595,7 +4600,7 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "交换分区"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4606,7 +4611,7 @@ msgid "Save"
 msgstr "保存"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存并应用"
@@ -4628,11 +4633,11 @@ msgstr "扫描"
 msgid "Scheduled Tasks"
 msgstr "计划任务"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "添加的节点"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "移除的节点"
 
@@ -4649,9 +4654,9 @@ msgstr ""
 "即使映像文件检查失败，也“强制升级”以烧录映像。仅在您确定固件正确且适用于您的"
 "设备时使用！"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr "选择文件…"
 
@@ -4737,7 +4742,7 @@ msgstr "Short Preamble"
 msgid "Show current backup file list"
 msgstr "显示当前备份文件列表"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr "显示空链"
 
@@ -4767,7 +4772,7 @@ msgstr "信号衰减（SATN）"
 msgid "Signal:"
 msgstr "信号："
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "大小"
@@ -4794,7 +4799,7 @@ msgid "Skip to navigation"
 msgstr "跳转到导航"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr "软件 VLAN"
 
@@ -4820,8 +4825,8 @@ msgstr ""
 "设备的固件更新说明。"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "源地址"
 
@@ -4884,7 +4889,7 @@ msgstr "启动"
 msgid "Start priority"
 msgstr "启动优先级"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "开始应用配置…"
 
@@ -4915,7 +4920,7 @@ msgstr "静态路由"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "静态地址"
 
@@ -4993,7 +4998,7 @@ msgid "Switch Speed Mask"
 msgstr "交换机速率掩码"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr "交换机 VLAN"
 
@@ -5007,7 +5012,7 @@ msgstr "切换协议"
 msgid "Switch to CIDR list notation"
 msgstr "切换到 CIDR 列表记法"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr "符号链接"
 
@@ -5026,8 +5031,8 @@ msgstr "同步浏览器时间"
 msgid "System"
 msgstr "系统"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "系统日志"
 
@@ -5060,16 +5065,16 @@ msgstr "发送"
 msgid "TX Rate"
 msgstr "发送速率"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "表"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "目标"
 
@@ -5114,7 +5119,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "由于以下错误，配置文件无法被加载："
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5152,7 +5157,7 @@ msgstr ""
 "刷写镜像已上传。下面是列出的校验和及文件大小，将它们与原始文件进行比较以确保"
 "数据完整性。<br />单击下面的“继续”开始刷写。"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "以下规则当前在系统中处于活动状态。"
 
@@ -5291,7 +5296,7 @@ msgstr "不支持所上传的映像文件格式，请选择适合当前平台的
 msgid "There are no active leases"
 msgstr "没有已分配的租约"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr "没有待应用的更改"
 
@@ -5387,8 +5392,8 @@ msgid ""
 "their status."
 msgstr "系统中正在运行的进程概况和它们的状态信息。"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5433,9 +5438,9 @@ msgstr "可用数"
 msgid "Traceroute"
 msgstr "Traceroute"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "流量"
 
@@ -5460,7 +5465,7 @@ msgid "Tunnel ID"
 msgstr "隧道 ID"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "隧道接口"
 
@@ -5527,6 +5532,11 @@ msgstr "无法确认上游接口"
 msgid "Unable to dispatch"
 msgstr "无法调度"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5538,6 +5548,14 @@ msgstr "无法获取客户端 ID"
 msgid "Unable to obtain mount information"
 msgstr "无法取得挂载信息"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5547,6 +5565,10 @@ msgstr "无法解析 AFTR 主机名"
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
 msgstr "无法解析 Pear 主机名"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
+msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:338
@@ -5563,12 +5585,12 @@ msgid "Unexpected reply data format"
 msgstr "错误的数据回复格式"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "未知"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr "未知错误（%s）"
 
@@ -5578,7 +5600,7 @@ msgstr "未知错误代码"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "不配置协议"
 
@@ -5592,7 +5614,7 @@ msgstr "卸载分区"
 msgid "Unnamed key"
 msgstr "未命名的密钥"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "未保存的配置"
 
@@ -5618,7 +5640,7 @@ msgstr "不支持的协议类型。"
 msgid "Up"
 msgstr "上移"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr "上传"
 
@@ -5633,21 +5655,21 @@ msgstr "从这里上传一个 sysupgrade 兼容镜像以更新正在运行的固
 msgid "Upload archive..."
 msgstr "上传备份…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr "上传文件"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr "上传文件…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr "上传请求失败：%s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr "正在上传文件…"
 
@@ -5949,19 +5971,19 @@ msgstr "WireGuard VPN"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "无线"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "无线适配器"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "无线网络"
 
@@ -6005,7 +6027,7 @@ msgstr "将收到的 DNS 请求写入系统日志"
 msgid "Write system log to file"
 msgstr "将系统日志写入文件"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "是"
@@ -6223,7 +6245,7 @@ msgstr "未连接"
 msgid "non-empty value"
 msgstr "非空值"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "无"
 
@@ -6331,7 +6353,7 @@ msgstr "未知"
 msgid "unlimited"
 msgstr "无限制"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368
@@ -6530,6 +6552,9 @@ msgstr "是"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 后退"
+
+#~ msgid "Leasetime remaining"
+#~ msgstr "剩余租赁时间"
 
 #~ msgid "Bad address specified!"
 #~ msgstr "指定了错误的地址！"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2223
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2287
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -57,11 +57,11 @@ msgid "-- Additional Field --"
 msgstr "-- 更多選項 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1788
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:315
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:415
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1243
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
@@ -69,7 +69,7 @@ msgstr "-- 請選擇 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:416
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1180
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1244
 #: modules/luci-compat/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- 自訂 --"
@@ -166,12 +166,10 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:452
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:45
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-位置"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:75
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
 msgstr "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-閘道"
 
@@ -205,7 +203,6 @@ msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 名稱"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:408
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:46
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
 msgstr "<abbr title=\"Media Access Control\">MAC</abbr>-位置"
 
@@ -239,7 +236,7 @@ msgid ""
 "was empty before editing."
 msgstr "注意: 如果這個檔案在編輯之前是空的,您將需要重新啟動cron服務"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1631
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1695
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -269,6 +266,10 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:67
 msgid "APN"
 msgstr "APN"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
+msgid "ARP"
+msgstr ""
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid "ARP retry threshold"
@@ -330,11 +331,11 @@ msgstr "存取點 (AP)"
 msgid "Actions"
 msgstr "動作"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:69
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:201
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgstr "啟用 <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-路由"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:97
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:207
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "啟用 <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-路由"
 
@@ -358,11 +359,11 @@ msgstr "已分配的DHCPv6租用"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:902
-#: modules/luci-base/htdocs/luci-static/resources/form.js:904
-#: modules/luci-base/htdocs/luci-static/resources/form.js:917
-#: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1541
+#: modules/luci-base/htdocs/luci-static/resources/form.js:908
+#: modules/luci-base/htdocs/luci-static/resources/form.js:910
+#: modules/luci-base/htdocs/luci-static/resources/form.js:923
+#: modules/luci-base/htdocs/luci-static/resources/form.js:924
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1547
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:197
@@ -466,7 +467,7 @@ msgid "Alert"
 msgstr "警示"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2808
-#: modules/luci-compat/luasrc/model/network.lua:1416
+#: modules/luci-compat/luasrc/model/network.lua:1417
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:56
 msgid "Alias Interface"
 msgstr ""
@@ -640,16 +641,16 @@ msgstr "任意區域"
 msgid "Apply backup?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2925
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2579
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2643
 msgid "Apply unchecked"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
 msgid "Applying configuration changes… %ds"
 msgstr ""
 
@@ -854,7 +855,7 @@ msgid "Bogus NX Domain Override"
 msgstr "忽略NX網域解析"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2814
-#: modules/luci-compat/luasrc/model/network.lua:1420
+#: modules/luci-compat/luasrc/model/network.lua:1421
 msgid "Bridge"
 msgstr "橋接"
 
@@ -871,8 +872,8 @@ msgstr "橋接單位號碼"
 msgid "Bring up on boot"
 msgstr "開機自動執行"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1719
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1783
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2368
 msgid "Browse…"
 msgstr ""
 
@@ -903,8 +904,8 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1811
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2313
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1875
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2377
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:182
@@ -920,17 +921,17 @@ msgstr "取消"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:234
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:198
 msgid "Chain"
 msgstr "鏈"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 msgid "Changes"
 msgstr "待修改"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2715
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2779
 msgid "Changes have been reverted."
 msgstr "設定值已還原."
 
@@ -1042,7 +1043,8 @@ msgstr "關閉清單"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2013
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:386
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:315
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:318
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:204
 msgid "Collecting data..."
 msgstr "收集資料中..."
@@ -1059,7 +1061,7 @@ msgstr ""
 msgid "Command failed"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:70
 msgid "Comment"
 msgstr ""
 
@@ -1071,16 +1073,16 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2467
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2531
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
 msgid "Configuration"
 msgstr "設定"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2626
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2690
 msgid "Configuration changes applied."
 msgstr "設定值已套用"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2565
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2629
 msgid "Configuration changes have been rolled back!"
 msgstr "設定值已復原"
 
@@ -1111,7 +1113,7 @@ msgstr ""
 msgid "Connection lost"
 msgstr ""
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:114
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:96
 msgid "Connections"
 msgstr "連線數"
 
@@ -1127,7 +1129,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2665
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1215,7 +1217,7 @@ msgstr "DHCP 和 DNS"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1956
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
-#: modules/luci-compat/luasrc/model/network.lua:968
+#: modules/luci-compat/luasrc/model/network.lua:969
 msgid "DHCP client"
 msgstr "DHCP用戶端"
 
@@ -1341,11 +1343,11 @@ msgstr ""
 "定義額外的DHCP選項,例如\"<code>6,192.168.2.1,192.168.2.2</code>\"將會通告不同"
 "的DNS伺服器到客戶端."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1218
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1526
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/form.js:972
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1221
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1224
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1532
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1844
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
@@ -1357,7 +1359,7 @@ msgstr "刪除"
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1679
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1743
 msgid "Delete request failed: %s"
 msgstr ""
 
@@ -1373,7 +1375,7 @@ msgstr ""
 msgid "Description"
 msgstr "說明"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1776
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1840
 msgid "Deselect"
 msgstr ""
 
@@ -1382,7 +1384,7 @@ msgid "Design"
 msgstr "設計規劃"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:381
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "Destination"
 msgstr "目的地"
 
@@ -1418,7 +1420,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2664
 msgid "Device unreachable!"
 msgstr "無法連線到設備!"
 
@@ -1435,7 +1437,7 @@ msgstr "診斷"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1580
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1644
 msgid "Directory"
 msgstr "目錄"
 
@@ -1501,10 +1503,10 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1377
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2017
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2484
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2571
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2081
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2548
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2635
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:326
 msgid "Dismiss"
@@ -1541,7 +1543,7 @@ msgstr "對不被公用名稱伺服器回應的請求不轉發"
 msgid "Do not forward reverse lookups for local networks"
 msgstr "對本地網域不轉發反解析鎖定"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1665
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1729
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
@@ -1553,7 +1555,7 @@ msgstr ""
 msgid "Do you really want to erase all settings?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1663
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1727
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1593,7 +1595,7 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1180
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1636,9 +1638,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP協定驗證方式"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1196
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1452
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1199
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1202
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1458
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:334
@@ -1825,12 +1827,12 @@ msgid "Errored seconds (ES)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2826
-#: modules/luci-compat/luasrc/model/network.lua:1432
+#: modules/luci-compat/luasrc/model/network.lua:1433
 msgid "Ethernet Adapter"
 msgstr "乙太網路卡"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2817
-#: modules/luci-compat/luasrc/model/network.lua:1422
+#: modules/luci-compat/luasrc/model/network.lua:1423
 msgid "Ethernet Switch"
 msgstr "乙太交換器"
 
@@ -1911,7 +1913,7 @@ msgstr ""
 msgid "Failed to change the system password."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2559
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2623
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1919,15 +1921,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1587
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
 msgid "File"
 msgstr "檔案"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1540
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1604
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1720
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
 msgid "Filename"
 msgstr ""
 
@@ -1979,7 +1981,7 @@ msgstr ""
 msgid "Firewall Settings"
 msgstr "防火牆設定"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:295
 msgid "Firewall Status"
 msgstr "防火牆狀況"
 
@@ -2165,8 +2167,8 @@ msgstr "全域網路設定"
 msgid "Go to password configuration..."
 msgstr "前往密碼設定頁"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1117
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1619
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1123
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1625
 #: modules/luci-compat/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2206,8 +2208,8 @@ msgstr "在這裡設置基本設定值,如主機名稱或者時區...等"
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "隱藏 <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:61
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:301
 msgid "Hide empty chains"
 msgstr ""
 
@@ -2297,7 +2299,7 @@ msgstr "缺少IP位址"
 msgid "IPv4"
 msgstr "IPv4版"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:49
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:314
 msgid "IPv4 Firewall"
 msgstr "IPv4防火牆"
 
@@ -2348,8 +2350,13 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:34
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:29
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:155
 msgid "IPv4-Address"
 msgstr "IPv4-位址"
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:165
+msgid "IPv4-Gateway"
+msgstr ""
 
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
@@ -2376,11 +2383,11 @@ msgstr ""
 msgid "IPv6"
 msgstr "IPv6版"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:52
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:317
 msgid "IPv6 Firewall"
 msgstr "IPv6防火牆"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:128
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -2443,7 +2450,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:56
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:132
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:173
 msgid "IPv6-Address"
 msgstr "IPv6-位址"
 
@@ -2553,7 +2560,7 @@ msgstr "不使用解析檔"
 msgid "Image"
 msgstr "映像檔"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:59
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
 msgid "In"
 msgstr "輸入"
 
@@ -2606,8 +2613,8 @@ msgstr "安裝延伸協定中..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:730
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:734
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:157
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:175
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "介面"
@@ -2737,8 +2744,8 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/dmesg.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:56
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:19
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:39
 msgid "Kernel Log"
 msgstr "核心日誌"
 
@@ -2820,18 +2827,15 @@ msgid "Lease time"
 msgstr "租賃時間長度"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:36
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
 msgid "Lease time remaining"
 msgstr "租賃保留時間"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:166
 msgid "Leasefile"
 msgstr "租賃檔案"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:55
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:31
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:58
-msgid "Leasetime remaining"
-msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
@@ -2846,7 +2850,7 @@ msgstr "保持空白以便自動偵測"
 msgid "Leave empty to use the current WAN address"
 msgstr "保持空白以便採用現今的寬頻位址"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2469
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2533
 msgid "Legend:"
 msgstr "圖例:"
 
@@ -2935,7 +2939,7 @@ msgid "Listening port for inbound DNS queries"
 msgstr "進入的DNS請求聆聽埠"
 
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:203
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
 msgid "Load"
 msgstr "掛載"
 
@@ -2943,7 +2947,7 @@ msgstr "掛載"
 msgid "Load Average"
 msgstr "平均掛載"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1905
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3055,7 +3059,8 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:55
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:30
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:125
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:156
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:174
 msgid "MAC-Address"
 msgstr "MAC-位址"
 
@@ -3195,8 +3200,8 @@ msgid "Method not found"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:166
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:184
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "公測單位"
@@ -3267,7 +3272,7 @@ msgstr "監視"
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1060
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1066
 msgid "More…"
 msgstr ""
 
@@ -3356,8 +3361,8 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "NTP伺服器備選"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1097
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2290
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1103
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2354
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
@@ -3378,8 +3383,8 @@ msgstr "導覽"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:378
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:62
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:124
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:163
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:181
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:54
 msgid "Network"
 msgstr "網路"
@@ -3405,7 +3410,7 @@ msgstr ""
 msgid "Next »"
 msgstr "下一個 »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3426,7 +3431,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1786
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1850
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3466,7 +3471,7 @@ msgstr ""
 msgid "No public keys present yet."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:83
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:88
 msgid "No rules in this chain."
 msgstr "尚無規則在這個鏈接上"
 
@@ -3627,11 +3632,11 @@ msgstr ""
 msgid "Operating frequency"
 msgstr "操作頻率"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2476
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2540
 msgid "Option changed"
 msgstr "選項已變更"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2478
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2542
 msgid "Option removed"
 msgstr "選項已移除"
 
@@ -3692,7 +3697,7 @@ msgstr ""
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:69
 msgid "Options"
 msgstr "選項"
 
@@ -3700,7 +3705,7 @@ msgstr "選項"
 msgid "Other:"
 msgstr "其它:"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:60
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:66
 msgid "Out"
 msgstr "出"
 
@@ -3770,7 +3775,7 @@ msgstr "覆蓋之前內部使用的路由表"
 msgid "Overview"
 msgstr "預覽"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1696
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3871,7 +3876,7 @@ msgstr ""
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Packets"
 msgstr "封包"
 
@@ -4005,7 +4010,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:78
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:135
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
 msgid "Pkts."
 msgstr "封包數."
 
@@ -4013,11 +4018,11 @@ msgstr "封包數."
 msgid "Please enter your username and password."
 msgstr "請輸入您的用戶名稱和密碼"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2273
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2337
 msgid "Please select the file to upload."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
 msgid "Policy"
 msgstr "策略"
 
@@ -4085,7 +4090,7 @@ msgid "Private Key"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:63
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:66
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:48
 msgid "Processes"
 msgstr "執行緒"
 
@@ -4093,7 +4098,7 @@ msgstr "執行緒"
 msgid "Profile"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:58
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Prot."
 msgstr "協定."
 
@@ -4221,7 +4226,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "確定要更換協定?"
 
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:57
 msgid "Realtime Graphs"
 msgstr "即時圖表"
 
@@ -4261,7 +4266,7 @@ msgstr ""
 msgid "Reconnect this interface"
 msgstr "重新連接這個介面"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "References"
 msgstr "引用"
 
@@ -4400,7 +4405,7 @@ msgstr ""
 msgid "Reset"
 msgstr "重置"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:62
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:306
 msgid "Reset Counters"
 msgstr "重置計數器"
 
@@ -4427,7 +4432,7 @@ msgstr ""
 msgid "Restart"
 msgstr "重啟"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:311
 msgid "Restart Firewall"
 msgstr "重啟防火牆"
 
@@ -4448,19 +4453,19 @@ msgstr "還原之前備份設定"
 msgid "Reveal/hide password"
 msgstr "明示/隱藏 密碼"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2492
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2556
 msgid "Revert"
 msgstr "回溯"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2575
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2639
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2724
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2788
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2704
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2768
 msgid "Reverting configuration…"
 msgstr "正在還原設定值..."
 
@@ -4494,8 +4499,8 @@ msgid "Router Password"
 msgstr "路由器密碼"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:14
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:37
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:37
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:195
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:21
 msgid "Routes"
 msgstr "路由"
 
@@ -4505,7 +4510,7 @@ msgid ""
 "can be reached."
 msgstr "路由器指定介面導出到特定主機或者能夠到達的網路."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:240
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:204
 msgid "Rule"
 msgstr ""
 
@@ -4562,7 +4567,7 @@ msgstr "基地台服務設定識別碼SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2940
 #: modules/luci-compat/luasrc/view/cbi/error.htm:17
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:26
@@ -4573,7 +4578,7 @@ msgid "Save"
 msgstr "保存"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2924
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存並啟用"
@@ -4595,11 +4600,11 @@ msgstr "掃描"
 msgid "Scheduled Tasks"
 msgstr "排程任務"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2472
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2536
 msgid "Section added"
 msgstr "新增的區段"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2474
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2538
 msgid "Section removed"
 msgstr "區段移除"
 
@@ -4614,9 +4619,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1672
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1831
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1736
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1895
 msgid "Select file…"
 msgstr ""
 
@@ -4700,7 +4705,7 @@ msgstr ""
 msgid "Show current backup file list"
 msgstr "顯示現今的備份檔清單"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:99
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:262
 msgid "Show empty chains"
 msgstr ""
 
@@ -4730,7 +4735,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "信號:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2291
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2355
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:213
 msgid "Size"
 msgstr "大小"
@@ -4757,7 +4762,7 @@ msgid "Skip to navigation"
 msgstr "跳到導覽"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1427
+#: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
 msgstr ""
 
@@ -4783,8 +4788,8 @@ msgstr ""
 "設備安裝指引."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:380
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:183
 msgid "Source"
 msgstr "來源"
 
@@ -4845,7 +4850,7 @@ msgstr "啟用"
 msgid "Start priority"
 msgstr "啟用優先權順序"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2669
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2733
 msgid "Starting configuration apply…"
 msgstr "開始套用設定值..."
 
@@ -4876,7 +4881,7 @@ msgstr "靜態路由"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1955
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
-#: modules/luci-compat/luasrc/model/network.lua:966
+#: modules/luci-compat/luasrc/model/network.lua:967
 msgid "Static address"
 msgstr "靜態位址"
 
@@ -4954,7 +4959,7 @@ msgid "Switch Speed Mask"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2820
-#: modules/luci-compat/luasrc/model/network.lua:1425
+#: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
 msgstr ""
 
@@ -4968,7 +4973,7 @@ msgstr "切換協定"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1573
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Symbolic link"
 msgstr ""
 
@@ -4987,8 +4992,8 @@ msgstr "與瀏覽器同步時間"
 msgid "System"
 msgstr "系統"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/syslog.htm:8
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:46
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:17
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:30
 msgid "System Log"
 msgstr "系統日誌"
 
@@ -5021,16 +5026,16 @@ msgstr "傳送"
 msgid "TX Rate"
 msgstr "傳送速度"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:8
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:77
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:105
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:15
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:167
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:185
 msgid "Table"
 msgstr "表格"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:30
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:57
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:74
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:102
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:164
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:182
 msgid "Target"
 msgstr "目標"
 
@@ -5075,7 +5080,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2566
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2630
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5108,7 +5113,7 @@ msgid ""
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:196
 msgid "The following rules are currently active on this system."
 msgstr "以下的規則現正作用在系統中."
 
@@ -5245,7 +5250,7 @@ msgstr ""
 msgid "There are no active leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2748
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5339,8 +5344,8 @@ msgid ""
 "their status."
 msgstr "這清單提供目前正在執行的系統的執行緒和狀態的預覽."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:936
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1067
+#: modules/luci-base/htdocs/luci-static/resources/form.js:942
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1073
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
@@ -5385,9 +5390,9 @@ msgstr "全部可用"
 msgid "Traceroute"
 msgstr "路由追蹤"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:56
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:93
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:51
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:75
 msgid "Traffic"
 msgstr "流量"
 
@@ -5412,7 +5417,7 @@ msgid "Tunnel ID"
 msgstr "通道ID"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2823
-#: modules/luci-compat/luasrc/model/network.lua:1430
+#: modules/luci-compat/luasrc/model/network.lua:1431
 msgid "Tunnel Interface"
 msgstr "通道介面"
 
@@ -5479,6 +5484,11 @@ msgstr ""
 msgid "Unable to dispatch"
 msgstr "無法發送"
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:8
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:8
+msgid "Unable to load log data:"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:22
@@ -5490,6 +5500,14 @@ msgstr ""
 msgid "Unable to obtain mount information"
 msgstr ""
 
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
+msgid "Unable to reset ip6tables counters: %s"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:274
+msgid "Unable to reset iptables counters: %s"
+msgstr ""
+
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
@@ -5498,6 +5516,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:282
+msgid "Unable to restart firewall: %s"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:17
@@ -5515,12 +5537,12 @@ msgid "Unexpected reply data format"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1957
-#: modules/luci-compat/luasrc/model/network.lua:970
+#: modules/luci-compat/luasrc/model/network.lua:971
 msgid "Unknown"
 msgstr "未知"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2266
-#: modules/luci-compat/luasrc/model/network.lua:1137
+#: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
 msgstr ""
 
@@ -5530,7 +5552,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:1954
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
-#: modules/luci-compat/luasrc/model/network.lua:964
+#: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
 msgstr "未託管"
 
@@ -5544,7 +5566,7 @@ msgstr ""
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2495
 msgid "Unsaved Changes"
 msgstr "尚未存檔的修改"
 
@@ -5570,7 +5592,7 @@ msgstr "不支援的協定型態"
 msgid "Up"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2365
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2429
 msgid "Upload"
 msgstr ""
 
@@ -5585,21 +5607,21 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "上傳壓縮檔..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1725
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1700
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2353
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1713
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2417
 msgid "Upload request failed: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2272
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2326
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2336
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
 msgid "Uploading file…"
 msgstr ""
 
@@ -5894,19 +5916,19 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:77
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:16
-#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:102
+#: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
 msgid "Wireless"
 msgstr "無線網路"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2811
-#: modules/luci-compat/luasrc/model/network.lua:1418
+#: modules/luci-compat/luasrc/model/network.lua:1419
 msgid "Wireless Adapter"
 msgstr "無線網卡"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2790
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3994
-#: modules/luci-compat/luasrc/model/network.lua:1404
-#: modules/luci-compat/luasrc/model/network.lua:1865
+#: modules/luci-compat/luasrc/model/network.lua:1405
+#: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
 msgstr "無線網路"
 
@@ -5950,7 +5972,7 @@ msgstr "寫入已接收的DNS請求到系統日誌中"
 msgid "Write system log to file"
 msgstr "將系統日誌寫入檔案"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1757
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1762
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6168,7 +6190,7 @@ msgstr "無連線"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1448
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1454
 msgid "none"
 msgstr "無"
 
@@ -6276,7 +6298,7 @@ msgstr "未知"
 msgid "unlimited"
 msgstr "無限"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1657
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:76
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:137
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:368


### PR DESCRIPTION
- luci-app-ddns: fix some errors in pl/ddns.po
- luci-app-ocserv: fix errors in hu/ocserv.po
- luci-base: remove duplicated translations from Hungarian and Marathi
- i18n: sync translations