### PR TITLE
luci-base: remove hardcoded cgi-bin path

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/fs.js
+++ b/modules/luci-base/htdocs/luci-static/resources/fs.js
@@ -342,7 +342,7 @@ var FileSystem = L.Class.extend(/** @lends LuCI.fs.prototype */ {
 		var postdata = 'sessionid=%s&path=%s'
 			.format(encodeURIComponent(L.env.sessionid), encodeURIComponent(path));
 
-		return L.Request.post('/cgi-bin/cgi-download', postdata, {
+		return L.Request.post(L.env.cgi_base + '/cgi-download', postdata, {
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
 		}).then(handleCgiIoReply);
 	},
@@ -385,7 +385,7 @@ var FileSystem = L.Class.extend(/** @lends LuCI.fs.prototype */ {
 		var postdata = 'sessionid=%s&command=%s'
 			.format(encodeURIComponent(L.env.sessionid), encodeURIComponent(cmdstr));
 
-		return L.Request.post('/cgi-bin/cgi-exec', postdata, {
+		return L.Request.post(L.env.cgi_base + '/cgi-exec', postdata, {
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
 		}).then(handleCgiIoReply);
 	}

--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -1192,6 +1192,8 @@
 			if (env.base_url == null)
 				this.error('InternalError', 'Cannot find url of luci.js');
 
+			env.cgi_base = env.scriptname.replace(/\/[^\/]+$/, '');
+
 			Object.assign(this.env, env);
 
 			document.addEventListener('poll-start', function(ev) {

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -1702,7 +1702,7 @@ var UIFileUpload = UIElement.extend({
 		data.append('filename', path + '/' + filename);
 		data.append('filedata', fileinput.files[0]);
 
-		return L.Request.post('/cgi-bin/cgi-upload', data, {
+		return L.Request.post(L.env.cgi_base + '/cgi-upload', data, {
 			progress: L.bind(function(btn, ev) {
 				btn.firstChild.data = '%.2f%%'.format((ev.loaded / ev.total) * 100);
 			}, this, ev.target)
@@ -2397,7 +2397,7 @@ return L.Class.extend({
 
 								var filename = input.files[0].name;
 
-								L.Request.post('/cgi-bin/cgi-upload', data, {
+								L.Request.post(L.env.cgi_base + '/cgi-upload', data, {
 									timeout: 0,
 									progress: function(pev) {
 										var percent = (pev.loaded / pev.total) * 100;

--- a/modules/luci-base/root/www/index.html
+++ b/modules/luci-base/root/www/index.html
@@ -3,9 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
-<meta http-equiv="refresh" content="0; URL=/cgi-bin/luci/" />
+<meta http-equiv="refresh" content="0; URL=cgi-bin/luci/" />
 </head>
 <body style="background-color: white">
-<a style="color: black; font-family: arial, helvetica, sans-serif;" href="/cgi-bin/luci/">LuCI - Lua Configuration Interface</a>
+<a style="color: black; font-family: arial, helvetica, sans-serif;" href="cgi-bin/luci/">LuCI - Lua Configuration Interface</a>
 </body>
 </html>

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
@@ -76,7 +76,7 @@ return L.view.extend({
 	handleBackup: function(ev) {
 		var form = E('form', {
 			method: 'post',
-			action: '/cgi-bin/cgi-backup',
+			action: L.env.cgi_base + '/cgi-backup',
 			enctype: 'application/x-www-form-urlencoded'
 		}, E('input', { type: 'hidden', name: 'sessionid', value: rpc.getSessionID() }));
 
@@ -169,7 +169,7 @@ return L.view.extend({
 		var mtdblock = L.dom.parent(ev.target, '.cbi-section').querySelector('[data-name="mtdselect"] select').value;
 		var form = E('form', {
 			'method': 'post',
-			'action': '/cgi-bin/cgi-download',
+			'action': L.env.cgi_base + '/cgi-download',
 			'enctype': 'application/x-www-form-urlencoded'
 		}, [
 			E('input', { 'type': 'hidden', 'name': 'sessionid', 'value': rpc.getSessionID() }),


### PR DESCRIPTION
Currently LuCI can be loaded only when placed in the root of the server as the cgi-bin paths are hardcoded. Change the index.html to load the cgi-bin path from the current level.
Also add a new entry in the env Object to make the cgi_base path easily accessible.
This variable will be based on the position of /cgi-bin/luci.

@jow- Was easier than I tought. No extra config needed. 
Should I also change the comments? 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>