### PR TITLE
luci-base: fix error 404 on missing relay protocol

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -106,7 +106,7 @@ function getProtocolHandlers(cache) {
 			Object.assign(protos, { none: { no_device: false } });
 
 		/* Hack: emulate relayd protocol */
-		if (!protos.hasOwnProperty('relay'))
+		if (!protos.hasOwnProperty('relay') && L.hasSystemFeature('relayd'))
 			Object.assign(protos, { relay: { no_device: true } });
 
 		Object.assign(_protospecs, protos);

--- a/modules/luci-base/root/usr/libexec/rpcd/luci
+++ b/modules/luci-base/root/usr/libexec/rpcd/luci
@@ -217,6 +217,7 @@ local methods = {
 			rv.ipv6          = fs.access("/proc/net/ipv6_route")
 			rv.dropbear      = fs.access("/usr/sbin/dropbear")
 			rv.cabundle      = fs.access("/etc/ssl/certs/ca-certificates.crt")
+			rv.relayd        = fs.access("/usr/sbin/relayd")
 
 			local wifi_features = { "eap", "11n", "11ac", "11r", "11w", "acs", "sae", "owe", "suiteb192" }
 


### PR DESCRIPTION
Currently relay.js is included in any case even if
the router doesn't have the needed package to use it.
Fix this by checking if the system has this feature.