### PR TITLE
luci-app-openvpn: fix typo

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -497,7 +497,7 @@ local knownParams = {
 		{ DynamicList,
 			"remote",
 			"1.2.3.4",
-			translate("Remote host name or ip address") },
+			translate("Remote host name or IP address") },
 		{ Flag,
 			"remote_random",
 			0,

--- a/applications/luci-app-openvpn/po/templates/openvpn.pot
+++ b/applications/luci-app-openvpn/po/templates/openvpn.pot
@@ -476,12 +476,9 @@ msgstr ""
 msgid "Remap SIGUSR1 signals"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:500
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:61
 msgid "Remote host name or IP address"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:500
-msgid "Remote host name or ip address"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:315


### PR DESCRIPTION
The POT and PO files already contain the changed string. I changed only the POT file, Weblate will merge it to PO files and remove the unnecessary entry.