### PR TITLE
luci-base: extended network.js for check if new interface is createable

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -2298,6 +2298,23 @@ Protocol = L.Class.extend(/** @lends LuCI.Network.Protocol.prototype */ {
 	},
 
 	/**
+	 * Check function for the protocol handler if a new interface is createable.
+	 *
+	 * This function should be overwritten by protocol specific subclasses.
+	 *
+	 * @abstract
+	 *
+	 * @param {string} ifname
+	 * The name of the interface to be created.
+	 *
+	 * @returns {Promise<null|error message>}
+	 * Returns `null` if new interface is createable, else returns (error) message.
+	 */
+	isCreateable: function(ifname) {
+		return Promise.resolve(null);
+	},
+
+	/**
 	 * Checks whether the protocol functionality is installed.
 	 *
 	 * This function exists for compatibility with old code, it always


### PR DESCRIPTION
In some cases it could be needful to check whether a new interface can be created.
This extension allows proto handlers to implement such a functionality.

The result of this check can be evaluated in interfaces.js for example and the creation can be aborted with an error message.

The implementation in interfaces.js can be found at https://github.com/openwrt/luci/pull/3713