### PR TITLE
luci-app-mwan3: Remove unnecessary dependency

### DIFF
--- a/applications/luci-app-mwan3/Makefile
+++ b/applications/luci-app-mwan3/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for the MWAN3 multiwan hotplug script
-LUCI_DEPENDS:=+luci-compat +mwan3 +libuci-lua +luci-mod-admin-full +luci-app-firewall +luci-lib-nixio
+LUCI_DEPENDS:=+luci-compat +mwan3 +libuci-lua +luci-mod-admin-full +luci-lib-nixio
 LUCI_PKGARCH:=all
 PKG_LICENSE:=GPLv2
 


### PR DESCRIPTION
There is no need to depend on luci-app-firewall, so remove the dependency.

I have examined the code and cannot see any reason for the dependency
and I have built a router with luci-app-mwan3, and without firewall,
luci-app-firewall and it all functions just fine.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>