### PR TITLE
luci-mod-system: add led plugin infrastructure

### DIFF
--- a/applications/luci-app-ledtrig-rssi/Makefile
+++ b/applications/luci-app-ledtrig-rssi/Makefile
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2020 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the Apache License Version 2.0.
+# See https://www.apache.org/licenses/LICENSE-2.0 for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:= LuCI Support for ledtrigger rssi
+LUCI_DEPENDS:=+rssileds
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-rssi/htdocs/luci-static/resources/view/system/led-trigger/rssi.js
+++ b/applications/luci-app-ledtrig-rssi/htdocs/luci-static/resources/view/system/led-trigger/rssi.js
@@ -1,0 +1,38 @@
+'use strict';
+'require form';
+'require tools.widgets as widgets';
+
+return L.Class.extend({
+	trigger: _('rssi (service)'),
+	kernel: false,
+	addFormOptions(s){
+		var o;
+
+		o = s.option(widgets.DeviceSelect, '_rssi_iface', _('Device'));
+		o.rmempty = true;
+		o.ucioption = 'iface';
+		o.modalonly = true;
+		o.noaliases = true;
+		o.depends('trigger', 'rssi');
+
+		o = s.option(form.Value, 'minq', _('Minimal quality'));
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('trigger', 'rssi');
+
+		o = s.option(form.Value, 'maxq', _('Maximal quality'));
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('trigger', 'rssi');
+
+		o = s.option(form.Value, 'offset', _('Value offset'));
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('trigger', 'rssi');
+
+		o = s.option(form.Value, 'factor', _('Multiplication factor'));
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('trigger', 'rssi');
+	}
+});

--- a/applications/luci-app-ledtrig-switch/Makefile
+++ b/applications/luci-app-ledtrig-switch/Makefile
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2020 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the Apache License Version 2.0.
+# See https://www.apache.org/licenses/LICENSE-2.0 for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:= LuCI Support for ledtrigger switch
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch0.js
+++ b/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch0.js
@@ -1,0 +1,18 @@
+'use strict';
+'require form';
+
+return L.Class.extend({
+	trigger: _('switch0 (kernel)'),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+
+		o = s.option(form.Value, 'port_mask', _('Switch Port Mask'));
+		o.modalonly = true;
+		o.depends('trigger', 'switch0');
+
+		o = s.option(form.Value, 'speed_mask', _('Switch Speed Mask'));
+		o.modalonly = true;
+		o.depends('trigger', 'switch0');
+	}
+});

--- a/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch1.js
+++ b/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch1.js
@@ -1,0 +1,18 @@
+'use strict';
+'require form';
+
+return L.Class.extend({
+	trigger: _('switch1 (kernel)'),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+
+		o = s.option(form.Value, 'port_mask', _('Switch Port Mask'));
+		o.modalonly = true;
+		o.depends('trigger', 'switch1');
+
+		o = s.option(form.Value, 'speed_mask', _('Switch Speed Mask'));
+		o.modalonly = true;
+		o.depends('trigger', 'switch1');
+	}
+});

--- a/applications/luci-app-ledtrig-usbport/Makefile
+++ b/applications/luci-app-ledtrig-usbport/Makefile
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2020 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the Apache License Version 2.0.
+# See https://www.apache.org/licenses/LICENSE-2.0 for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:= LuCI Support for ledtrigger usbport
+LUCI_DEPENDS:=+kmod-usb-ledtrig-usbport
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-usbport/htdocs/luci-static/resources/view/system/led-trigger/usbport.js
+++ b/applications/luci-app-ledtrig-usbport/htdocs/luci-static/resources/view/system/led-trigger/usbport.js
@@ -1,0 +1,46 @@
+'use strict';
+'require rpc';
+'require uci';
+'require form';
+
+var callUSB = rpc.declare({
+	object: 'luci',
+	method: 'getUSBDevices',
+	expect: { 'ports': [] }
+});
+
+return L.Class.extend({
+	trigger: _('usbport (kernel)'),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+
+		o = s.option(form.Value, 'port', _('USB Ports'));
+		o.depends('trigger', 'usbport');
+		o.rmempty = true;
+		o.modalonly = true;
+		o.load = function(s) {
+			return Promise.all([
+				callUSB()
+			]).then(L.bind(function(usbport){
+				for (var i = 0; i < usbport[0].length; i++)
+					o.value(usbport[0][i].port, _('Port %s').format(usbport[0][i].port));
+			},this));
+		};
+		o.cfgvalue = function(section_id) {
+			var ports = [],
+				value = uci.get('system', section_id, 'port');
+
+			if (!Array.isArray(value))
+				value = String(value || '').split(/\s+/);
+
+			for (var i = 0; i < value.length; i++)
+				if (value[i].match(/^(\d+)-(\d+)$/))
+					ports.push('usb%d-port%d'.format(Regexp.$1, Regexp.$2));
+				else
+					ports.push(value[i]);
+
+			return ports;
+		};
+	}
+});

