### PR TITLE
luci-base: Add missed config parameter for cbi when converting to JSON

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -193,7 +193,8 @@ local function target_to_json(target, module)
 	elseif target.type == "cbi" then
 		action = {
 			["type"] = "cbi",
-			["path"] = target.model
+			["path"] = target.model,
+			["config"] = target.config
 		}
 	elseif target.type == "form" then
 		action = {


### PR DESCRIPTION
The cbi() function has a second argument 'config' in which various
configuration parameters can be passed. When converting the lua menu
to JSON, we must also convert this parameter.

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>