### PR TITLE
luci-app-olsr: fix typo

### DIFF
--- a/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua
+++ b/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd.lua
@@ -224,8 +224,8 @@ i:tab("addrs",   translate("IP Addresses"))
 i:tab("timing",  translate("Timing and Validity"))
 
 mode = i:taboption("general", ListValue, "Mode", translate("Mode"),
-	translate("Interface Mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
-	"valid Modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
+	translate("Interface mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
+	"Valid modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
 mode:value("mesh")
 mode:value("ether")
 mode.optional = true

--- a/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua
+++ b/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrd6.lua
@@ -218,8 +218,8 @@ i:tab("addrs",   translate("IP Addresses"))
 i:tab("timing",  translate("Timing and Validity"))
 
 mode = i:taboption("general", ListValue, "Mode", translate("Mode"),
-	translate("Interface Mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
-	"valid Modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
+	translate("Interface mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
+	"Valid modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
 mode:value("mesh")
 mode:value("ether")
 mode.optional = true

--- a/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua
+++ b/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua
@@ -49,8 +49,8 @@ network.widget   = "radio"
 network.nocreate = true
 
 mode = i:taboption("general", ListValue, "Mode", translate("Mode"),
-	translate("Interface Mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
-	"valid Modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
+	translate("Interface mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
+	"Valid modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
 mode:value("mesh")
 mode:value("ether")
 mode.optional = true

--- a/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua
+++ b/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua
@@ -49,8 +49,8 @@ network.widget   = "radio"
 network.nocreate = true
 
 mode = i:taboption("general", ListValue, "Mode", translate("Mode"),
-	translate("Interface Mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
-	"valid Modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
+	translate("Interface mode is used to prevent unnecessary packet forwarding on switched ethernet interfaces. "..
+	"Valid modes are \"mesh\" and \"ether\". Default is \"mesh\"."))
 mode:value("mesh")
 mode:value("ether")
 mode.optional = true

--- a/applications/luci-app-olsr/po/bg/olsr.po
+++ b/applications/luci-app-olsr/po/bg/olsr.po
@@ -415,8 +415,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ca/olsr.po
+++ b/applications/luci-app-olsr/po/ca/olsr.po
@@ -420,8 +420,8 @@ msgstr "Interfície"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/cs/olsr.po
+++ b/applications/luci-app-olsr/po/cs/olsr.po
@@ -415,8 +415,8 @@ msgstr "Rozhraní"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/de/olsr.po
+++ b/applications/luci-app-olsr/po/de/olsr.po
@@ -460,8 +460,8 @@ msgstr "Schnittstelle"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "Mit dieser Einstellung kann unnötiges Forwarden von Paketen auf geswitchten "

--- a/applications/luci-app-olsr/po/el/olsr.po
+++ b/applications/luci-app-olsr/po/el/olsr.po
@@ -417,8 +417,8 @@ msgstr "Διεπαφή"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/en/olsr.po
+++ b/applications/luci-app-olsr/po/en/olsr.po
@@ -417,8 +417,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/es/olsr.po
+++ b/applications/luci-app-olsr/po/es/olsr.po
@@ -452,8 +452,8 @@ msgstr "Interfaz"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "El modo de interfaz se usar para evitar traspaso innecesario de paquetes en "

--- a/applications/luci-app-olsr/po/fr/olsr.po
+++ b/applications/luci-app-olsr/po/fr/olsr.po
@@ -417,8 +417,8 @@ msgstr "Interface"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/he/olsr.po
+++ b/applications/luci-app-olsr/po/he/olsr.po
@@ -411,8 +411,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/hi/olsr.po
+++ b/applications/luci-app-olsr/po/hi/olsr.po
@@ -415,8 +415,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/hu/olsr.po
+++ b/applications/luci-app-olsr/po/hu/olsr.po
@@ -461,8 +461,8 @@ msgstr "Csatoló"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 #, fuzzy
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "A csatoló módját arra használják, hogy megakadályozzák a szükségtelen "

--- a/applications/luci-app-olsr/po/it/olsr.po
+++ b/applications/luci-app-olsr/po/it/olsr.po
@@ -441,8 +441,8 @@ msgstr "Interfaccia"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ja/olsr.po
+++ b/applications/luci-app-olsr/po/ja/olsr.po
@@ -449,8 +449,8 @@ msgstr "インターフェース"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "インターフェースモードは、スイッチ上のイーサネットインターフェースに不必要な"

--- a/applications/luci-app-olsr/po/ko/olsr.po
+++ b/applications/luci-app-olsr/po/ko/olsr.po
@@ -415,8 +415,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/mr/olsr.po
+++ b/applications/luci-app-olsr/po/mr/olsr.po
@@ -417,8 +417,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ms/olsr.po
+++ b/applications/luci-app-olsr/po/ms/olsr.po
@@ -410,8 +410,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/no/olsr.po
+++ b/applications/luci-app-olsr/po/no/olsr.po
@@ -415,8 +415,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/pl/olsr.po
+++ b/applications/luci-app-olsr/po/pl/olsr.po
@@ -446,8 +446,8 @@ msgstr "Interfejs"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "Tryb interfejsu jest używany, aby zapobiec niepotrzebnemu przekazywaniu "

--- a/applications/luci-app-olsr/po/pt-br/olsr.po
+++ b/applications/luci-app-olsr/po/pt-br/olsr.po
@@ -484,8 +484,8 @@ msgstr "Interface"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "Modo da Interface é usado para evitar o encaminhamento desnecessário de "

--- a/applications/luci-app-olsr/po/pt/olsr.po
+++ b/applications/luci-app-olsr/po/pt/olsr.po
@@ -464,8 +464,8 @@ msgstr "Interface"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "O Modo de Interface é usado para para prevenir encaminhamentos "

--- a/applications/luci-app-olsr/po/ro/olsr.po
+++ b/applications/luci-app-olsr/po/ro/olsr.po
@@ -416,8 +416,8 @@ msgstr "Interfaţă"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/ru/olsr.po
+++ b/applications/luci-app-olsr/po/ru/olsr.po
@@ -461,8 +461,8 @@ msgstr "Интерфейс"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "Режим интерфейса используется для предотвращения ненужных перенаправлений на "

--- a/applications/luci-app-olsr/po/sk/olsr.po
+++ b/applications/luci-app-olsr/po/sk/olsr.po
@@ -415,8 +415,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/sv/olsr.po
+++ b/applications/luci-app-olsr/po/sv/olsr.po
@@ -417,8 +417,8 @@ msgstr "Gränssnitt"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/templates/olsr.pot
+++ b/applications/luci-app-olsr/po/templates/olsr.pot
@@ -404,8 +404,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/tr/olsr.po
+++ b/applications/luci-app-olsr/po/tr/olsr.po
@@ -411,8 +411,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/uk/olsr.po
+++ b/applications/luci-app-olsr/po/uk/olsr.po
@@ -416,8 +416,8 @@ msgstr "Інтерфейс"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/vi/olsr.po
+++ b/applications/luci-app-olsr/po/vi/olsr.po
@@ -420,8 +420,8 @@ msgstr ""
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 

--- a/applications/luci-app-olsr/po/zh-cn/olsr.po
+++ b/applications/luci-app-olsr/po/zh-cn/olsr.po
@@ -434,8 +434,8 @@ msgstr "接口"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "接口模式用于防止以太网交换机接口上不必要的数据包转发。有效模式"

--- a/applications/luci-app-olsr/po/zh-tw/olsr.po
+++ b/applications/luci-app-olsr/po/zh-tw/olsr.po
@@ -433,8 +433,8 @@ msgstr "介面"
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface.lua:52
 #: applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdiface6.lua:52
 msgid ""
-"Interface Mode is used to prevent unnecessary packet forwarding on switched "
-"ethernet interfaces. valid Modes are \"mesh\" and \"ether\". Default is "
+"Interface mode is used to prevent unnecessary packet forwarding on switched "
+"ethernet interfaces. Valid modes are \"mesh\" and \"ether\". Default is "
 "\"mesh\"."
 msgstr ""
 "介面模式用於防止乙太網交換機介面上不必要的資料包轉發。有效模式"


### PR DESCRIPTION
Fixed typos:

- Interface Mode is -> Interface mode is
- valid Modes are -> Valid modes are