--- a/modules/luci-mod-system/Makefile
+++ b/modules/luci-mod-system/Makefile
@@ -7,7 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Administration - Global System Settings
-LUCI_DEPENDS:=+luci-base
+LUCI_DEPENDS:=+luci-base \
+	+kmod-ledtrig-default-on \
+	+kmod-ledtrig-heartbeat \
+	+kmod-ledtrig-netdev \
+	+kmod-ledtrig-timer
 
 PKG_LICENSE:=Apache-2.0
 

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/default-on.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/default-on.js
@@ -1,0 +1,20 @@
+'use strict';
+'require form';
+
+return L.Class.extend({
+	trigger: _('default-on (kernel)'),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+
+		o = s.option(form.Flag, 'default', _('Default state'));
+		o.rmempty = false;
+		o.depends('trigger', 'default-on');
+		o.textvalue = function(section_id) {
+			var cval = this.cfgvalue(section_id);
+			if (cval == null)
+				cval = this.default;
+			return (cval == this.enabled) ? _('On') : _('Off');
+		};
+	}
+});

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/heartbeat.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/heartbeat.js
@@ -1,0 +1,9 @@
+'use strict';
+
+return L.Class.extend({
+	trigger: _('heartbeat (kernel)'),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+	}
+});

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/netdev.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/netdev.js
@@ -1,0 +1,26 @@
+'use strict';
+'require form';
+'require tools.widgets as widgets';
+
+return L.Class.extend({
+	trigger: _("netdev (kernel)"),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+
+		o = s.option(widgets.DeviceSelect, '_net_dev', _('Device'));
+		o.rmempty = true;
+		o.ucioption = 'dev';
+		o.modalonly = true;
+		o.noaliases = true;
+		o.depends('trigger', 'netdev');
+
+		o = s.option(form.MultiValue, 'mode', _('Trigger Mode'));
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('trigger', 'netdev');
+		o.value('link', _('Link On'));
+		o.value('tx', _('Transmit'));
+		o.value('rx', _('Receive'));
+	}
+});

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/none.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/none.js
@@ -1,0 +1,9 @@
+'use strict';
+
+return L.Class.extend({
+	trigger: _('none (kernel)'),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+	}
+});

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js
@@ -1,0 +1,18 @@
+'use strict';
+'require form';
+
+return L.Class.extend({
+	trigger: _('timer (kernel)'),
+	kernel: true,
+	addFormOptions(s){
+		var o;
+
+		o = s.option(form.Value, 'delayon', _('On-State Delay'));
+		o.modalonly = true;
+		o.depends('trigger', 'timer');
+
+		o = s.option(form.Value, 'delayoff', _('Off-State Delay'));
+		o.modalonly = true;
+		o.depends('trigger', 'timer');
+	}
+});


### PR DESCRIPTION
This pullrequest is intended to create the possibility that not only kernel-led-triggers can be selected but also application-led-triggers from user space. This is done via a plugin mechanism.
Application-led-triggers are scripts that set LEDs on system events or services (for example the package rssileds service). Until now this has not been possible

The following new packages are added:

- luci-app-ledtrig-rssi (application-led-trigger) 
- luci-app-ledtrig-switch (kernel-led-trigger) not needed on every most devices
- luci-app-ledtrig-usport (kernel-led-trigger) optional trigger

Since we have now a plugin mechanism I have added the following triggers as a dependency. So this triggers are now installed per default on LuCI installation.

- kmod-ledtrig-default-on
- kmod-ledtrig-heartbeat
- kmod-ledtrig-netdev
- kome-ledtrig-timer

The kernel trigger `kmod-ledtrig-usbdev` was removed with the commit https://github.com/openwrt/openwrt/commit/d0b50c2770a0e2d54b37153f2801e2e7dc865fa6. So I have not ported the relevant code anymore.

If we do not want to get a warning on /etc/init.d/led restart if we select an application-led-trigger the following commit should also get commit in openwrt https://github.com/openwrt/openwrt/pull/2741
