### PR TITLE
luci-app-aria2: fix incorrect "Extra Settings" section option name

### DIFF
--- a/applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua
+++ b/applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua
@@ -484,7 +484,7 @@ s = m:section(NamedSection, "main", "aria2", translate("Extra Settings"),
 s.addremove = false
 s.anonymous = true
 
-o = s:option(DynamicList, "extra_setting", translate("Settings list"),
+o = s:option(DynamicList, "extra_settings", translate("Settings list"),
 	translate("List of extra settings. Format: option=value, eg. <code>netrc-path=/tmp/.netrc</code>."))
 o.placeholder = "option=value"
 

--- a/applications/luci-app-aria2/root/etc/uci-defaults/40_luci-aria2
+++ b/applications/luci-app-aria2/root/etc/uci-defaults/40_luci-aria2
@@ -9,7 +9,7 @@ if [ ."$(uci -q get aria2.main)" != ."aria2" ]; then
 		set aria2.main.config_dir="/var/etc/aria2"
 		add_list aria2.main.header=""
 		add_list aria2.main.bt_tracker=""
-		add_list aria2.main.extra_setting=""
+		add_list aria2.main.extra_settings=""
 		commit aria2
 	EOF
 fi


### PR DESCRIPTION
The "Extra Settings" section `extra_setting` option name does not match what the `net/aria2` package expects: `extra_settings`. 

See:

- https://github.com/openwrt/packages/blob/openwrt-19.07/net/aria2/files/aria2.init#L311
- https://github.com/openwrt/packages/blob/openwrt-19.07/net/aria2/files/aria2.conf#L31

Causing the luci UI "Extra Settings" option to have **no effect**. This fix renames `extra_setting` => `extra_settings`