### PR TITLE
wireguard: add checkbox for `nohostroute` option

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -60,6 +60,8 @@ return network.registerProtocol('wireguard', {
 		o.datatype = 'ipaddr';
 		o.optional = true;
 
+		o = s.taboption('general', form.Flag, 'nohostroute', _('No Host Routes'), _('Optional. Do not create host routes to peers.'));
+		o.optional = true;
 
 		// -- advanced --------------------------------------------------------------------
 


### PR DESCRIPTION
This change allows to configure `nohostroute` option for wireguard to explicitely prevent creation
of host routes to endpoints.

By default without `option nohostroute '1'`, an explicite route to the peer's endpoint will be created in the main routing table with the next hop to the gateway. However, it causes issues with some setup. Enabling this option will inhibit this behavior. See discussions at http://lists.openwrt.org/pipermail/openwrt-devel/2019-March/016329.html.