### PR TITLE
luci-app-wol: use uci etherwake default interface

### DIFF
--- a/applications/luci-app-wol/htdocs/luci-static/resources/view/wol.js
+++ b/applications/luci-app-wol/htdocs/luci-static/resources/view/wol.js
@@ -1,4 +1,5 @@
 'use strict';
+'require uci';
 'require fs';
 'require ui';
 'require rpc';
@@ -18,7 +19,8 @@ return L.view.extend({
 		return Promise.all([
 			L.resolveDefault(fs.stat('/usr/bin/etherwake')),
 			L.resolveDefault(fs.stat('/usr/bin/wol')),
-			this.callHostHints()
+			this.callHostHints(),
+			uci.load('etherwake')
 		]);
 	},
 
@@ -48,6 +50,7 @@ return L.view.extend({
 			o = s.option(widgets.DeviceSelect, 'iface', _('Network interface to use'),
 				_('Specifies the interface the WoL packet is sent on'));
 
+			o.default = uci.get('etherwake', 'setup', 'interface');
 			o.rmempty = false;
 			o.noaliases = true;
 			o.noinactive = true;


### PR DESCRIPTION
Use uci config 'etherwake.setup.interface' to default WOL interface
selection.

On some devices the lan interface is not the first item in the drop down
interface selection list.  Configuring this parameter allows the user to
set a preferred interface to be used/selected.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>