### PR TITLE
[19.07] luci-app-advanced-reboot: pluggable device files, highlight current partition

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -13,7 +13,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=46
+PKG_RELEASE:=51
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices.disabled/linksys-ea9500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices.disabled/linksys-ea9500.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "EA9500",
+	boardName = "linksys-panamera",
+	partition1MTD = "mtd3",
+	partition2MTD = "mtd6",
+	labelOffset = 28,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-e4200v2-ea4500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-e4200v2-ea4500.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "E4200v2/EA4500",
+	boardName = "linksys-viper",
+	partition1MTD = "mtd3",
+	partition2MTD = "mtd5",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea3500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea3500.lua
@@ -1,0 +1,15 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "EA3500",
+	boardName = "linksys-audi",
+	partition1MTD = "mtd3",
+	partition2MTD = "mtd5",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}
+

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea6350v3.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea6350v3.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "EA6350v3",
+	boardName = "linksys-ea6350v3",
+	partition1MTD = "mtd10",
+	partition2MTD = "mtd12",
+	labelOffset = 192,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8300.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8300.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "EA8300",
+	boardName = "linksys-ea8300",
+	partition1MTD = "mtd10",
+	partition2MTD = "mtd12",
+	labelOffset = 192,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8500.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "EA8500",
+	boardName = "linksys-ea8500",
+	partition1MTD = "mtd13",
+	partition2MTD = "mtd15",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1200ac.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1200ac.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "WRT1200AC",
+	boardName = "linksys-caiman",
+	partition1MTD = "mtd4",
+	partition2MTD = "mtd6",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900ac.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900ac.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "WRT1900AC",
+	boardName = "linksys-mamba",
+	partition1MTD = "mtd4",
+	partition2MTD = "mtd6",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acs.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acs.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "WRT1900ACS",
+	boardName = "linksys-shelby",
+	partition1MTD = "mtd4",
+	partition2MTD = "mtd6",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acv2.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acv2.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "WRT1900ACv2",
+	boardName = "linksys-cobra",
+	partition1MTD = "mtd4",
+	partition2MTD = "mtd6",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt3200acm.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt3200acm.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "WRT3200ACM",
+	boardName = "linksys-rango",
+	partition1MTD = "mtd5",
+	partition2MTD = "mtd7",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt32x.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt32x.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "WRT32X",
+	boardName = "linksys-venom",
+	partition1MTD = "mtd5",
+	partition2MTD = "mtd7",
+	labelOffset = nil,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = "bootcmd",
+	bootEnv2Partition1Value = "run nandboot",
+	bootEnv2Partition2Value = "run altnandboot"
+}

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/zyxel-nbg6817.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/zyxel-nbg6817.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "ZyXEL",
+	deviceName = "NBG6817",
+	boardName = "nbg6817",
+	partition1MTD = "mmcblk0p4",
+	partition2MTD = "mmcblk0p7",
+	labelOffset = 32,
+	bootEnv1 = nil,
+	bootEnv1Partition1Value = 255,
+	bootEnv1Partition2Value = 1,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}

--- a/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
@@ -15,7 +15,8 @@ local http = require "luci.http"
 local sys = require "luci.sys"
 local dispatcher = require "luci.dispatcher"
 local uci = require "luci.model.uci".cursor()
-local packageName = "luci-app-advanced-reboot"
+local packageName = "advanced-reboot"
+local devices_dir = "/usr/lib/lua/luci/" .. packageName .. "/devices/"
 
 function logger(t)
 	util.exec("logger -t " .. packageName .. " '" .. tostring(t) .. "'")
@@ -34,7 +35,7 @@ function is_alt_mountable(p1_mtd, p2_mtd)
 end
 
 function get_partition_os_info(op_ubi)
-	local cp_info, ap_info
+	local cp_info, op_info
 	if fs.access("/etc/os-release") then
 		cp_info = util.trim(util.exec('. /etc/os-release && echo "$PRETTY_NAME"'))
 		if cp_info:find("SNAPSHOT") then
@@ -45,14 +46,14 @@ function get_partition_os_info(op_ubi)
 	alt_partition_unmount(op_ubi)
 	alt_partition_mount(op_ubi)
 	if fs.access("/alt/rom/etc/os-release") then
