### PR TITLE
luci-app-mosquitto: translations + option list fixes

### DIFF
--- a/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
+++ b/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
@@ -209,9 +209,9 @@ psk_key.validate = validate_psk_key
 b_tls_version = s:option(ListValue, "tls_version", _("TLS Version"),
     _("The remote broker must support the same version of TLS for the connection to succeed."))
 b_tls_version:value("", "Default")
-b_tls_version:value("tlsv1")
 b_tls_version:value("tlsv1.1")
 b_tls_version:value("tlsv1.2")
+b_tls_version:value("tlsv1.3")
 b_tls_version.optional = true
 
 o = s:option(Value, "cafile", _("Path to CA file"))

--- a/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
+++ b/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
@@ -11,6 +11,7 @@ You may obtain a copy of the License at
 ]]--
 
 local datatypes = require("luci.cbi.datatypes")
+local _ = luci.i18n.translate
 
 --- Like a Flag, but with an option to remove/set to default.
 local function OptionalFlag(section, key, title, description)
@@ -22,207 +23,207 @@ local function OptionalFlag(section, key, title, description)
     return o
 end
 
-m = Map("mosquitto", "Mosquitto MQTT Broker",
-    [[mosquitto - the <a href='http://www.mosquitto.org'>blood thirsty</a> 
+m = Map("mosquitto", _("Mosquitto MQTT Broker"),
+    _([[mosquitto - the <a href='http://www.mosquitto.org'>blood thirsty</a>
 MQTT messaging broker.  Note, only some of the available configuration files
  are supported at this stage, use the checkbox below to use config generated
  by this page, or the stock mosquitto configuration file in 
- /etc/mosquitto/mosquitto.conf]])
+ /etc/mosquitto/mosquitto.conf]]))
  
 s = m:section(TypedSection, "owrt", "OpenWRT")
 s.anonymous = true
-p = s:option(Flag, "use_uci", "Use this LuCI configuration page",
-	[[If checked, mosquitto runs with a config generated
+p = s:option(Flag, "use_uci", _("Use this LuCI configuration page"),
+	_([[If checked, mosquitto runs with a config generated
 	from this page. (Or from UCI directly)  If unchecked, mosquitto
         runs with the config in /etc/mosquitto/mosquitto.conf
-        (and this page is ignored)]])
+        (and this page is ignored)]]))
 
 s = m:section(TypedSection, "mosquitto", "Mosquitto")
 s.anonymous = true
 
-p = s:option(MultiValue, "log_dest", "Log destination",
-    "You can have multiple, but 'none' will override all others")
+p = s:option(MultiValue, "log_dest", _("Log destination"),
+    _("You can have multiple, but 'none' will override all others"))
 p:value("stderr", "stderr")
 p:value("stdout", "stdout")
 p:value("syslog", "syslog")
 p:value("topic", "$SYS/broker/log/[severity]")
 p:value("none", "none")
 
-OptionalFlag(s, "no_remote_access", "Disallow remote access to this broker",
-    [[Outbound bridges will still work, but this will make the primary listener
-    only available from localhost]])
+OptionalFlag(s, "no_remote_access", _("Disallow remote access to this broker"),
+    _([[Outbound bridges will still work, but this will make the primary listener
+    only available from localhost]]))
 
 local o
-o = s:option(Value, "sys_interval", "Time in seconds between updates of the $SYS tree", "Set to zero to disable")
+o = s:option(Value, "sys_interval", _("Time in seconds between updates of the $SYS tree"), _("Set to zero to disable"))
 o.datatype = "uinteger"
 o.optional = true
 
-o = s:option(Value, "max_inflight_messages", "Max Inflight Messages", "Limit for message allowed inflight")
+o = s:option(Value, "max_inflight_messages", _("Max Inflight Messages"), _("Limit for message allowed inflight"))
 o.datatype = "uinteger"
 o.optional = true
-o = s:option(Value, "max_queued_messages", "Max Queued Messages", "Limit for message queue when offline")
+o = s:option(Value, "max_queued_messages", _("Max Queued Messages"), _("Limit for message queue when offline"))
 o.datatype = "uinteger"
 o.optional = true
-o = s:option(Value, "max_queued_bytes", "Max Queued bytes", "Limit for message queue when offline, zero to disable)")
+o = s:option(Value, "max_queued_bytes", _("Max Queued bytes"), _("Limit for message queue when offline, zero to disable)"))
 o.datatype = "uinteger"
 o.optional = true
 
 
