### PR TITLE
luci-mod-network: interfaces.js: add global packet steering option

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -874,6 +874,9 @@ return L.view.extend({
 		o = s.option(form.Value, 'ula_prefix', _('IPv6 ULA-Prefix'));
 		o.datatype = 'cidr6';
 
+		o = s.option(form.Flag, 'packet_steering', _('Packet Steering'), _('Enable packet steering across all CPUs. May help or hinder network speed.'));
+		o.optional = true;
+
 
 		if (dslModemType != null) {
 			s = m.section(form.TypedSection, 'dsl', _('DSL'));


### PR DESCRIPTION
Previously an undocumented _default_ps_ option without a corresponding luci entry. Hotplug script was [updated](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=d3868f15f876507db54afacdef22a7059011a54e) in openwrt master to use _packet_steering_ as the option and now defaults to off since on routers it can be detrimental.

Descriptive text needs to indicate that this may help or hinder network speed without be overly verbose on, say, IRQ balancing versus packet steering. Set as optional so config entry will be removed if disabled/0.