### PR TITLE
treewide: Remove myself as maintainer

### DIFF
--- a/applications/luci-app-radicale2/Makefile
+++ b/applications/luci-app-radicale2/Makefile
@@ -5,7 +5,6 @@ LUCI_DEPENDS:=+luci-compat +radicale2 +rpcd-mod-rad2-enc
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
 
 LUA_TARGET:=source
 

--- a/libs/rpcd-mod-rad2-enc/Makefile
+++ b/libs/rpcd-mod-rad2-enc/Makefile
@@ -8,7 +8,6 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-rad2-enc
 PKG_VERSION:=20190109
-PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
Life changes, I'm no longer avaiable to be an sufficiently active
OpenWrt developer.  Therefore removing myself from maintainer from
all packages I maintained in OpenWrt.

All the best for those who keep up the good work!

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>