-s = m:section(TypedSection, "persistence", "Persistence")
+s = m:section(TypedSection, "persistence", _("Persistence"))
 s.anonymous = true
 s.addremove = false
-s:option(Flag, "persistence", "Persistence enabled", "Should persistence to disk be enabled at all").rmempty = false
-o = s:option(Value, "client_expiration", "Client expiration", "Remove persistent clients if they haven't reconnected in this period, eg 6h, 3d, 2w")
+s:option(Flag, "persistence", _("Persistence enabled"), _("Should persistence to disk be enabled at all")).rmempty = false
+o = s:option(Value, "client_expiration", _("Client expiration"), _("Remove persistent clients if they haven't reconnected in this period, eg 6h, 3d, 2w"))
 o.optional = true
 o:depends("persistence", true)
-o = OptionalFlag(s, "autosave_on_changes", "Autosave on changes", "Autosave interval applies to change counts instead of time")
+o = OptionalFlag(s, "autosave_on_changes", _("Autosave on changes"), _("Autosave interval applies to change counts instead of time"))
 o:depends("persistence", true)
-o = s:option(Value, "autosave_interval", "Autosave interval", "Save persistence file after this many seconds or changes")
+o = s:option(Value, "autosave_interval", _("Autosave interval"), _("Save persistence file after this many seconds or changes"))
 o.optional = true
 o:depends("persistence", true)
-o = s:option(Value, "file", "Persistent file name")
+o = s:option(Value, "file", _("Persistent file name"))
 o.optional = true
 o:depends("persistence", true)
-o = s:option(Value, "location", "Persistent file path (with trailing/)", "Path to persistent file")
+o = s:option(Value, "location", _("Persistent file path (with trailing/)"), _("Path to persistent file"))
 o.optional = true
 o:depends("persistence", true)
 
-s = m:section(TypedSection, "listener", "Listeners", "You can configure additional listeners here")
+s = m:section(TypedSection, "listener", _("Listeners"), _("You can configure additional listeners here"))
 s.addremove = true
 s.anonymous = true
-s:option(Value, "port", "Port").datatype = "port"
+s:option(Value, "port", _("Port")).datatype = "port"
 
-o = s:option(ListValue, "protocol", "Protocol to use when listening")
+o = s:option(ListValue, "protocol", _("Protocol to use when listening"))
 o:value("", "Default")
-o:value("mqtt", "MQTT")
-o:value("websockets", "WebSockets")
+o:value("mqtt", _("MQTT"))
+o:value("websockets", _("WebSockets"))
 
-s:option(Value, "http_dir", "http_dir to serve on websockets listeners").optional = true
+s:option(Value, "http_dir", _("http_dir to serve on websockets listeners")).optional = true
 OptionalFlag(s, "use_username_as_clientid", "use_username_as_clientid")
-o = s:option(Value, "cafile", "CA file path")
+o = s:option(Value, "cafile", _("CA file path"))
 o.optional = true
 o.datatype = "file"
-o = s:option(Value, "capath", "CA path to search")
+o = s:option(Value, "capath", _("CA path to search"))
 o.optional = true
 o.datatype = "directory"
-o = s:option(Value, "certfile", "server certificate file (PEM encoded)")
+o = s:option(Value, "certfile", _("server certificate file (PEM encoded)"))
 o.optional = true
 o.datatype = "file"
-o = s:option(Value, "keyfile", "keyfile (PEM encoded)")
+o = s:option(Value, "keyfile", _("keyfile (PEM encoded)"))
 o.optional = true
 o.datatype = "file"
 
-o = s:option(ListValue, "tls_version", "TLS Version",
-    "Depends on your openssl version, empty to support all")
+o = s:option(ListValue, "tls_version", _("TLS Version"),
+    _("Depends on your openssl version, empty to support all"))
 o.optional = true
 o:value("", "Default")
 o:value("tlsv1.1")
 o:value("tlsv1.2")
 o:value("tlsv1.3")
 
-OptionalFlag(s, "require_certificate", "Require clients to present a certificate")
+OptionalFlag(s, "require_certificate", _("Require clients to present a certificate"))
 OptionalFlag(s, "use_identity_as_username", "use_identity_as_username")
