### PR TITLE
build: sort location annotation table in i18n sync process

### DIFF
--- a/build/i18n-scan.pl
+++ b/build/i18n-scan.pl
@@ -272,7 +272,7 @@ if( open C, "| msgcat -" )
 	{
 		if( length $key )
 		{
-			my @positions = @{$stringtable{$key}};
+			my @positions = sort @{$stringtable{$key}};
 
 			$key =~ s/\\/\\\\/g;
 			$key =~ s/\n/\\n/g;


### PR DESCRIPTION
@jow- 
Your opinion, please.

The i18n scanning routine has caused unnecessary changes to the .po files if a string has been found in multiple files and those files have been found in different order than the previous time.

Example of unnecessary change:
```
@@ -467,10 +467,10 @@ msgstr ""
 msgid "Members assigned"
 msgstr "Mitglieder, zugewiesen"
 
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:249
-#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:230
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua:25
+#: applications/luci-app-mwan3/luasrc/model/cbi/mwan/member.lua:33
 msgid "Metric"
 msgstr "Metrik"
 ```

This PR sorts the location annotations to avoid unnecessary changes to the .po files.

Note that my simple approach is not perfect. As this simple sorting is alphabetic, the line numbers at the end of the line are sorted that way. It leads to sorting the line numbers like 104,109,41,46

```
 #: applications/luci-app-clamav/luasrc/model/cbi/clamav.lua:104 
 #: applications/luci-app-clamav/luasrc/model/cbi/clamav.lua:109
 #: applications/luci-app-clamav/luasrc/model/cbi/clamav.lua:41
 #: applications/luci-app-clamav/luasrc/model/cbi/clamav.lua:46
```

That could be avoided either 
* by drafting a more complex sorting routine to first sort by file name and secondarily by numeric line numbers,   or 
* by printing the line numbers with leading spaces or zeroes. Four digits should be enough. (But as the current formatting is really simple `my $position = "$file:$line"`, changing it would require again some perl work.)

But as the actual usage of the annotations is likely small, I thought to keep this simple and just implement the minimal change to avoid unnecessary changes in future.
