### PR TITLE
luci-app-wireguard: fix String.format is not a function

### DIFF
--- a/applications/luci-app-wireguard/luasrc/view/wireguard.htm
+++ b/applications/luci-app-wireguard/luasrc/view/wireguard.htm
@@ -66,6 +66,7 @@
 
 <%+header%>
 
+<script src="/luci-static/resources/cbi.js"></script>	
 <script type="text/javascript">//<![CDATA[
 
 	function bytes_to_str(bytes) {


### PR DESCRIPTION
Because of missing JS import page JS is crashing and dos not work.