### PR TITLE
luci-mod-network: make 802.11s capaple of 802.11w

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1700,6 +1700,7 @@ return L.view.extend({
 							o.depends({ mode: 'sta-wds', encryption: 'sae' });
 							o.depends({ mode: 'sta-wds', encryption: 'sae-mixed' });
 							o.depends({ mode: 'sta-wds', encryption: 'owe' });
+							o.depends({ mode: 'mesh', encryption: 'sae' });
 							o.defaults = {
 								'2': [{ encryption: 'sae' }, { encryption: 'owe' }],
 								'1': [{ encryption: 'sae-mixed'}],


### PR DESCRIPTION
According to https://github.com/openwrt/openwrt/blob/master/package/network/services/hostapd/files/hostapd.sh#L1016-L1030 802.11s is capable of 802.11w. luci does currently not show an option to enable 802.11w for mesh wireless. This adds this option.

* not yet compile or runtime tested
* I kindly ask for help with the commit message
* will add signed-of line in the next days