### PR TITLE
luci-app-ddns: fix update interval unit values in combobox

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -852,7 +852,7 @@ return L.view.extend({
 		o.default  = "minutes"
 		o.value("minutes", _("minutes"));
 		o.value("hours", _("hours"));
-		o.value("hours", _("days"));
+		o.value("days", _("days"));
 
 		// retry_count
 


### PR DESCRIPTION
Value "hours" is used twice instead of "hours" and "days".

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>