### PR TITLE
luci: fix exception in OpenWrt theme

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -69,7 +69,7 @@ return L.view.extend({
 				E('div', {}, status['_enabled'] ? _('DDNS Autostart enabled') : [
 					_('DDNS Autostart disabled'),
 					E('div', { 'class' : 'cbi-value-description' },
-					_("Currently DDNS updates are not started at boot or on interface events.") + "<br>" +
+					_("Currently DDNS updates are not started at boot or on interface events.") + "<br />" +
 					_("This is the default if you run DDNS scripts by yourself (i.e. via cron with force_interval set to '0')"))
 				]),]);
 		});
@@ -103,8 +103,8 @@ return L.view.extend({
 					service_status = '<b>' + _('Running') + '</b> : ' + service[section_id].pid;
 			}
 
-			cfg_detail_ip.innerHTML = host + '<br>' + ip;
-			cfg_update.innerHTML = last_update + '<br>' + next_update;
+			cfg_detail_ip.innerHTML = host + '<br />' + ip;
+			cfg_update.innerHTML = last_update + '<br />' + next_update;
 			cfg_status.innerHTML = service_status;
 		}
 
@@ -160,13 +160,13 @@ return L.view.extend({
 		o.cfgvalue = function() {
 			var res = status[this.option];
 			if (!res) {
-				this.description = _("Currently DDNS updates are not started at boot or on interface events.") + "<br>" +
+				this.description = _("Currently DDNS updates are not started at boot or on interface events.") + "<br />" +
 				_("This is the default if you run DDNS scripts by yourself (i.e. via cron with force_interval set to '0')")
 			}
 			return res ? _('DDNS Autostart enabled') : _('DDNS Autostart disabled')
 		};
 
-		o = s.option(form.DummyValue, '_toggle', '&nbsp');
+		o = s.option(form.DummyValue, '_toggle', '');
 		o.cfgvalue = function() {
 			var action = status['_enabled'] ? 'stop' : 'start';
 			return E([], [
@@ -182,7 +182,7 @@ return L.view.extend({
 			}, _(action.toUpperCase() + ' DDns'))]);
 		};
 
-		o = s.option(form.DummyValue, '_restart', '&nbsp');
+		o = s.option(form.DummyValue, '_restart', '');
 		o.cfgvalue = function() {
 			return E([], [
 				E('button', {
@@ -199,8 +199,8 @@ return L.view.extend({
 			o = s.option(form.DummyValue, '_no_ipv6');
 			o.rawhtml  = true;
 			o.title = '<b>' + _("IPv6 not supported") + '</b>';
-			o.cfgvalue = function() { return _("IPv6 is currently not (fully) supported by this system") + "<br>" +
-			_("Please follow the instructions on OpenWrt's homepage to enable IPv6 support") + "<br>" +
+			o.cfgvalue = function() { return _("IPv6 is currently not (fully) supported by this system") + "<br />" +
+			_("Please follow the instructions on OpenWrt's homepage to enable IPv6 support") + "<br />" +
 			_("or update your system to the latest OpenWrt Release")};
 		}
 
@@ -391,7 +391,7 @@ return L.view.extend({
 			return '<b>' + section_id + '</b>';
 		}
 
-		o = s.option(form.DummyValue, '_cfg_detail_ip', _('Lookup Hostname') + "<br>" + _('Registered IP'));
+		o = s.option(form.DummyValue, '_cfg_detail_ip', _('Lookup Hostname') + "<br />" + _('Registered IP'));
 		o.rawhtml   = true;
 		o.modalonly = false;
 		o.textvalue = function(section_id) {
@@ -400,7 +400,7 @@ return L.view.extend({
 			if (resolved[section_id] && resolved[section_id].ip)
 				ip = resolved[section_id].ip;
 
-			return host + '<br>' + ip;
+			return host + '<br />' + ip;
 		};
 
 		o = s.option(form.Flag, 'enabled', _('Enabled'));
@@ -408,7 +408,7 @@ return L.view.extend({
 		o.editable = true;
 		o.modalonly = false;
 
-		o = s.option(form.DummyValue, '_cfg_update', _('Last Update') + "<br>" + _('Next Update'));
+		o = s.option(form.DummyValue, '_cfg_update', _('Last Update') + "<br />" + _('Next Update'));
 		o.rawhtml   = true;
 		o.modalonly = false;
 		o.textvalue = function(section_id) {
@@ -420,7 +420,7 @@ return L.view.extend({
 					next_update =  NextUpdateStrings[resolved[section_id].next_update] || resolved[section_id].next_update;
 			}
 
-			return  last_update + '<br>' + next_update;
+			return  last_update + '<br />' + next_update;
 		};
 
 		s.modaltitle = function(section_id) {
@@ -586,7 +586,7 @@ return L.view.extend({
 
 			o = s.taboption('basic', form.Value, 'cacert',
 				_("Path to CA-Certificate"),
-				_("directory or path/file") + "<br>" +
+				_("directory or path/file") + "<br />" +
 				_("or") + '<b>' + " IGNORE " + '</b>' +
 				_("to run HTTPS without verification of server certificates (insecure)"));
 			o.modalonly = true;
@@ -650,8 +650,8 @@ return L.view.extend({
 		// ip_url
 
 		o = s.taboption('advanced', form.Value, 'ip_url', _("URL to detect"),
-		_("Defines the Web page to read systems IP-Address from" + '<br>' +
-		_('Example for IPv4' + ': http://checkip.dyndns.com') + '<br>' +
+		_("Defines the Web page to read systems IP-Address from" + '<br />' +
+		_('Example for IPv4' + ': http://checkip.dyndns.com') + '<br />' +
 		_('Example for IPv6' + ': http://checkipv6.dyndns.com')));
 		o.depends("ip_source", "web")
 
@@ -708,7 +708,7 @@ return L.view.extend({
 
 		if (env['has_bindnet']) {
 			o = s.taboption('advanced', widgets.ZoneSelect, 'bind_network', _("Bind Network"),
-				_('OPTIONAL: Network to use for communication') + '<br>' +
+				_('OPTIONAL: Network to use for communication') + '<br />' +
 				_("Network on which the ddns-updater scripts will be started"));
 			o.depends("ip_source", "web");
 			o.optional = true;
@@ -783,7 +783,7 @@ return L.view.extend({
 		o.optional = true;
 		o.modalonly = true;
 		o.cfgvalue = function(section_id) {
-			this.description = _("Writes detailed messages to log file. File will be truncated automatically.") + "<br>" +
+			this.description = _("Writes detailed messages to log file. File will be truncated automatically.") + "<br />" +
 			_("File") + ': "' + logdir + '/' + section_id + '.log"';
 			return uci.get('ddns', section_id, 'use_logfile');
 		};
@@ -907,7 +907,7 @@ return L.view.extend({
 		o.modalonly = true;
 
 		o.update_log = L.bind(function(view, log_data) {
-			return document.getElementById('log_area').innerHTML = log_data.result;
+			return document.getElementById('log_area').textContent = log_data.result;
 		}, o, this)
 
 		o.render = L.bind(function() {
@@ -942,7 +942,7 @@ return L.view.extend({
 		o = s.option(form.Value, 'ddns_dateformat', _('Date format'));
 		o.description = '<a href="http://www.cplusplus.com/reference/ctime/strftime/" target="_blank">'
 			+ _("For supported codes look here")
-			+ '</a><br>' +
+			+ '</a><br />' +
 			_('Current setting: ') + '<b>' + status['_curr_dateformat'] + '</b>';
 		o.default = "%F %R"
 		o.optional = true;

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -2276,7 +2276,8 @@ return L.Class.extend({
 
 			try {
 				var val = JSON.parse(window.sessionStorage.getItem('tab'));
-				if (val.page === page && L.isObject(val.paths))
+
+				if (val && val.page === page && L.isObject(val.paths))
 					return val;
 			}
 			catch(e) {}


### PR DESCRIPTION
With the Firefox debugger is was reported that
with OpenWrt theme, 2 exception are reported.
One was caused in ui.js in case val is nil
The other were caused by invalid &nbsp and <br>
that are not accepted in XHTML.

@jow- is the use of textContext accepted ? innerHtml 
cause also an exception. 

Also it would be good to merge this in 19.07 too... 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>