### PR TITLE
luci-base: accept alternative logread location

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
@@ -49,6 +49,7 @@
 				"/sbin/ip -6 neigh show": [ "exec" ],
 				"/sbin/ip -6 route show table all": [ "exec" ],
 				"/sbin/logread -e ^": [ "exec" ],
+				"/usr/sbin/logread -e ^": [ "exec" ],
 				"/usr/bin/ping *": [ "exec" ],
 				"/usr/bin/ping6 *": [ "exec" ],
 				"/usr/bin/traceroute *": [ "exec" ],

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
@@ -4,9 +4,16 @@
 
 return L.view.extend({
 	load: function() {
-		return fs.exec_direct('/sbin/logread', [ '-e', '^' ]).catch(function(err) {
-			ui.addNotification(null, E('p', {}, _('Unable to load log data: ' + err.message)));
-			return '';
+		return Promise.all([
+			L.resolveDefault(fs.stat('/sbin/logread'), null),
+			L.resolveDefault(fs.stat('/usr/sbin/logread'), null)
+		]).then(function(stat) {
+			var logger = stat[0] ? stat[0].path : stat[1] ? stat[1].path : null;
+
+			return fs.exec_direct(logger, [ '-e', '^' ]).catch(function(err) {
+				ui.addNotification(null, E('p', {}, _('Unable to load log data: ' + err.message)));
+				return '';
+			});
 		});
 	},
 


### PR DESCRIPTION
* minimal change to accept the usual logread location
  plus the alternative location (/usr/sbin/logread)
  used by syslog-ng (see openwrt/packages/issues/11535 for reference)

Signed-off-by: Dirk Brenken <dev@brenken.org>