-s:option(Value, "crlfile", "CRL to use if require_certificate is enabled").optional = true
-s:option(Value, "ciphers", "Ciphers control. Should match 'openssl ciphers' format").optional = true
-s:option(Value, "psk_hint", "PSK Hint to provide to connecting clients").optional = true
+s:option(Value, "crlfile", _("CRL to use if require_certificate is enabled")).optional = true
+s:option(Value, "ciphers", _("Ciphers control. Should match 'openssl ciphers' format")).optional = true
+s:option(Value, "psk_hint", _("PSK Hint to provide to connecting clients")).optional = true
 
 -- we want to allow multiple bridge sections
-s = m:section(TypedSection, "bridge", "Bridges",
-    "You can configure multiple bridge connections here")
+s = m:section(TypedSection, "bridge", _("Bridges"),
+    _("You can configure multiple bridge connections here"))
 s.anonymous = true
 s.addremove = true
 
-conn = s:option(Value, "connection", "Connection name",
-    "unique name for this bridge configuration")
+conn = s:option(Value, "connection", _("Connection name"),
+    _("unique name for this bridge configuration"))
 
 local function validate_address(self, value)
     local host, port = unpack(luci.util.split(value, ":"))
     if (datatypes.host(host)) then
         if port and #port then
             if not datatypes.port(port) then
-                return nil, "Please enter a valid port after the :"
+                return nil, _("Please enter a valid port after the :")
             end
         end
         return value
     end
-    return nil, "Please enter a hostname or an IP address"
+    return nil, _("Please enter a hostname or an IP address")
 end
 
-addr = s:option(Value, "address", "address", "address[:port] of remote broker")
+addr = s:option(Value, "address", _("address"), _("address[:port] of remote broker"))
 addr.datatype = "string"
 addr.validate = validate_address
 
 -- TODO - make the in/out/both a dropdown/radio or something....
-topics = s:option(DynamicList, "topic", "topic",
-    "full topic string for mosquitto.conf, eg: 'power/# out 2'")
+topics = s:option(DynamicList, "topic", _("topic"),
+    _("full topic string for mosquitto.conf, eg: 'power/# out 2'"))
 
-OptionalFlag(s, "cleansession", "Clean session")
-OptionalFlag(s, "notifications", "notifications",
-    "Attempt to notify the local and remote broker of connection status, defaults to $SYS/broker/connections/<clientid>/state")
-s:option(Value, "notification_topic", "Topic to use for local+remote remote for notifications.").optional = true
+OptionalFlag(s, "cleansession", _("Clean session"))
+OptionalFlag(s, "notifications", _("notifications"),
+    _("Attempt to notify the local and remote broker of connection status, defaults to $SYS/broker/connections/<clientid>/state"))
+s:option(Value, "notification_topic", _("Topic to use for local+remote remote for notifications.")).optional = true
 
-s:option(Value, "remote_clientid", "Client id to use on remote end of this bridge connection").optional = true
-s:option(Value, "local_clientid", "Client id to use locally. Important when bridging to yourself").optional = true
-o = s:option(Value, "keepalive_interval", "Keepalive interval for this bridge")
+s:option(Value, "remote_clientid", _("Client id to use on remote end of this bridge connection")).optional = true
+s:option(Value, "local_clientid", _("Client id to use locally. Important when bridging to yourself")).optional = true
+o = s:option(Value, "keepalive_interval", _("Keepalive interval for this bridge"))
 o.datatype = "uinteger"
 o.optional = true
-o = s:option(ListValue, "start_type", "How should this bridge be started")
+o = s:option(ListValue, "start_type", _("How should this bridge be started"))
 o.optional = true
 o:value("", "Default")
-o:value("automatic", "Automatic, includes restarts")
-o:value("lazy", "Automatic, but stopped when not used")
-o:value("once", "Automatic, but no restarts")
-o = s:option(Value, "restart_timeout", "How long to wait before reconnecting")
+o:value("automatic", _("Automatic, includes restarts"))
+o:value("lazy", _("Automatic, but stopped when not used"))
+o:value("once", _("Automatic, but no restarts"))
+o = s:option(Value, "restart_timeout", _("How long to wait before reconnecting"))
 o.datatype = "uinteger"
 o.optional = true
-o = s:option(Value, "idle_timeout", "How long to wait before disconnecting")
+o = s:option(Value, "idle_timeout", _("How long to wait before disconnecting"))
 o.datatype = "uinteger"
 o.optional = true
