### PR TITLE
luci-lib-nixio: allow building with Lua5.2/LuaJIT

### DIFF
--- a/libs/luci-lib-nixio/src/address.c
+++ b/libs/luci-lib-nixio/src/address.c
@@ -544,7 +544,7 @@ static int nixio_getifaddrs(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #if defined(__linux__) || defined(BSD)
 	{"getifaddrs",	nixio_getifaddrs},
 #endif
@@ -554,7 +554,7 @@ static const luaL_reg R[] = {
 };
 
 /* object table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"getsockname",	nixio_sock_getsockname},
 	{"getpeername",	nixio_sock_getpeername},
 	{NULL,			NULL}

--- a/libs/luci-lib-nixio/src/binary.c
+++ b/libs/luci-lib-nixio/src/binary.c
@@ -296,7 +296,7 @@ static int nixio_bin_b64decode(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"hexlify",		nixio_bin_hexlify},
 	{"unhexlify",	nixio_bin_unhexlify},
 	{"crc32",		nixio_bin_crc32},

--- a/libs/luci-lib-nixio/src/bind.c
+++ b/libs/luci-lib-nixio/src/bind.c
@@ -269,14 +269,14 @@ static int nixio_sock_accept(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"bind",		nixio_bind},
 	{"connect",		nixio_connect},
 	{NULL,			NULL}
 };
 
 /* object table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"bind",		nixio_sock_bind},
 	{"connect",		nixio_sock_connect},
 	{"listen",		nixio_sock_listen},

--- a/libs/luci-lib-nixio/src/bit.c
+++ b/libs/luci-lib-nixio/src/bit.c
@@ -120,7 +120,7 @@ static int nixio_bit_swap(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"bor",			nixio_bit_or},
 	{"set",			nixio_bit_or},
 	{"band",		nixio_bit_and},

--- a/libs/luci-lib-nixio/src/file.c
+++ b/libs/luci-lib-nixio/src/file.c
@@ -379,7 +379,7 @@ static int nixio_file__tostring(lua_State *L) {
 }
 
 /* method table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"write",		nixio_file_write},
 	{"read",		nixio_file_read},
 	{"tell",		nixio_file_tell},
@@ -394,7 +394,7 @@ static const luaL_reg M[] = {
 };
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"dup",			nixio_dup},
 	{"open",		nixio_open},
 	{"open_flags",	nixio_open_flags},

--- a/libs/luci-lib-nixio/src/fs.c
+++ b/libs/luci-lib-nixio/src/fs.c
@@ -519,7 +519,7 @@ static int nixio_statvfs(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #ifndef __WINNT__
 	{"glob",		nixio_glob},
 	{"mkfifo",		nixio_mkfifo},

--- a/libs/luci-lib-nixio/src/io.c
+++ b/libs/luci-lib-nixio/src/io.c
@@ -208,7 +208,7 @@ static int nixio_sock_recvfrom(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"send",	nixio_sock_send},
 	{"sendto",	nixio_sock_sendto},
 	{"recv",	nixio_sock_recv},

--- a/libs/luci-lib-nixio/src/nixio.c
+++ b/libs/luci-lib-nixio/src/nixio.c
@@ -102,7 +102,7 @@ static int nixio_strerror(lua_State *L) {
 }
 
 /* object table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"errno",		nixio_errno},
 	{"strerror",	nixio_strerror},
 	{NULL,			NULL}

--- a/libs/luci-lib-nixio/src/nixio.h
+++ b/libs/luci-lib-nixio/src/nixio.h
@@ -21,6 +21,10 @@
 #include <lauxlib.h>
 #include <luaconf.h>
 
+#if LUA_VERSION_NUM < 501
+#define luaL_Reg luaL_reg
+#endif
+
 #define NIXIO_BUFFERSIZE 8192
 
 typedef struct nixio_socket {

--- a/libs/luci-lib-nixio/src/poll.c
+++ b/libs/luci-lib-nixio/src/poll.c
@@ -197,7 +197,7 @@ static int nixio_poll(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"gettimeofday", nixio_gettimeofday},
 	{"nanosleep",	nixio_nanosleep},
 	{"poll",		nixio_poll},

--- a/libs/luci-lib-nixio/src/process.c
+++ b/libs/luci-lib-nixio/src/process.c
@@ -412,7 +412,7 @@ static int nixio_sysinfo(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #ifdef __linux__
 	{"sysinfo",		nixio_sysinfo},
 #endif

--- a/libs/luci-lib-nixio/src/protoent.c
+++ b/libs/luci-lib-nixio/src/protoent.c
@@ -91,7 +91,7 @@ static int nixio_getproto(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
     {"getprotobyname",		nixio_getprotobyname},
     {"getprotobynumber",	nixio_getprotobynumber},
     {"getproto",			nixio_getproto},

--- a/libs/luci-lib-nixio/src/socket.c
+++ b/libs/luci-lib-nixio/src/socket.c
@@ -150,13 +150,13 @@ static int nixio_sock_shutdown(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"socket",		nixio_socket},
 	{NULL,			NULL}
 };
 
 /* object table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"close",		nixio_sock_close},
 	{"shutdown",	nixio_sock_shutdown},
 	{"__gc",		nixio_sock__gc},

--- a/libs/luci-lib-nixio/src/sockopt.c
+++ b/libs/luci-lib-nixio/src/sockopt.c
@@ -366,7 +366,7 @@ static int nixio_sock_setsockopt(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"setblocking", nixio_sock_setblocking},
 	{"getsockopt",	nixio_sock_getsockopt},
 	{"setsockopt",	nixio_sock_setsockopt},

--- a/libs/luci-lib-nixio/src/splice.c
+++ b/libs/luci-lib-nixio/src/splice.c
@@ -161,7 +161,7 @@ static int nixio_sendfile(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #ifdef _GNU_SOURCE
 #ifdef SPLICE_F_MOVE
 	{"splice",			nixio_splice},

--- a/libs/luci-lib-nixio/src/syslog.c
+++ b/libs/luci-lib-nixio/src/syslog.c
@@ -102,7 +102,7 @@ static int nixio_syslog(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"openlog",		nixio_openlog},
 	{"syslog",		nixio_syslog},
 	{"setlogmask",	nixio_setlogmask},

--- a/libs/luci-lib-nixio/src/tls-context.c
+++ b/libs/luci-lib-nixio/src/tls-context.c
@@ -203,13 +203,13 @@ static int nixio_tls_ctx__tostring(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"tls",		nixio_tls_ctx},
 	{NULL,			NULL}
 };
 
 /* ctx function table */
-static const luaL_reg CTX_M[] = {
+static const luaL_Reg CTX_M[] = {
 	{"set_cert",			nixio_tls_ctx_set_cert},
 	{"set_verify_locations",       nixio_tls_ctx_set_verify_locations},
 	{"set_key",				nixio_tls_ctx_set_key},

--- a/libs/luci-lib-nixio/src/tls-crypto.c
+++ b/libs/luci-lib-nixio/src/tls-crypto.c
@@ -154,14 +154,14 @@ static int nixio_crypto_hash__tostring(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"hash",		nixio_crypto_hash},
 	{"hmac",		nixio_crypto_hmac},
 	{NULL,			NULL}
 };
 
 /* hash table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"update",		nixio_crypto_hash_update},
 	{"final",		nixio_crypto_hash_final},
 	{"__gc",		nixio_crypto_hash__gc},

--- a/libs/luci-lib-nixio/src/tls-socket.c
+++ b/libs/luci-lib-nixio/src/tls-socket.c
@@ -239,7 +239,7 @@ static int nixio_tls_sock__tostring(lua_State *L) {
 
 
 /* ctx function table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"recv", 		nixio_tls_sock_recv},
 	{"send", 		nixio_tls_sock_send},
 	{"read", 		nixio_tls_sock_recv},

--- a/libs/luci-lib-nixio/src/user.c
+++ b/libs/luci-lib-nixio/src/user.c
@@ -238,7 +238,7 @@ static int nixio_crypt(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"crypt",		nixio_crypt},
 	{"getgr",		nixio_getgr},
 	{"getpw",		nixio_getpw},
@@ -252,7 +252,7 @@ static const luaL_reg R[] = {
 
 #else /* __WINNT__ */
 
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 		{NULL,			NULL}
 };
 


### PR DESCRIPTION
Lua 5.1 defines a "luaL_Reg" alias for deprecated
"luaL_reg", but Lua >= 5.2 and LuaJIT do not.
Replace by "luaL_Reg", and define a "luaL_reg"
alias in case we build with old Lua 5.0.

Signed-off-by: Manuel BACHMANN <tarnyko@tarnyko.net>