### PR TITLE
luci-app-statistics: fix 'RRATimespan' option for rrdtool plugin

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/graphs.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/graphs.js
@@ -182,7 +182,7 @@ return L.view.extend({
 			}, [ host ])
 		}));
 
-		var spanSel = E('select', { 'style': 'max-width:170px', 'data-name': 'timespan' }, L.toArray(uci.get('luci_statistics', 'collectd_rrdtool', 'RRATimespans')).map(function(span) {
+		var spanSel = E('select', { 'style': 'max-width:170px', 'data-name': 'timespan' }, L.toArray(uci.get('luci_statistics', 'collectd_rrdtool', 'RRATimespan')).map(function(span) {
 			return E('option', {
 				'selected': (rrdtool.opts.timespan == span) ? 'selected' : null
 			}, [ span ])

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/rrdtool.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/rrdtool.js
@@ -34,7 +34,7 @@ return L.Class.extend({
 			_('Max values for a period can be used instead of averages when not using \'only average RRAs\''));
 		o.depends('RRASingle', '0');
 
-		o = s.option(form.DynamicList, 'RRATimespans', _('Stored timespans'));
+		o = s.option(form.DynamicList, 'RRATimespan', _('Stored timespans'));
 		o.default = '10min 1day 1week 1month 1year';
 		o.depends('enable', '1');
 		o.validate = function(section_id, value) {

--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -21,7 +21,7 @@ config statistics 'collectd_rrdtool'
 	option DataDir '/tmp/rrd'
 	option RRARows '100'
 	option RRASingle '1'
-	option RRATimespans '1hour 1day 1week 1month 1year'
+	option RRATimespan '1hour 1day 1week 1month 1year'
 
 config statistics 'collectd_csv'
 	option enable '0'

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -302,7 +302,7 @@ end
 
 
 preprocess = {
-	RRATimespans = function(val)
+	RRATimespan = function(val)
 		local rv = { }
 		for time in luci.util.imatch(val) do
 			table.insert( rv, luci.util.parse_units(time) )

--- a/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/rrdtool.json
+++ b/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/rrdtool.json
@@ -4,6 +4,6 @@
 	"legend": [
 		["DataDir", "StepSize", "HeartBeat", "RRARows", "XFF", "CacheFlush", "CacheTimeout"],
 		["RRASingle"],
-		["RRATimespans"]
+		["RRATimespan"]
 	]
 }


### PR DESCRIPTION
Collectd plugin rrdtool uses option 'RRATimespan' not 'RRATimespans' (see [sources](https://github.com/collectd/collectd/blob/f43dc9256efce4bd53d451115a23c584b5cda2d6/src/rrdtool.c#L62)).

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>