-o = s:option(Value, "threshold", "How many messages to queue before restarting lazy bridge")
+o = s:option(Value, "threshold", _("How many messages to queue before restarting lazy bridge"))
 o.datatype = "uinteger"
 o.optional = true
 
 OptionalFlag(s, "try_private", "try_private",
-    "attempt to notify the remote broker that this is a bridge, not all brokers support this.")
-s:option(Value, "remote_username", "Remote username").optional = true
-o = s:option(Value, "remote_password", "Remote password")
+    _("attempt to notify the remote broker that this is a bridge, not all brokers support this."))
+s:option(Value, "remote_username", _("Remote username")).optional = true
+o = s:option(Value, "remote_password", _("Remote password"))
 o.optional = true
 o.password = true
 
-s:option(Value, "identity", "PSK Bridge Identity", "Identity for TLS-PSK").optional = true
+s:option(Value, "identity", _("PSK Bridge Identity"), _("Identity for TLS-PSK")).optional = true
 
 -- no hex validation available in datatypes
 local function validate_psk_key(self, value)
     if (value:match("^[a-fA-F0-9]+$")) then
         return value
     end
-    return nil, "Only hex numbers are allowed (use A-F characters and 0-9 digits)"
+    return nil, _("Only hex numbers are allowed (use A-F characters and 0-9 digits)")
 end
 
-psk_key = s:option(Value, "psk", "Bridge PSK", "Key for TLS-PSK")
+psk_key = s:option(Value, "psk", _("Bridge PSK"), _("Key for TLS-PSK"))
 psk_key.password = true
 psk_key.optional = true
 psk_key.datatype = "string"
 psk_key.validate = validate_psk_key
 
-b_tls_version = s:option(ListValue, "tls_version", "TLS Version",
-    "The remote broker must support the same version of TLS for the connection to succeed.")
+b_tls_version = s:option(ListValue, "tls_version", _("TLS Version"),
+    _("The remote broker must support the same version of TLS for the connection to succeed."))
 b_tls_version:value("", "Default")
 b_tls_version:value("tlsv1")
 b_tls_version:value("tlsv1.1")
 b_tls_version:value("tlsv1.2")
 b_tls_version.optional = true
 
-o = s:option(Value, "cafile", "Path to CA file")
+o = s:option(Value, "cafile", _("Path to CA file"))
 o.optional = true
 o.datatype = "file"
-o = s:option(Value, "capath", "Directory to search for CA files")
+o = s:option(Value, "capath", _("Directory to search for CA files"))
 o.optional = true
 o.datatype = "directory"
-o = s:option(Value, "certfile", "Path to PEM encoded server certificate file")
+o = s:option(Value, "certfile", _("Path to PEM encoded server certificate file"))
 o.optional = true
 o.datatype = "file"
-o = s:option(Value, "keyfile", "Path to PEM encoded keyfile")
+o = s:option(Value, "keyfile", _("Path to PEM encoded keyfile"))
 o.optional = true
 o.datatype = "file"
 

