### PR TITLE
luci-app-statistics: conntrack: add percent usage graph

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/conntrack.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/conntrack.js
@@ -6,7 +6,7 @@ return L.Class.extend({
 	title: _('Conntrack'),
 
 	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
-		return {
+		var entries = {
 			title: "%H: Conntrack entries",
 			vlabel: "Count",
 			number_format: "%5.0lf",
@@ -26,5 +26,26 @@ return L.Class.extend({
 				}
 			}
 		};
+
+		var percent = {
+			title: "%H: Conntrack usage",
+			vlabel: "Percent",
+			number_format: "%5.1lf%%",
+			y_min: "0",
+			alt_autoscale_max: true,
+			data: {
+				instances: {
+					percent: [ "used" ]
+				},
+				options: {
+					percent_used: {
+						color: "00ff00",
+						title: "Used"
+					}
+				}
+			}
+		};
+
+		return [ entries, percent ];
 	}
 });


### PR DESCRIPTION
The existing graph shows a conntrack entry usage value but doesn't show
a conntrack table size figure so you don't know if you're close to
filling the table.  Add a percent usage graph to show conntrack table
percent used.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>