### PR TITLE
luci-app-adblock query form: Fix enter key submitting form but not showing any results

### DIFF
--- a/applications/luci-app-adblock/luasrc/view/adblock/query.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/query.htm
@@ -43,7 +43,7 @@ This is free software, licensed under the Apache License, Version 2.0
 //]]>
 </script>
 
-<form method="post" action="<%=REQUEST_URI%>">
+<form method="post" action="<%=REQUEST_URI%>" onsubmit="update_status(this.input); return false;">
 	<div class="cbi-map">
 		<div class="cbi-section">
 			<div class="cbi-section-descr"><%:This form allows you to query active block lists for certain domains, e.g. for whitelisting.%></div>


### PR DESCRIPTION
Right now you can hit the enter key while the input field is focused, and it submits the form, but no result is displayed. Even though a POST request is made, it doesn't seem to actually be querying the domain.

It might be nice to fix that too, so it would work for users that have JavaScript disabled. But I am not sure how to make that work, so if someone can provide help with that, that would be great.

Thanks!