-		ap_info = util.trim(util.exec('. /alt/rom/etc/os-release && echo "$PRETTY_NAME"'))
-		if ap_info:find("SNAPSHOT") then
-			ap_info = util.trim(util.exec('. /alt/rom/etc/os-release && echo "$OPENWRT_RELEASE"'))
+		op_info = util.trim(util.exec('. /alt/rom/etc/os-release && echo "$PRETTY_NAME"'))
+		if op_info:find("SNAPSHOT") then
+			op_info = util.trim(util.exec('. /alt/rom/etc/os-release && echo "$OPENWRT_RELEASE"'))
 		end 
 	end
 	logger(i18n.translate("attempting to unmount alternative partition") .. " (mtd" .. tostring(op_ubi) .. ")")
 	alt_partition_unmount(op_ubi)
-	return cp_info, ap_info
+	return cp_info, op_info
 end
 
 function alt_partition_mount(op_ubi)
@@ -71,6 +72,7 @@ function alt_partition_mount(op_ubi)
 end
 
 function alt_partition_unmount(op_ubi)
+	local i
 	local mtdCount = tonumber(util.exec("ubinfo | grep 'Present UBI devices' | grep -c ','"))
 	mtdCount = mtdCount and mtdCount + 1 or 10
 --	util.exec("[ -d /alt/firmware ] && umount /alt/firmware")
@@ -87,105 +89,94 @@ function alt_partition_unmount(op_ubi)
 	end
 end
 
