### PR TITLE
add ipv6 firewall view

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ip6tables.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ip6tables.lua
@@ -1,0 +1,45 @@
+-- Copyright 2008 Freifunk Leipzig / Jo-Philipp Wich <jow@openwrt.org>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.statistics.rrdtool.definitions.ip6tables", package.seeall)
+
+function item()
+	return luci.i18n.translate("Firewall (IPv6)")
+end
+
+function rrdargs( graph, plugin, plugin_instance, dtype )
+
+	return {
+		{
+			title = "%H: Firewall: Processed bytes in %pi",
+			vlabel = "Bytes/s",
+			number_format = "%5.1lf%sB/s",
+			totals_format = "%5.1lf%sB",
+			data = { 
+				types = { "ipt_bytes" },
+				options = {
+					ipt_bytes = {
+						total = true,
+						title = "%di"
+					}
+				}
+			}
+		},
+
+		{
+			title = "%H: Firewall: Processed packets in %pi",
+			vlabel = "Packets/s",
+			number_format = "%5.1lf P/s",
+			totals_format = "%5.1lf%s",
+			data = {
+				types = { "ipt_packets" },
+				options = {
+					ipt_packets = {
+						total = true,
+						title = "%di"
+					}
+				}
+			}
+		}
+	}
+end


### PR DESCRIPTION
## rrdtool definition for ip6tables

Permits one to obtain real-time graphs of any ip6tables chains being monitored by collectd.
Fixes issue #3760.
