### PR TITLE
luci-base/mod-network: add system cert bundle validation

### DIFF
--- a/modules/luci-base/root/usr/libexec/rpcd/luci
+++ b/modules/luci-base/root/usr/libexec/rpcd/luci
@@ -216,6 +216,7 @@ local methods = {
 			rv.sysntpd       = fs.readlink("/usr/sbin/ntpd") and true
 			rv.ipv6          = fs.access("/proc/net/ipv6_route")
 			rv.dropbear      = fs.access("/usr/sbin/dropbear")
+			rv.cabundle      = fs.access("/etc/ssl/certs/ca-certificates.crt")
 
 			local wifi_features = { "eap", "11n", "11ac", "11r", "11w", "acs", "sae", "owe", "suiteb192" }
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1428,11 +1428,26 @@ return L.view.extend({
 					o.depends({ mode: 'sta-wds', encryption: 'wpa' });
 					o.depends({ mode: 'sta-wds', encryption: 'wpa2' });
 
-					o = ss.taboption('encryption', form.FileUpload, 'ca_cert', _('Path to CA-Certificate'));
+					o = ss.taboption('encryption', form.Flag, 'ca_cert_usesystem', _('Use system certificates'), _("Validate server certificate using built-in system CA bundle,<br />requires the \"ca-bundle\" package"))
+					o.enabled = '1';
+					o.disabled = '0';
+					o.default = o.disabled;
 					o.depends({ mode: 'sta', encryption: 'wpa' });
 					o.depends({ mode: 'sta', encryption: 'wpa2' });
 					o.depends({ mode: 'sta-wds', encryption: 'wpa' });
 					o.depends({ mode: 'sta-wds', encryption: 'wpa2' });
+					o.validate = function(section_id, value) {
+						if (value == '1' && !L.hasSystemFeature('cabundle')) {
+							return _("This option cannot be used because the ca-bundle package is not installed.");
+						}
+						return true;
+					};
+
+					o = ss.taboption('encryption', form.FileUpload, 'ca_cert', _('Path to CA-Certificate'));
+					o.depends({ mode: 'sta', encryption: 'wpa', ca_cert_usesystem: '0' });
+					o.depends({ mode: 'sta', encryption: 'wpa2', ca_cert_usesystem: '0' });
+					o.depends({ mode: 'sta-wds', encryption: 'wpa', ca_cert_usesystem: '0' });
+					o.depends({ mode: 'sta-wds', encryption: 'wpa2', ca_cert_usesystem: '0' });
 
 					o = ss.taboption('encryption', form.Value, 'subject_match', _('Certificate constraint (Subject)'), _("Certificate constraint substring - e.g. /CN=wifi.mycompany.com<br />See `logread -f` during handshake for actual values"));
 					o.depends({ mode: 'sta', encryption: 'wpa' });
@@ -1509,11 +1524,26 @@ return L.view.extend({
 						return true;
 					};
 
-					o = ss.taboption('encryption', form.FileUpload, 'ca_cert2', _('Path to inner CA-Certificate'));
+					o = ss.taboption('encryption', form.Flag, 'ca_cert2_usesystem', _('Use system certificates for inner-tunnel'), _("Validate server certificate using built-in system CA bundle,<br />requires the \"ca-bundle\" package"))
+					o.enabled = '1';
+					o.disabled = '0';
+					o.default = o.disabled;
 					o.depends({ mode: 'sta', auth: 'EAP-TLS', encryption: 'wpa' });
 					o.depends({ mode: 'sta', auth: 'EAP-TLS', encryption: 'wpa2' });
 					o.depends({ mode: 'sta-wds', auth: 'EAP-TLS', encryption: 'wpa' });
 					o.depends({ mode: 'sta-wds', auth: 'EAP-TLS', encryption: 'wpa2' });
+					o.validate = function(section_id, value) {
+						if (value == '1' && !L.hasSystemFeature('cabundle')) {
+							return _("This option cannot be used because the ca-bundle package is not installed.");
+						}
+						return true;
+					};
+
+					o = ss.taboption('encryption', form.FileUpload, 'ca_cert2', _('Path to inner CA-Certificate'));
+					o.depends({ mode: 'sta', auth: 'EAP-TLS', encryption: 'wpa', ca_cert2_usesystem: '0' });
+					o.depends({ mode: 'sta', auth: 'EAP-TLS', encryption: 'wpa2', ca_cert2_usesystem: '0' });
+					o.depends({ mode: 'sta-wds', auth: 'EAP-TLS', encryption: 'wpa', ca_cert2_usesystem: '0' });
+					o.depends({ mode: 'sta-wds', auth: 'EAP-TLS', encryption: 'wpa2', ca_cert2_usesystem: '0' });
 
 					o = ss.taboption('encryption', form.Value, 'subject_match2', _('Inner certificate constraint (Subject)'), _("Certificate constraint substring - e.g. /CN=wifi.mycompany.com<br />See `logread -f` during handshake for actual values"));
 					o.depends({ mode: 'sta', auth: 'EAP-TLS', encryption: 'wpa' });


### PR DESCRIPTION
luci-mod-network: add system cert bundle validation

This commit adds the ability for users to validate against the system's 
built-in CA bundle if it is installed. The process is made much easier because 
the user does not have to first extract the CA certificate from the EAPOL 
handshake and upload it via LuCI uploads. Dependent on commit 
openwrt/openwrt#2696.

luci-base: add system cert bundle detection

Add detection mechanism for system cert CA bundle installed by the 
ca-bundle package. Used by LuCI to detect whether the "Use system 
certificates" certificate validation option should be enabled.

Signed-off-by: David Lam <david@thedavid.net>