-devices = {
-	-- deviceName, boardName, part1MTD, part2MTD, offset, envVar1, envVar1Value1, envVar1Value2, envVar2, envVar2Value1, envVar2Value2
-	{"Linksys EA3500", "linksys-audi", "mtd3", "mtd5", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"Linksys E4200v2/EA4500", "linksys-viper", "mtd3", "mtd5", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"Linksys EA6350v3", "linksys-ea6350v3", "mtd10", "mtd12", 192, "boot_part", 1, 2},
-	{"Linksys EA8300", "linksys-ea8300", "mtd10", "mtd12", 192, "boot_part", 1, 2},
-	{"Linksys EA8500", "ea8500", "mtd13", "mtd15", 32, "boot_part", 1, 2},
---  {"Linksys EA9500", "linksys-panamera", "mtd3", "mtd6", 28, "boot_part", 1, 2},
-	{"Linksys WRT1200AC", "linksys-caiman", "mtd4", "mtd6", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"Linksys WRT1900AC", "linksys-mamba", "mtd4", "mtd6", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"Linksys WRT1900ACv2", "linksys-cobra", "mtd4", "mtd6", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"Linksys WRT1900ACS", "linksys-shelby", "mtd4", "mtd6", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"Linksys WRT3200ACM", "linksys-rango", "mtd5", "mtd7", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"Linksys WRT32X", "linksys-venom", "mtd5", "mtd7", nil, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-	{"ZyXEL NBG6817", "nbg6817", "mmcblk0p4", "mmcblk0p7", 32, nil, 255, 1}
-}
-
--- local errorMessage, d
--- local device_name, p1_mtd, p2_mtd, offset, bev1, bev1p1, bev1p2, bev2, bev2p1, bev2p2
-romBoardName = util.trim(util.exec("cat /tmp/sysinfo/board_name"))
-
-for i=1, #devices do
-	d = devices[i][2]:gsub('%p','')
-	if romBoardName and romBoardName:gsub('%p',''):match(d) then
-		device_name = devices[i][1]
-		p1_mtd = devices[i][3] or nil
-		p2_mtd = devices[i][4] or nil
-		offset = devices[i][5] or nil
-		bev1 = devices[i][6] or nil
-		bev1p1 = tonumber(devices[i][7]) or nil
-		bev1p2 = tonumber(devices[i][8]) or nil
-		bev2 = devices[i][9] or nil
-		bev2p1 = devices[i][10] or nil
-		bev2p2 = devices[i][11] or nil
-		if p1_mtd and offset then
-			p1_label = util.trim(util.exec("dd if=/dev/" .. p1_mtd .. " bs=1 skip=" .. offset .. " count=128" .. "  2>/dev/null"))
-			n, p1_version = p1_label:match('(Linux)-([%d|.]+)')
-		end
-		if p2_mtd and offset then
-			p2_label = util.trim(util.exec("dd if=/dev/" .. p2_mtd .. " bs=1 skip=" .. offset .. " count=128" .. "  2>/dev/null"))
-			n, p2_version = p2_label:match('(Linux)-([%d|.]+)')
-		end
-		if p1_label and p1_label:find("LEDE") then p1_os = "LEDE" end
-		if p1_label and p1_label:find("OpenWrt") then p1_os = "OpenWrt" end
-		if p1_label and p1_label:find("Linksys") then p1_os = "Linksys" end
-		if p2_label and p2_label:find("LEDE") then p2_os = "LEDE" end
-		if p2_label and p2_label:find("OpenWrt") then p2_os = "OpenWrt" end
-		if p2_label and p2_label:find("Linksys") then p2_os = "Linksys" end
-		if device_name == "ZyXEL NBG6817" then
-			if not p1_os then p1_os = "ZyXEL" end
-			if not p2_os then p2_os = "ZyXEL" end
-		end
-		if device_name == "Linksys WRT32X" then
-			if not p1_os then p1_os = "Unknown/Compressed" end
-			if not p2_os then p2_os = "Unknown/Compressed" end
-		end
-		if not p1_os then p1_os = "Unknown" end
-		if not p2_os then p2_os = "Unknown" end
-		if p1_os and p1_version then p1_os = p1_os .. " (Linux " .. p1_version .. ")" end
-		if p2_os and p2_version then p2_os = p2_os .. " (Linux " .. p2_version .. ")" end
-
-		if device_name == "ZyXEL NBG6817" then
-			if not zyxelFlagPartition then zyxelFlagPartition = util.trim(util.exec(". /lib/functions.sh; find_mtd_part 0:DUAL_FLAG")) end
-			if not zyxelFlagPartition then
-				errorMessage = errorMessage or "" .. i18n.translate("Unable to find Dual Boot Flag Partition." .. " ")
-				util.perror(i18n.translate("Unable to find Dual Boot Flag Partition."))
+function obtain_device_info()
+	local p, boardName, n, p1_label, p1_version, p2_label, p2_version, p1_os, p2_os
+	local errorMessage, current_partition
+	local op_ubi, cp_info, op_info, zyxelFlagPartition
+	local romBoardName = util.trim(util.exec("cat /tmp/sysinfo/board_name"))
+	for filename in fs.dir(devices_dir) do
+		local p_func = loadfile(devices_dir .. filename)
+		setfenv(p_func, { _ = i18n.translate })
+		p = p_func()
+		boardName = p.boardName:gsub('%p','')
+		if romBoardName and romBoardName:gsub('%p',''):match(boardName) then
+			if p.labelOffset then
+				if p.partition1MTD then
+					p1_label = util.trim(util.exec("dd if=/dev/" .. p.partition1MTD .. " bs=1 skip=" .. p.labelOffset .. " count=128" .. "  2>/dev/null"))
+					n, p1_version = p1_label:match('(Linux)-([%d|.]+)')
+				end
+				if p.partition2MTD then
+					p2_label = util.trim(util.exec("dd if=/dev/" .. p.partition2MTD .. " bs=1 skip=" .. p.labelOffset .. " count=128" .. "  2>/dev/null"))
+					n, p2_version = p2_label:match('(Linux)-([%d|.]+)')
+				end
+				if p1_label and p1_label:find("LEDE") then p1_os = "LEDE" end
+				if p1_label and p1_label:find("OpenWrt") then p1_os = "OpenWrt" end
+				if p1_label and p.vendorName and p1_label:find(p.vendorName) then p1_os = p.vendorName end
+				if p2_label and p2_label:find("LEDE") then p2_os = "LEDE" end
+				if p2_label and p2_label:find("OpenWrt") then p2_os = "OpenWrt" end
+				if p2_label and p.vendorName and p2_label:find(p.vendorName) then p2_os = p.vendorName end
+				if not p1_os then p1_os = p.vendorName .. "/" .. i18n.translate("Unknown") end
+				if not p2_os then p2_os = p.vendorName .. "/" .. i18n.translate("Unknown") end
+				if p1_os and p1_version then p1_os = p1_os .. " (Linux " .. p1_version .. ")" end
+				if p2_os and p2_version then p2_os = p2_os .. " (Linux " .. p2_version .. ")" end
 			else
-				current_partition = tonumber(util.exec("dd if=" .. zyxelFlagPartition .. " bs=1 count=1 2>/dev/null | hexdump -n 1 -e '1/1 \"%d\"'"))
+				p1_os = p.vendorName .. "/" .. i18n.translate("Unknown") .. " (" .. i18n.translate("Compressed") .. ")"
+				p2_os = p.vendorName .. "/" .. i18n.translate("Unknown") .. " (" .. i18n.translate("Compressed") .. ")"
 			end
-		else
-			if fs.access("/usr/sbin/fw_printenv") and fs.access("/usr/sbin/fw_setenv") then
-				current_partition = tonumber(util.trim(util.exec("fw_printenv -n " .. bev1)))
-			end
-		end
-		other_partition = current_partition == bev1p2 and bev1p1 or bev1p2
-		
-		if is_alt_mountable(p1_mtd, p2_mtd) then
-			if current_partition == bev1p1 then
-				op_ubi = tonumber(p2_mtd:sub(4)) + 1
+
+			if p.bootEnv1 then
+				if fs.access("/usr/sbin/fw_printenv") and fs.access("/usr/sbin/fw_setenv") then
+					current_partition = tonumber(util.trim(util.exec("fw_printenv -n " .. p.bootEnv1)))
+				end
 			else
-				op_ubi = tonumber(p1_mtd:sub(4)) + 1
+				if not zyxelFlagPartition then zyxelFlagPartition = util.trim(util.exec(". /lib/functions.sh; find_mtd_part 0:DUAL_FLAG")) end
+				if zyxelFlagPartition then
+					current_partition = tonumber(util.exec("dd if=" .. zyxelFlagPartition .. " bs=1 count=1 2>/dev/null | hexdump -n 1 -e '1/1 \"%d\"'"))
+				else
+					errorMessage = errorMessage or i18n.translate("Unable to find Dual Boot Flag Partition.")
+					util.perror(i18n.translate("Unable to find Dual Boot Flag Partition."))
+				end
 			end
-			local cp_info, ap_info = get_partition_os_info(op_ubi)
-			if current_partition == bev1p1 then
-				p1_os = cp_info or p1_os
-				p2_os = ap_info or p2_os
-			else
-				p1_os = ap_info or p1_os
-				p2_os = cp_info or p2_os
+			
+			if is_alt_mountable(p.partition1MTD, p.partition2MTD) then
+				if current_partition == p.bootEnv1Partition1Value then
+					op_ubi = tonumber(p.partition2MTD:sub(4)) + 1
+				else
+					op_ubi = tonumber(p.partition1MTD:sub(4)) + 1
+				end
+				local cp_info, op_info = get_partition_os_info(op_ubi)
+				if current_partition == p.bootEnv1Partition1Value then
+					p1_os = cp_info or p1_os
+					p2_os = op_info or p2_os
+				else
+					p1_os = op_info or p1_os
+					p2_os = cp_info or p2_os
+				end
 			end
+			return romBoardName, p.vendorName .. " " .. p.deviceName, p.bootEnv1, p.bootEnv1Partition1Value, p1_os, p.bootEnv1Partition2Value, p2_os, p.bootEnv2, p.bootEnv2Partition1Value, p.bootEnv2Partition1Value, current_partition
 		end
 	end
+	return romBoardName, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil
 end
 
 function index()
-	entry({"admin", "system", "advanced_reboot"}, template("advanced_reboot/advanced_reboot"), _("Advanced Reboot"), 90)
+	entry({"admin", "system", "advanced_reboot"}, call("action_template"), _("Advanced Reboot"), 90)
 	entry({"admin", "system", "advanced_reboot", "reboot"}, post("action_reboot"))
 	entry({"admin", "system", "advanced_reboot", "alternative_reboot"}, post("action_altreboot"))
 	entry({"admin", "system", "advanced_reboot", "power_off"}, post("action_poweroff"))
+end
+
+function action_template()
+	local romBoardName, device_name, bev1, bev1p1, p1_os, bev1p2, p2_os, bev2, bev2p1, bev2p2, current_partition = obtain_device_info()
+	ltemplate.render("advanced_reboot/advanced_reboot",{
+				romBoardName=romBoardName,
+				device_name=device_name,
+				bev1p1=bev1p1,
+				p1_os=p1_os,
+				bev1p2=bev1p2,
+				p2_os=p2_os,
+				current_partition=current_partition,
+				errorMessage = errorMessage})
 end
 
 function action_reboot()
@@ -198,6 +189,7 @@ function action_reboot()
 end
 
 function action_altreboot()
+	local romBoardName, device_name, bev1, bev1p1, p1_os, bev1p2, p2_os, bev2, bev2p1, bev2p2, current_partition = obtain_device_info()
 	local zyxelFlagPartition, zyxelBootFlag, zyxelNewBootFlag, errorCode, curEnvSetting, newEnvSetting
 	errorMessage = nil
 	errorCode = 0

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
@@ -1,7 +1,7 @@
 <%#
  Copyright 2008 Steven Barth <steven@midlink.org>
  Copyright 2008-2015 Jo-Philipp Wich <jow@openwrt.org>
- Copyright 2017-2018 Stan Grishin <stangri@melmac.net>
+ Copyright 2017-2020 Stan Grishin <stangri@melmac.net>
  Licensed to the public under the Apache License 2.0.
 -%>
 
@@ -28,7 +28,7 @@
 			<div class="th cbi-section-table-cell"><%:Firmware%></div>
 			<div class="th cbi-section-table-cell"><%:Reboot%></div>
 		</div>
-		<div class="tr cbi-section-table-row cbi-rowstyle-1">
+		<div class="tr cbi-section-table-row cbi-rowstyle-<%- if bev1p1 == current_partition then -%><%=1%><%- else -%><%=2%><%- end -%>">
 			<div class="td">
 				<%=string.format("%X", bev1p1)%>
 			</div>
@@ -52,7 +52,7 @@
 				<%- end -%>
 			</div>
 		</div>
-		<div class="tr cbi-section-table-row cbi-rowstyle-2">
+		<div class="tr cbi-section-table-row cbi-rowstyle-<%- if bev1p2 == current_partition then -%><%=1%><%- else -%><%=2%><%- end -%>">
 			<div class="td">
 				<%=string.format("%X", bev1p2)%>
 			</div>

--- a/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
+++ b/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:163
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
@@ -18,6 +18,11 @@ msgstr ""
 
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:42
 msgid "Changes applied."
+msgstr ""
+
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:123
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:124
+msgid "Compressed"
 msgstr ""
 
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm:10
@@ -42,7 +47,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:205
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
@@ -85,14 +90,14 @@ msgstr ""
 msgid "Reboot to current partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:184
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:289
 msgid "Shutting down..."
 msgstr ""
 
@@ -104,7 +109,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:194
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:185
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -112,7 +117,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -120,37 +125,44 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:290
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:154
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:155
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:136
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:137
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:212
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
 msgid "Unable to obtain firmware environment variable"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
 msgid "Unable to set Dual Boot Flag Partition entry for partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:218
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:219
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:232
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:233
 msgid "Unable to set firmware environment variable"
+msgstr ""
+
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:118
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:119
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:123
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:124
+msgid "Unknown"
 msgstr ""
 
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm:12
@@ -192,17 +204,17 @@ msgstr ""
 msgid "Warning: Unable to obtain device information!"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:44
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:45
 msgid "attempting to mount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:53
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:54
 msgid "attempting to unmount alternative partition"
 msgstr ""
 
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
-#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:218
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:219
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:232
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:233
 msgid "to"
 msgstr ""


### PR DESCRIPTION
Switching to a model where device specifics are in pluggable files.
Highlight current (instead of first) partition in the list.

Signed-off-by: Stan Grishin <stangri@melmac.net>