### PR TITLE
luci-base: remove needless warning message

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -814,8 +814,6 @@
 			if (xhr.status === 0 && xhr.statusText === '') {
 				if (duration >= this.timeout)
 					rejectFn.call(this, new Error('XHR request timed out'));
-				else
-					rejectFn.call(this, new Error('XHR request aborted by browser'));
 			}
 			else {
 				var response = new Response(


### PR DESCRIPTION
* remove needless 'XHR request aborted by browser' warning message,
  see #3740 for reference

Signed-off-by: Dirk Brenken <dev@brenken.org>