--- a/applications/luci-app-mosquitto/po/templates/mosquitto.pot
+++ b/applications/luci-app-mosquitto/po/templates/mosquitto.pot
@@ -1,6 +1,353 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:162
+msgid ""
+"Attempt to notify the local and remote broker of connection status, defaults "
+"to $SYS/broker/connections/<clientid>/state"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:175
+msgid "Automatic, but no restarts"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:174
+msgid "Automatic, but stopped when not used"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:173
+msgid "Automatic, includes restarts"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:81
+msgid "Autosave interval"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:79
+msgid "Autosave interval applies to change counts instead of time"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:79
+msgid "Autosave on changes"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:203
+msgid "Bridge PSK"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:131
+msgid "Bridges"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:103
+msgid "CA file path"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:106
+msgid "CA path to search"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:126
+msgid "CRL to use if require_certificate is enabled"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:127
+msgid "Ciphers control. Should match 'openssl ciphers' format"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:160
+msgid "Clean session"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:76
+msgid "Client expiration"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:166
+msgid "Client id to use locally. Important when bridging to yourself"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:165
+msgid "Client id to use on remote end of this bridge connection"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:136
+msgid "Connection name"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:117
+msgid "Depends on your openssl version, empty to support all"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:220
+msgid "Directory to search for CA files"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:52
+msgid "Disallow remote access to this broker"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:179
+msgid "How long to wait before disconnecting"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:176
+msgid "How long to wait before reconnecting"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:182
+msgid "How many messages to queue before restarting lazy bridge"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:170
+msgid "How should this bridge be started"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:193
+msgid "Identity for TLS-PSK"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:36
+msgid ""
+"If checked, mosquitto runs with a config generated from this page. (Or from "
+"UCI directly) If unchecked, mosquitto runs with the config in /etc/mosquitto/"
+"mosquitto.conf (and this page is ignored)"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:167
+msgid "Keepalive interval for this bridge"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:203
+msgid "Key for TLS-PSK"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:61
+msgid "Limit for message allowed inflight"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:64
+msgid "Limit for message queue when offline"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:67
+msgid "Limit for message queue when offline, zero to disable)"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:91
+msgid "Listeners"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:44
+msgid "Log destination"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:98
+msgid "MQTT"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:61
+msgid "Max Inflight Messages"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:64
+msgid "Max Queued Messages"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:67
+msgid "Max Queued bytes"
+msgstr ""
+
 #: applications/luci-app-mosquitto/luasrc/controller/mosquitto.lua:15
 msgid "Mosquitto"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:26
+msgid "Mosquitto MQTT Broker"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:200
+msgid "Only hex numbers are allowed (use A-F characters and 0-9 digits)"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:53
+msgid ""
+"Outbound bridges will still work, but this will make the primary listener "
+"only available from localhost"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:193
+msgid "PSK Bridge Identity"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:128
+msgid "PSK Hint to provide to connecting clients"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:217
+msgid "Path to CA file"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:226
+msgid "Path to PEM encoded keyfile"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:223
+msgid "Path to PEM encoded server certificate file"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:87
+msgid "Path to persistent file"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:72
+msgid "Persistence"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:75
+msgid "Persistence enabled"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:84
+msgid "Persistent file name"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:87
+msgid "Persistent file path (with trailing/)"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:149
+msgid "Please enter a hostname or an IP address"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:144
+msgid "Please enter a valid port after the :"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:94
+msgid "Port"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:96
+msgid "Protocol to use when listening"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:189
+msgid "Remote password"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:188
+msgid "Remote username"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:76
+msgid ""
+"Remove persistent clients if they haven't reconnected in this period, eg 6h, "
+"3d, 2w"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:124
+msgid "Require clients to present a certificate"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:81
+msgid "Save persistence file after this many seconds or changes"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:57
+msgid "Set to zero to disable"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:75
+msgid "Should persistence to disk be enabled at all"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:116
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:209
+msgid "TLS Version"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:210
+msgid ""
+"The remote broker must support the same version of TLS for the connection to "
+"succeed."
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:57
+msgid "Time in seconds between updates of the $SYS tree"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:163
+msgid "Topic to use for local+remote remote for notifications."
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:35
+msgid "Use this LuCI configuration page"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:99
+msgid "WebSockets"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:91
+msgid "You can configure additional listeners here"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:132
+msgid "You can configure multiple bridge connections here"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:45
+msgid "You can have multiple, but 'none' will override all others"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:152
+msgid "address"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:152
+msgid "address[:port] of remote broker"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:187
+msgid ""
+"attempt to notify the remote broker that this is a bridge, not all brokers "
+"support this."
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:158
+msgid "full topic string for mosquitto.conf, eg: 'power/# out 2'"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:101
+msgid "http_dir to serve on websockets listeners"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:112
+msgid "keyfile (PEM encoded)"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:27
+msgid ""
+"mosquitto - the <a href='http://www.mosquitto.org'>blood thirsty</a> MQTT "
+"messaging broker. Note, only some of the available configuration files are "
+"supported at this stage, use the checkbox below to use config generated by "
+"this page, or the stock mosquitto configuration file in /etc/mosquitto/"
+"mosquitto.conf"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:161
+msgid "notifications"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:109
+msgid "server certificate file (PEM encoded)"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:157
+msgid "topic"
+msgstr ""
+
+#: applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua:137
+msgid "unique name for this bridge configuration"
 msgstr ""


### PR DESCRIPTION
Marks all the strings as translateable, which had been completely skipped in the past
Also includes a fix to the list of tls versions.

further details are in each commit