### PR TITLE
[19.07] luci-app-vpn-policy-routing: styling bugfix

### DIFF
--- a/applications/luci-app-vpn-policy-routing/Makefile
+++ b/applications/luci-app-vpn-policy-routing/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=VPN Policy-Based Routing Service Web UI
 LUCI_DESCRIPTION:=Provides Web UI for vpn-policy-routing service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +vpn-policy-routing
 LUCI_PKGARCH:=all
-PKG_RELEASE:=68
+PKG_RELEASE:=69
 
 include ../../luci.mk
 

--- a/applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm
+++ b/applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm
@@ -10,9 +10,11 @@ This is free software, licensed under the Apache License, Version 2.0
 	disabled="disabled"><%=self:cfgvalue(section):gsub('\n', '\n')%>
 </textarea>
 
+<div>
 <%- local readmeURL = "https://github.com/openwrt/packages/tree/master/net/vpn-policy-routing/files/README.md" -%>
 <%=translate("Checkmark represents the default gateway. See the") .. " " 
 .. [[<a href="]] .. readmeURL .. [[#a-word-about-default-routing" target="_blank">]] 
 .. translate("README") .. [[</a>]] .. " " .. translate("for details.")%>
+</div>
 
 <%+cbi/valuefooter%>

--- a/applications/luci-app-vpn-policy-routing/po/templates/vpn-policy-routing.pot
+++ b/applications/luci-app-vpn-policy-routing/po/templates/vpn-policy-routing.pot
@@ -53,7 +53,7 @@ msgstr ""
 msgid "Chain"
 msgstr ""
 
-#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm:14
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm:15
 msgid "Checkmark represents the default gateway. See the"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:184
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:350
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:363
-#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm:16
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm:17
 msgid "README"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgstr ""
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:155
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:350
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:363
-#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm:16
+#: applications/luci-app-vpn-policy-routing/luasrc/view/vpn-policy-routing/status-gateways.htm:17
 msgid "for details."
 msgstr ""
 


### PR DESCRIPTION
Fix for the orphaned text in the view-file.

Signed-off-by: Stan Grishin <stangri@melmac.net>