### PR TITLE
luci-app-ser2net: add app supporting ser2net

### DIFF
--- a/applications/luci-app-ser2net/Makefile
+++ b/applications/luci-app-ser2net/Makefile
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2020 Michele Primavera
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI Support for ser2net
+LUCI_DEPENDS:=+ser2net
+
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js
+++ b/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js
@@ -1,0 +1,32 @@
+'use strict';
+'require form';
+
+return L.view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('ser2net', 'ser2net');
+
+		s = m.section(form.TypedSection, "led", _("LED redirect"));
+		s.anonymous = false;
+		s.addremove = true;
+
+		o = s.option(form.Value, "driver", _("Driver"), _("The driver required for the device."));
+		o.rmempty = false;
+		o.default = "sysfs";
+
+		o = s.option(form.Value, "device", _("Device"), _("The device itself."));
+		o.rmempty = false;
+		o.default = "duckbill:red:rs485";
+
+		o = s.option(form.Value, "driver", _("Duration"), _("Blink duration."));
+		o.rmempty = false;
+		o.default = 20;
+
+		o = s.option(form.Value, "state", _("State"));
+		o.rmempty = false;
+		o.default = 1;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/proxies.js
+++ b/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/proxies.js
@@ -1,0 +1,78 @@
+'use strict';
+'require form';
+
+return L.view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('ser2net', 'ser2net');
+
+		s = m.section(form.TypedSection, "proxy", _("Proxies"));
+		s.anonymous = true;
+		s.addremove = true;
+
+		o = s.option(form.Flag, "enabled", _("Enabled"));
+		o.rmempty = false;
+
+		o = s.option(form.Value, "port", _("Service port"), _("The TCP port to listen on."));
+		o.rmempty = false;
+		o.default = 5000;
+
+		o = s.option(form.ListValue, "protocol", _("Protocol"), _("The protocol to listen to."));
+		o.rmempty = false;
+		o.value("raw", _("Raw"));
+		o.value("rawlp", _("Rawlp"));
+		o.value("telnet", _("Telnet"));
+		o.value("off", _("Off"));
+		o.default = "raw";
+
+		o = s.option(form.Value, "timeout", _("Timeout"), _("The amount of seconds of inactivity before a disconnect occurs.<br/>A value of zero means wait indefinitely."));
+		o.rmempty = false;
+		o.default = 0;
+
+		o = s.option(form.Value, "device", _("Device"), _("The name of the device to connect to.<br/>This must be in the form of /dev/<device>."));
+		o.rmempty = false;
+		o.default = "/dev/ttyUSB0";
+
+		o = s.option(form.ListValue, "baudrate", _("Baud rate"), _("The speed the device port should operate at."));
+		o.rmempty = false;
+		o.value(300);
+		o.value(1200);
+		o.value(2400);
+		o.value(4800);
+		o.value(9600);
+		o.value(19200);
+		o.value(38400);
+		o.value(57600);
+		o.value(115200);
+		o.default = 9600;
+
+		o = s.option(form.ListValue, "databits", _("Data bits"));
+		o.rmempty = false;
+		o.value(8);
+		o.value(7);
+		o.default = 8;
+
+		o = s.option(form.ListValue, "parity", _("Parity"));
+		o.rmempty = false;
+		o.value("none", _("None"));
+		o.value("even", _("Even"));
+		o.value("odd", _("Odd"));
+		o.default = "none";
+
+		o = s.option(form.ListValue, "stopbits", _("Stop bits"));
+		o.rmempty = false;
+		o.value(1);
+		o.value(2);
+		o.default = 1;
+
+		s.option(form.Flag, "rtscts", _("Use RTS and CTS lines"));
+		s.option(form.Flag, "local", _("Ignore modem control signals"));
+		s.option(form.Flag, "remctl", _("Allow the RFC 2217 protocol"));
+		s.option(form.DynamicList, "options", _("Extra options"));
+		s.option(form.Value, "led_tx", _("TX LED configuration"));
+		s.option(form.Value, "led_rx", _("RX LED configuration"));
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/settings.js
+++ b/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/settings.js
@@ -1,0 +1,74 @@
+'use strict';
+'require form';
+
+return L.view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('ser2net', 'ser2net');
+
+		//ser2net
+		s = m.section(form.TypedSection, "ser2net", _("Global switch"));
+		s.anonymous = true;
+
+		o = s.option(form.Flag, "enabled", _("Enabled"));
+		o.rmempty = false;
+
+		//controlport
+		s = m.section(form.TypedSection, "controlport", _("Control port"));
+		s.anonymous = true;
+
+		o = s.option(form.Flag, "enabled", _("Enabled"));
+		o.rmempty = false;
+
+		o = s.option(form.Value, "host", _("Binding address"), _("The network to listen from."));
+		o.rmempty = false;
+		o.default = "localhost";
+
+		o = s.option(form.Value, "port", _("Control port"), _("The TCP port to listen on."));
+		o.rmempty = false;
+		o.default = 2000;
+
+		//default
+		s = m.section(form.TypedSection, "default", _("Default settings"));
+		s.anonymous = true;
+
+		o = s.option(form.ListValue, "speed", _("Baud rate"), _("The speed the device port should operate at."));
+		o.rmempty = false;
+		o.value(300);
+		o.value(1200);
+		o.value(2400);
+		o.value(4800);
+		o.value(9600);
+		o.value(19200);
+		o.value(38400);
+		o.value(57600);
+		o.value(115200);
+		o.default = 9600;
+
+		o = s.option(form.ListValue, "databits", _("Data bits"));
+		o.rmempty = false;
+		o.value(8);
+		o.value(7);
+		o.default = 8;
+
+		o = s.option(form.ListValue, "parity", _("Parity"));
+		o.rmempty = false;
+		o.value("none", _("None"));
+		o.value("even", _("Even"));
+		o.value("odd", _("Odd"));
+		o.default = "none";
+
+		o = s.option(form.ListValue, "stopbits", _("Stop bits"));
+		o.rmempty = false;
+		o.value(1);
+		o.value(2);
+		o.default = 1;
+
+		s.option(form.Flag, "rtscts", _("Use RTS and CTS lines"));
+		s.option(form.Flag, "local", _("Ignore modem control signals"));
+		s.option(form.Flag, "remctl", _("Allow the RFC 2217 protocol"));
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-ser2net/luasrc/controller/ser2net.lua
+++ b/applications/luci-app-ser2net/luasrc/controller/ser2net.lua
@@ -1,0 +1,12 @@
+module("luci.controller.ser2net", package.seeall)
+
+function index()
+	if not nixio.fs.access("/etc/config/ser2net") then
+		return
+	end
+
+	entry({"admin", "services", "ser2net"}, firstchild(), "ser2net").dependent = true
+	entry({"admin", "services", "ser2net", "settings"}, view("ser2net/settings"), _("Settings"), 1).leaf = false
+	entry({"admin", "services", "ser2net", "proxies"}, view("ser2net/proxies"), _("Proxies"), 2).leaf = false
+	entry({"admin", "services", "ser2net", "leds"}, view("ser2net/leds"), _("LEDs"), 3).leaf = false
+end

--- a/applications/luci-app-ser2net/root/usr/share/rpcd/acl.d/luci-app-ser2net.json
+++ b/applications/luci-app-ser2net/root/usr/share/rpcd/acl.d/luci-app-ser2net.json
@@ -1,0 +1,8 @@
+{
+	"luci-app-ser2net": {
+		"description": "Grant access to LuCI app ser2net",
+		"write": {
+			"uci": [ "ser2net" ]
+		}
+	}
+}


### PR DESCRIPTION
This implements full support to the new uci config format for ser2net in luci.
Requires openwrt/packages#11086 for full functionality.
Signed-off-by: Michele Primavera <primavera@elmod.it>