### PR TITLE
[19.07] luci-app-ksmbd: support new UCI option, update for 3.2.1 version

### DIFF
--- a/applications/luci-app-ksmbd/Makefile
+++ b/applications/luci-app-ksmbd/Makefile
@@ -5,6 +5,6 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Network Shares - Ksmbd the SMB kernel fileserver
 LUCI_DEPENDS:=+ksmbd-server
 
-include $(TOPDIR)/feeds/luci/luci.mk
+include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
+++ b/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
@@ -38,6 +38,9 @@ return L.view.extend({
 
 		o = s.taboption('general', form.Value, 'description', _('Description'));
 		o.placeholder = 'Ksmbd on OpenWrt';
+		
+		o = s.taboption('general', form.Flag, 'allow_legacy_protocols', _('Allow legacy (insecure) protocols/authentication.'),
+			_('Allow legacy smb(v1)/Lanman connections, needed for older devices without smb(v2.1/3) support.'));
 
 		o = s.taboption('template', form.TextValue, '_tmpl',
 			_('Edit the template that is used for generating the ksmbd configuration.'),

--- a/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
+++ b/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
@@ -8,7 +8,7 @@ return L.view.extend({
 		return Promise.all([
 			L.resolveDefault(fs.stat('/sbin/block'), null),
 			L.resolveDefault(fs.stat('/etc/config/fstab'), null),
-			L.resolveDefault(fs.exec('/usr/sbin/usmbd', ['-V']), {}).then(function(res) { return L.toArray((res.stdout || '').match(/version : (\S+)/))[1] }),
+			L.resolveDefault(fs.exec('/usr/sbin/ksmbd.mountd', ['-V']), {}).then(function(res) { return L.toArray((res.stdout || '').match(/version : (\S+)/))[1] }),
 			L.resolveDefault(fs.exec('/sbin/modinfo', ['ksmbd']), {}).then(function(res) { return L.toArray((res.stdout || '').match(/version:\t(\S+)/))[1] }),
 		]);
 	},

--- a/applications/luci-app-ksmbd/po/bg/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/bg/ksmbd.po
@@ -4,19 +4,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -24,7 +34,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -32,11 +42,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -44,11 +54,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -60,7 +70,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -69,25 +79,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/ca/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/ca/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10.1\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -30,7 +40,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descripció"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -38,11 +48,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr "Interfície"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Nom"
 
@@ -75,25 +85,25 @@ msgstr "Nom"
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/cs/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/cs/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Povolení hosté"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Povolení uživatelé"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Možnost procházení"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Vytvořit masku"
 
@@ -30,7 +40,7 @@ msgstr "Vytvořit masku"
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Maska adresáře"
 
@@ -38,11 +48,11 @@ msgstr "Maska adresáře"
 msgid "Edit Template"
 msgstr "Editovat šablonu"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr "Editovat šablonu, která je použita pro generování konfigurace CIFSD."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Vynutit superuživatelský přístup"
 
@@ -50,11 +60,11 @@ msgstr "Vynutit superuživatelský přístup"
 msgid "General Settings"
 msgstr "Obecné nastavení"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Skrýt soubory začínající tečkou"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Zdědit vlastníka"
 
@@ -66,7 +76,7 @@ msgstr "Rozhraní"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "Naslouchat pouze na daném rozhraní nebo, pokud není zadáno, v síti LAN"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Název"
 
@@ -75,11 +85,11 @@ msgstr "Název"
 msgid "Network Shares"
 msgstr "Síťová sdílení"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Cesta"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -87,15 +97,15 @@ msgstr ""
 "Přidejte adresáře, které chcete sdílet. Každý adresář odkazuje na složku na "
 "připojeném zařízení."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Pouze pro čtení"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Sdílené adresáře"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/de/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/de/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Gastzugang"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Legitimierte Benutzer"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Durchsuchbar"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Berechtigungs-maske für neue Dateien"
 
@@ -30,7 +40,7 @@ msgstr "Berechtigungs-maske für neue Dateien"
 msgid "Description"
 msgstr "Beschreibung"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Verzeichnis-maske"
 
@@ -38,13 +48,13 @@ msgstr "Verzeichnis-maske"
 msgid "Edit Template"
 msgstr "Template bearbeiten"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 "Bearbeite die Vorlage, die für die Erstellung der ksmbd-Konfiguration "
 "verwendet wird."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Root erzwingen"
 
@@ -52,11 +62,11 @@ msgstr "Root erzwingen"
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Dotfiles ausblenden"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Besitzer Erben"
 
@@ -70,7 +80,7 @@ msgstr ""
 "Nur auf die angegebene Schnittstelle reagieren oder, wenn nicht "
 "spezifiziert, auf LAN"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Name"
 
@@ -79,11 +89,11 @@ msgstr "Name"
 msgid "Network Shares"
 msgstr "Netzwerk-freigaben"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Pfad"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -91,15 +101,15 @@ msgstr ""
 "Bitte fügen Sie Verzeichnisse hinzu, die Sie freigeben möchten. Jedes "
 "Verzeichnis bezieht sich auf einen Ordner auf einem bereitgestellten Gerät."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Nur Lesen"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Freigegebene Verzeichnisse"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/el/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/el/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -30,7 +40,7 @@ msgstr ""
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -38,11 +48,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr "Διεπαφή"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -75,25 +85,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/en/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/en/ksmbd.po
@@ -4,19 +4,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -24,7 +34,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -32,11 +42,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -44,11 +54,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -60,7 +70,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -69,25 +79,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/es/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/es/ksmbd.po
@@ -13,19 +13,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Permitir invitados"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Usuarios permitidos"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Navegable"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Crear máscara"
 
@@ -33,7 +43,7 @@ msgstr "Crear máscara"
 msgid "Description"
 msgstr "Descripción"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Máscara de directorio"
 
@@ -41,11 +51,11 @@ msgstr "Máscara de directorio"
 msgid "Edit Template"
 msgstr "Editar plantilla"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr "Edite la plantilla que se utiliza para generar la configuración ksmbd."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Forzar Root"
 
@@ -53,11 +63,11 @@ msgstr "Forzar Root"
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Ocultar archivos pequeños"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Heredar propietario"
 
@@ -69,7 +79,7 @@ msgstr "Interfaz"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "Escuche solo en la interfaz dada o, si no se especifica, en lan"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Nombre"
 
@@ -78,11 +88,11 @@ msgstr "Nombre"
 msgid "Network Shares"
 msgstr "Recursos compartidos de red"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Ruta"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -90,15 +100,15 @@ msgstr ""
 "Por favor agregue directorios para compartir. Cada directorio hace "
 "referencia a una carpeta en un dispositivo montado."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Directorios compartidos"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "
@@ -113,3 +123,19 @@ msgstr ""
 #: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:36
 msgid "Workgroup"
 msgstr "Grupo de trabajo"
+
+#~ msgid ""
+#~ "Edit the template that is used for generating the samba configuration."
+#~ msgstr ""
+#~ "Edite la plantilla que se utiliza para generar la configuración de samba."
+
+#~ msgid ""
+#~ "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
+#~ "your samba configuration will be generated. Values enclosed by pipe "
+#~ "symbols ('|') should not be changed. They get their values from the "
+#~ "'General Settings' tab."
+#~ msgstr ""
+#~ "Este es el contenido del archivo '/etc/ksmbd/smb.conf.template' a partir "
+#~ "del cual se generará su configuración de samba. Los valores encerrados "
+#~ "por símbolos de tubería ('|') no deben cambiarse. Obtienen sus valores de "
+#~ "la pestaña 'Configuración general'."

--- a/applications/luci-app-ksmbd/po/fr/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/fr/ksmbd.po
@@ -10,20 +10,30 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Autoriser les invités"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Utilisateurs autorisés"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 #, fuzzy
 msgid "Browse-able"
 msgstr "Autorisé à parcourir"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Créer un masque"
 
@@ -31,7 +41,7 @@ msgstr "Créer un masque"
 msgid "Description"
 msgstr "Description"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Masque de répertoire"
 
@@ -39,13 +49,13 @@ msgstr "Masque de répertoire"
 msgid "Edit Template"
 msgstr "Modifier le modèle"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 "Modifier le modèle qui est utilisé pour la génération de a configuration de "
 "ksmbd."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Forcer le Root"
 
@@ -53,11 +63,11 @@ msgstr "Forcer le Root"
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Masquer les fichiers dot/cachés"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Hériter du propriétaire"
 
@@ -78,11 +88,11 @@ msgstr "Nom"
 msgid "Network Shares"
 msgstr "Partages réseau"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Chemin"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -90,15 +100,15 @@ msgstr ""
 "Veuillez ajouter des répertoires à partager. Chaque répertoire fait "
 "référence à un dossier sur un périphérique monté."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Lecture seule"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Répertoires partagés"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/he/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/he/ksmbd.po
@@ -4,19 +4,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -24,7 +34,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -32,11 +42,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -44,11 +54,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -60,7 +70,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -69,25 +79,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/hi/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/hi/ksmbd.po
@@ -4,19 +4,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -24,7 +34,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -32,11 +42,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -44,11 +54,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -60,7 +70,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -69,25 +79,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/hu/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/hu/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Vendégek engedélyezése"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Engedélyezett felhasználók"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Tallózható"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Létrehozási maszk"
 
@@ -30,7 +40,7 @@ msgstr "Létrehozási maszk"
 msgid "Description"
 msgstr "Leírás"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Könyvtármaszk"
 
@@ -38,13 +48,13 @@ msgstr "Könyvtármaszk"
 msgid "Edit Template"
 msgstr "Sablon szerkesztése"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 "A sablon szerkesztése, amely az ksmbd beállítások előállításához lesz "
 "használva."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Rendszergazda kényszerítése"
 
@@ -52,11 +62,11 @@ msgstr "Rendszergazda kényszerítése"
 msgid "General Settings"
 msgstr "Általános beállítások"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Rejtett fájlok elrejtése"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Tulajdonos öröklése"
 
@@ -69,7 +79,7 @@ msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 "Figyelés csak a megadott csatolón, vagy a helyi hálózaton, ha nincs megadva"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Név"
 
@@ -78,11 +88,11 @@ msgstr "Név"
 msgid "Network Shares"
 msgstr "Hálózati megosztások"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Útvonal"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -90,15 +100,15 @@ msgstr ""
 "Adja hozzá a megosztandó könyvtárakat. Minden egyes könyvtár egy csatolt "
 "eszközön lévő mappára hivatkozik."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Csak olvasható"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Megosztott könyvtárak"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/it/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/it/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -30,7 +40,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -38,11 +48,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Nome"
 
@@ -75,25 +85,25 @@ msgstr "Nome"
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/ko/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/ko/ksmbd.po
@@ -4,19 +4,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -24,7 +34,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -32,11 +42,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -44,11 +54,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -60,7 +70,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -69,25 +79,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/mr/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/mr/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "अतिथींना परवानगी द्या"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "अनुमत वापरकर्ते"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "ब्राउझ-सक्षम"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "मुखवटा तयार करा"
 
@@ -30,7 +40,7 @@ msgstr "मुखवटा तयार करा"
 msgid "Description"
 msgstr "वर्णन"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "निर्देशिका मास्क"
 
@@ -38,11 +48,11 @@ msgstr "निर्देशिका मास्क"
 msgid "Edit Template"
 msgstr "टेम्पलेट संपादित करा"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr "ksmbd कॉन्फिगरेशन व्युत्पन्न करण्यासाठी वापरला जाणारा टेम्पलेट संपादित करा."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "सक्ती रूट"
 
@@ -50,11 +60,11 @@ msgstr "सक्ती रूट"
 msgid "General Settings"
 msgstr "सामान्य सेटिंग्ज"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "डॉट फायली लपवा"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "वारसा मालकी मिळवा"
 
@@ -66,7 +76,7 @@ msgstr "इंटरफेस"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "केवळ दिलेल्या इंटरफेसवर किंवा, अनिर्दिष्ट असल्यास, लॅनवर ऐका"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "नाव"
 
@@ -75,11 +85,11 @@ msgstr "नाव"
 msgid "Network Shares"
 msgstr "नेटवर्क शेअर्स"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "पथ"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -87,15 +97,15 @@ msgstr ""
 "कृपया सामायिक करण्यासाठी निर्देशिका जोडा. प्रत्येक निर्देशिका माउंट केलेल्या डिव्हाइसवरील "
 "फोल्डरचा संदर्भ देते."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "केवळ-वाचनीय"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "सामायिक निर्देशिका"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/ms/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/ms/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -30,7 +40,7 @@ msgstr ""
 msgid "Description"
 msgstr "Keterangan"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -38,11 +48,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -75,25 +85,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/nb_NO/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/nb_NO/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -30,7 +40,7 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -38,11 +48,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -75,25 +85,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/pl/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/pl/ksmbd.po
@@ -11,19 +11,29 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Zezwól gościom"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Użytkownicy z prawem dostępu"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Możliwe do przeglądania"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Utwórz maskę"
 
@@ -31,7 +41,7 @@ msgstr "Utwórz maskę"
 msgid "Description"
 msgstr "Opis"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Maska katalogu"
 
@@ -39,11 +49,11 @@ msgstr "Maska katalogu"
 msgid "Edit Template"
 msgstr "Edytuj szablon"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr "Edytuj szablon, który jest używany do generowania konfiguracji ksmbd."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Wymuszanie Roota"
 
@@ -51,11 +61,11 @@ msgstr "Wymuszanie Roota"
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Ukryj pliki zaczynające się od kropki"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Właściciel spadku"
 
@@ -67,7 +77,7 @@ msgstr "Interfejs"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "Słuchaj tylko na podanym interfejsie, lub jeśli nie podano na LANie"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Nazwa"
 
@@ -76,11 +86,11 @@ msgstr "Nazwa"
 msgid "Network Shares"
 msgstr "Udziały sieciowe"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Ścieżka"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -88,15 +98,15 @@ msgstr ""
 "Proszę dodać katalogi do udostępnienia. Każdy katalog odnosi się do folderu "
 "w zamontowanym urządzeniu."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Tylko do odczytu"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Udostępniane katalogi"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/pt/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/pt/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Permitir Convidados"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Utilizadores Permitidos"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Navegável"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Criar máscara"
 
@@ -30,7 +40,7 @@ msgstr "Criar máscara"
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Máscara do diretório"
 
@@ -38,11 +48,11 @@ msgstr "Máscara do diretório"
 msgid "Edit Template"
 msgstr "Editar Modelo"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr "Editar o modelo que é usado para gerar a configuração ksmbd."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Forçar Root"
 
@@ -50,11 +60,11 @@ msgstr "Forçar Root"
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Ocultar ficheiros de ponto"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Herdar proprietário"
 
@@ -66,7 +76,7 @@ msgstr "Interface"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "Ouvir apenas na interface indicada ou, se não especificado, na LAN"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Nome"
 
@@ -75,11 +85,11 @@ msgstr "Nome"
 msgid "Network Shares"
 msgstr "Partilhas da Rede"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Caminho"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -87,15 +97,15 @@ msgstr ""
 "Por favor, adicione diretórios para compartilhar. Cada diretório refere-se a "
 "uma pasta num aparelho montado."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Apenas Leitura"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Directórios Partilhados"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/pt_BR/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/pt_BR/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Permitir convidados"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Usuários permitidos"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Navegável"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Máscara de criação"
 
@@ -30,7 +40,7 @@ msgstr "Máscara de criação"
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Máscara do diretório"
 
@@ -38,11 +48,11 @@ msgstr "Máscara do diretório"
 msgid "Edit Template"
 msgstr "Editar modelo"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr "Edita o modelo que é usado para gerar a configuração ksmbd."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Forçar Usuário Root"
 
@@ -50,11 +60,11 @@ msgstr "Forçar Usuário Root"
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr "Ocultar arquivos-ponto (dotfiles)"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Herdar o dono"
 
@@ -67,7 +77,7 @@ msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 "Ouvir apenas na interface fornecida ou, se não for especificado, na LAN"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Nome"
 
@@ -76,11 +86,11 @@ msgstr "Nome"
 msgid "Network Shares"
 msgstr "Compartilhamentos de Rede"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Caminho"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -88,15 +98,15 @@ msgstr ""
 "Por favor, adicione diretórios para compartilhar. Cada diretório refere-se a "
 "uma pasta em um dispositivo montado."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Somente leitura"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Diretórios Compartilhados"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/ro/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/ro/ksmbd.po
@@ -11,19 +11,29 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10.1\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -31,7 +41,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descriere"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -39,11 +49,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -51,11 +61,11 @@ msgstr ""
 msgid "General Settings"
 msgstr "Setări principale"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -67,7 +77,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -76,25 +86,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/ru/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/ru/ksmbd.po
@@ -11,19 +11,29 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10.1\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Разрешить гостевой вход"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Разрешенные пользователи"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Создать маску"
 
@@ -31,7 +41,7 @@ msgstr "Создать маску"
 msgid "Description"
 msgstr "Описание"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Маска папок"
 
@@ -39,11 +49,11 @@ msgstr "Маска папок"
 msgid "Edit Template"
 msgstr "Настройка шаблона"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -51,11 +61,11 @@ msgstr ""
 msgid "General Settings"
 msgstr "Основные настройки"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -67,7 +77,7 @@ msgstr "Интерфейс"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Имя"
 
@@ -76,11 +86,11 @@ msgstr "Имя"
 msgid "Network Shares"
 msgstr "Сетевые ресурсы"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Путь"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -88,15 +98,15 @@ msgstr ""
 "Добавьте папки для совместного доступа. Каждая папка - соответствует разделу "
 "на подключенном устройстве."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Только для чтения"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Совместно используемые папки"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/sk/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/sk/ksmbd.po
@@ -8,19 +8,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -28,7 +38,7 @@ msgstr ""
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -36,11 +46,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -48,11 +58,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -64,7 +74,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -73,25 +83,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/sv/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/sv/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Tillåt gäster"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Tillåtna användare"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Skapa mask"
 
@@ -30,7 +40,7 @@ msgstr "Skapa mask"
 msgid "Description"
 msgstr "Beskrivning"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Mask för mapp"
 
@@ -38,11 +48,11 @@ msgstr "Mask för mapp"
 msgid "Edit Template"
 msgstr "Redigera mall"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr "Gränssnitt"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Namn"
 
@@ -75,25 +85,25 @@ msgstr "Namn"
 msgid "Network Shares"
 msgstr "Nätverksdelningar"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Genväg"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Endast läsbar"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Delade mappar"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/templates/ksmbd.pot
+++ b/applications/luci-app-ksmbd/po/templates/ksmbd.pot
@@ -1,19 +1,29 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -21,7 +31,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -29,11 +39,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -41,11 +51,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -57,7 +67,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -66,25 +76,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/tr/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/tr/ksmbd.po
@@ -4,19 +4,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -24,7 +34,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -32,11 +42,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -44,11 +54,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -60,7 +70,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -69,25 +79,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/uk/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/uk/ksmbd.po
@@ -11,19 +11,29 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "Дозволити гостьовий вхід"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "Дозволені користувачі"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "Дост. для перегл."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "Створити маску"
 
@@ -31,7 +41,7 @@ msgstr "Створити маску"
 msgid "Description"
 msgstr "Опис"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "Маска каталогу"
 
@@ -39,11 +49,11 @@ msgstr "Маска каталогу"
 msgid "Edit Template"
 msgstr "Редагувати шаблон"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "Примусово Root"
 
@@ -51,11 +61,11 @@ msgstr "Примусово Root"
 msgid "General Settings"
 msgstr "Загальні параметри"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "Успадковувати власника"
 
@@ -69,7 +79,7 @@ msgstr ""
 "Прослуховувати тільки на цьому інтерфейсі, якщо <em>не визначено</em> – на "
 "всіх"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "Ім'я"
 
@@ -78,11 +88,11 @@ msgstr "Ім'я"
 msgid "Network Shares"
 msgstr "Спільні мережеві ресурси"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "Шлях"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -90,15 +100,15 @@ msgstr ""
 "Додайте каталоги для спільного доступу. Кожен каталог посилається на папку "
 "на підключеному пристрої."
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "Тільки читання"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "Спільні каталоги"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/vi/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/vi/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -30,7 +40,7 @@ msgstr ""
 msgid "Description"
 msgstr "Mô tả"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -38,11 +48,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -75,25 +85,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/zh_Hans/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/zh_Hans/ksmbd.po
@@ -13,19 +13,29 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr "允许匿名用户"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr "允许用户"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr "可浏览"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr "创建权限掩码"
 
@@ -33,7 +43,7 @@ msgstr "创建权限掩码"
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr "目录权限掩码"
 
@@ -41,11 +51,11 @@ msgstr "目录权限掩码"
 msgid "Edit Template"
 msgstr "编辑模板"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr "编辑用来生成 ksmbd 设置的模板。"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr "强制 Root"
 
@@ -53,11 +63,11 @@ msgstr "强制 Root"
 msgid "General Settings"
 msgstr "基本设置"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr "继承所有者"
 
@@ -69,7 +79,7 @@ msgstr "接口"
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "仅监听指定的接口，未指定则监听 lan"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr "名称"
 
@@ -78,25 +88,25 @@ msgstr "名称"
 msgid "Network Shares"
 msgstr "网络共享"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr "目录"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr "请添加要共享的目录。每个目录指到已挂载设备上的文件夹。"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr "只读"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr "共享目录"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/po/zh_Hant/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/zh_Hant/ksmbd.po
@@ -10,19 +10,29 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:85
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:79
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:42
+msgid "Allow legacy (insecure) protocols/authentication."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+msgid ""
+"Allow legacy smb(v1)/Lanman connections, needed for older devices without "
+"smb(v2.1/3) support."
+msgstr ""
+
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:82
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:69
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:98
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:101
 msgid "Create mask"
 msgstr ""
 
@@ -30,7 +40,7 @@ msgstr ""
 msgid "Description"
 msgstr "說明"
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:104
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:107
 msgid "Directory mask"
 msgstr ""
 
@@ -38,11 +48,11 @@ msgstr ""
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:43
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:46
 msgid "Edit the template that is used for generating the ksmbd configuration."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:77
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:80
 msgid "Force Root"
 msgstr ""
 
@@ -50,11 +60,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:93
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:96
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:88
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:91
 msgid "Inherit owner"
 msgstr ""
 
@@ -66,7 +76,7 @@ msgstr ""
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:60
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:63
 msgid "Name"
 msgstr ""
 
@@ -75,25 +85,25 @@ msgstr ""
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:64
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:56
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:59
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:71
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:74
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:55
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:58
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:44
+#: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:47
 msgid ""
 "This is the content of the file '/etc/ksmbd/smb.conf.template' from which "
 "your ksmbd configuration will be generated. Values enclosed by pipe symbols "

--- a/applications/luci-app-ksmbd/root/usr/share/rpcd/acl.d/luci-app-ksmbd.json
+++ b/applications/luci-app-ksmbd/root/usr/share/rpcd/acl.d/luci-app-ksmbd.json
@@ -4,7 +4,7 @@
 		"read": {
 			"file": {
 				"/etc/ksmbd/smb.conf.template": [ "read" ],
-				"/usr/sbin/usmbd": [ "exec" ],
+				"/usr/sbin/ksmbd.mountd": [ "exec" ],
 				"/sbin/modinfo": [ "exec" ]
 			}
 		},


### PR DESCRIPTION
* support new UCI option "allow_legacy_protocols"
* update for 3.2.1 version (usmbd -> ksmbd.mountd)

Depends on: openwrt/packages#11297