### PR TITLE
luci-base: make rpc webserver path configurable

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -1508,8 +1508,8 @@
 			if (rpcBaseURL == null) {
 				var rpcFallbackURL = this.url('admin/ubus');
 
-				rpcBaseURL = Request.get('/ubus/').then(function(res) {
-					return (rpcBaseURL = (res.status == 400) ? '/ubus/' : rpcFallbackURL);
+				rpcBaseURL = Request.get(this.env.ubuspath).then(function(res) {
+					return (rpcBaseURL = (res.status == 400) ? L.env.ubuspath : rpcFallbackURL);
 				}, function() {
 					return (rpcBaseURL = rpcFallbackURL);
 				}).then(function(url) {

--- a/modules/luci-base/luasrc/view/header.htm
+++ b/modules/luci-base/luasrc/view/header.htm
@@ -24,6 +24,7 @@
 		requestpath    = luci.dispatcher.context.requestpath,
 		dispatchpath   = luci.dispatcher.context.path,
 		pollinterval   = luci.config.main.pollinterval or 5,
+		ubuspath       = luci.config.main.ubuspath or '/ubus',
 		sessionid      = luci.dispatcher.context.authsession,
 		apply_rollback = math.max(applyconf and applyconf.rollback or 30, 30),
 		apply_holdoff  = math.max(applyconf and applyconf.holdoff or 4, 1),

--- a/modules/luci-base/root/etc/config/luci
+++ b/modules/luci-base/root/etc/config/luci
@@ -2,6 +2,7 @@ config core main
 	option lang auto
 	option mediaurlbase /luci-static/bootstrap
 	option resourcebase /luci-static/resources
+	option ubuspath /ubus
 	
 config extern flash_keep
 	option uci 		"/etc/config/"


### PR DESCRIPTION
Currently the ubus path that provide the webserver is hardcoded to be /ubus.
Change this to make it configurable from the luci config file.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>