### PR TITLE
luci-app-snmpd: Add snmpd as dependency

### DIFF
--- a/applications/luci-app-snmpd/Makefile
+++ b/applications/luci-app-snmpd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:= Net-SNMP LuCI interface
-LUCI_DEPENDS:=+luci-compat +luci-base
+LUCI_DEPENDS:=+luci-compat +luci-base +snmpd
 LUCI_PKGARCH:=all
 LUCI_DESCRIPTION:=Some common net-snmp config items. In no way is this comprehensive.
 


### PR DESCRIPTION
luci-app-snmpd allows to configure snmpd via LuCI. Without making sure that
the snmpd package is installed, the daemon that is about to be configured via
luci-app-snmpd might be missing (unless explicitly installed otherwise).

This is not only counter-intuitive, but also inconsistent with other LuCI based
applications, as they always include the underlying package(s) in order to make
sure that the software being configured is being available in the first place.