### PR TITLE
luci-app-openvpn: add editing field for .up and .down scripts

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
@@ -6,6 +6,8 @@ local util      = require("luci.util")
 local uci       = require("luci.model.uci").cursor()
 local cfg_file  = uci:get("openvpn", arg[1], "config")
 local auth_file = cfg_file:match("(.+)%..+").. ".auth"
+local down_file = cfg_file:match("(.+)%..+").. ".down"
+local up_file   = cfg_file:match("(.+)%..+").. ".up"
 
 local m = Map("openvpn")
 
@@ -76,6 +78,48 @@ function file.remove(self, section, value)
 end
 
 function s.handle(self, state, data2)
+	return true
+end
+
+s = f:section(SimpleSection, nil, translatef("Section to add an optional 'up' file which typically add routes to the tunnel by script (%s)", up_file))
+file = s:option(TextValue, "data3")
+file.datatype = "string"
+file.rows = 20
+
+function file.cfgvalue()
+        return fs.readfile(up_file) or ""
+end
+
+function file.write(self, section, data3)
+        return fs.writefile(up_file, util.trim(data3:gsub("\r\n", "\n")) .. "\n")
+end
+
+function file.remove(self, section, value)
+        return fs.writefile(up_file, "")
+end
+
+function s.handle(self, state, data3)
+	return true
+end
+
+s = f:section(SimpleSection, nil, translatef("Section to add an optional 'down' file which typically removes routes to the tunnel by script (%s)", down_file))
+file = s:option(TextValue, "data4")
+file.datatype = "string"
+file.rows = 20
+
+function file.cfgvalue()
+	return fs.readfile(down_file) or ""
+end
+
+function file.write(self, section, data4)
+	return fs.writefile(down_file, util.trim(data4:gsub("\r\n", "\n")) .. "\n")
+end
+
+function file.remove(self, section, value)
+	return fs.writefile(down_file, "")
+end
+
+function s.handle(self, state, data4)
 	return true
 end
 

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
@@ -91,7 +91,8 @@ function file.cfgvalue()
 end
 
 function file.write(self, section, data3)
-        return fs.writefile(up_file, util.trim(data3:gsub("\r\n", "\n")) .. "\n")
+        fs.writefile(up_file, util.trim(data3:gsub("\r\n", "\n")) .. "\n")
+        return fs.chmod( up_file, 755 )
 end
 
 function file.remove(self, section, value)
@@ -112,7 +113,8 @@ function file.cfgvalue()
 end
 
 function file.write(self, section, data4)
-	return fs.writefile(down_file, util.trim(data4:gsub("\r\n", "\n")) .. "\n")
+	fs.writefile(down_file, util.trim(data4:gsub("\r\n", "\n")) .. "\n")
+        return fs.chmod( down_file, 755 )
 end
 
 function file.remove(self, section, value)

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
@@ -90,11 +90,19 @@ end
 function s.remove(self, name)
 	local cfg_file  = "/etc/openvpn/" ..name.. ".ovpn"
 	local auth_file = "/etc/openvpn/" ..name.. ".auth"
+	local down_file = "/etc/openvpn/" ..name.. ".down"
+	local up_file   = "/etc/openvpn/" ..name.. ".up"
 	if fs.access(cfg_file) then
 		fs.unlink(cfg_file)
 	end
 	if fs.access(auth_file) then
 		fs.unlink(auth_file)
+	end
+	if fs.access(down_file) then
+		fs.unlink(down_file)
+	end
+	if fs.access(up_file) then
+		fs.unlink(up_file)
 	end
 	uci:delete("openvpn", name)
 	uci:save("openvpn")


### PR DESCRIPTION
These changes allow a seperate 'ovpnprofile.up/ovpnprofile.down' file/script besides the existing 'ovpnprofile.auth' file and the existing 'ovpnprofile.ovpn'&'ovpnprofile.auth' edit fields. 

Review requested:
It creates 'ovpnprofile.up/ovpnprofile.down' which are executable, because of a quick/dirty hack without further understanding of the lua languange.

Please backport these simple changes to 19.07.x because its 'luci-app-openvpn' can than be configured in very advanced ways just from the webinterface.

Signed-off-by: Walter Sonius <walterav1984@gmail.com>