### PR TITLE
luci-app-yggdrasil: fix listen uri type and remove tap for v3.13

### DIFF
--- a/applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/settings.js
+++ b/applications/luci-app-yggdrasil/htdocs/luci-static/resources/view/yggdrasil/settings.js
@@ -33,7 +33,6 @@ return L.view.extend({
 			try { JSON.parse(v); return true; } catch (e) { return e.message; }
 		}
 
-		s.option(form.Flag, "IfTAPMode", _("Enable tap mode"));
 		s.option(form.Value, "IfMTU", _("MTU size for the interface"));
 		s.option(form.Value, "SwitchOptions_MaxTotalQueueSize", 
 			_("Maximum size of all switch queues combined"));
@@ -53,8 +52,8 @@ return L.view.extend({
 				"Multicast peer discovery will work regardless of any listeners set " +
 				"here. Each listener should be specified in URI format as above, e.g. " +
 				"tcp://0.0.0.0:0 or tcp://[::]:0 to listen on all interfaces."));
-		o.option(form.Value, "address", 
 			_("Address to listen for incoming connections"), 
+		o.option(form.Value, "uri",
 			_("e.g. tcp://0.0.0.0:0 or tcp://[::]:0"));
 		o.anonymous = true;
 		o.addremove = true;


### PR DESCRIPTION
Tested against yggdrasil v3.12-develop (v3.13) / APU2 x86_64 (next release expected tomorrow)
uri is required, using address was omitting listen address for: `ygguci get`   
tap interface support is removed in v3.13

do we need to update translation maps file now? 

