### PR TITLE
luci-app-dawn: add luci app for dawn

### DIFF
--- a/applications/luci-app-dawn/Makefile
+++ b/applications/luci-app-dawn/Makefile
@@ -1,0 +1,10 @@
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for DAWN
+LUCI_DEPENDS:=+dawn
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature
+

--- a/applications/luci-app-dawn/luasrc/controller/dawn.lua
+++ b/applications/luci-app-dawn/luasrc/controller/dawn.lua
@@ -1,0 +1,8 @@
+module("luci.controller.dawn", package.seeall)
+
+function index()
+    entry({ "admin", "dawn" }, firstchild(), "DAWN", 60).dependent = false
+    entry({ "admin", "dawn", "configure_daemon" }, cbi("dawn/dawn_config"), "Configure DAWN", 1)
+    entry({ "admin", "dawn", "view_network" }, cbi("dawn/dawn_network"), "View Network Overview", 2)
+    entry({ "admin", "dawn", "view_hearing_map" }, cbi("dawn/dawn_hearing_map"), "View Hearing Map", 3)
+end

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_config.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_config.lua
@@ -1,0 +1,42 @@
+m = Map("dawn", translate("Dawn Configuration"), translate(""))
+s = m:section(TypedSection, "metric", "Metric", "Metric"); s.anonymous = true;
+s:option(Value, "ht_support", "High Throughput Support")
+s:option(Value, "no_ht_support", "No High Throughput Support")
+s:option(Value, "vht_support", "Very High Throughput Support")
+s:option(Value, "no_vht_support", "No Very High Throughput Support")
+s:option(Value, "rssi", "RSSI")
+s:option(Value, "low_rssi", "Low RSSI")
+s:option(Value, "freq", "5GHz")
+s:option(Value, "chan_util", "Channel Utilization")
+s:option(Value, "max_chan_util", "Above Maximum Channel Utilization")
+
+s = m:section(TypedSection, "metric", "Threshold", "Thresholds"); s.anonymous = true;
+s:option(Value, "bandwith_threshold", "Bandwidth Threshold")
+s:option(Value, "rssi_val", "RSSI Threshold")
+s:option(Value, "low_rssi_val", "Low RSSI Threshold")
+s:option(Value, "chan_util_val", "Channel Utilization Threshold")
+s:option(Value, "max_chan_util_val", "Maximaum Channel Utilization Threshold")
+s:option(Value, "min_probe_count", "Minimum Probe Count")
+s:option(Value, "min_number_to_kick", "Minimum Number After Kicking Client")
+
+s = m:section(TypedSection, "metric", "Evaluate", "What should be evaluated?"); s.anonymous = true;
+s:option(Flag, "kicking", "Activate Kicking")
+s:option(Flag, "eval_probe_req", "Evaluate Probe Requests")
+s:option(Flag, "eval_auth_req", "Evaluate Authentication Requests")
+s:option(Flag, "eval_assoc_req", "Evaluate Association Requests")
+s:option(Flag, "use_station_count", "Use Station Count")
+
+s = m:section(TypedSection, "metric", "IEE802.11", "Reasons for denying"); s.anonymous = true;
+s:option(Value, "deny_auth_reason", "Denying Authentication")
+s:option(Value, "deny_assoc_reason", "Denying Association")
+
+s = m:section(TypedSection, "times", "Time Configuration", "Time Configs"); s.anonymous = true;
+s:option(Value, "update_client", "Update Client Information Interval")
+s:option(Value, "denied_req_threshold", "Checking if client is connected")
+s:option(Value, "remove_client", "Remove Client Information")
+s:option(Value, "remove_probe", "Remove Hearing Map Information")
+s:option(Value, "update_hostapd", "Check for new Hostapd Sockets")
+s:option(Value, "update_tcp_con", "Check for new Routers")
+s:option(Value, "update_chan_util", "Update Channel Utilization Interval")
+
+return m

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
@@ -1,0 +1,64 @@
+m = Map("Hearing Map", translate("Hearing Map"))
+m.pageaction = false
+
+s = m:section(NamedSection, "__hearingmap__")
+
+function s.render(self, sid)
+    local tpl = require "luci.template"
+    tpl.render_string([[
+        <ul>
+		    <%
+            local utl = require "luci.util"
+            local status = require "luci.tools.ieee80211"
+            local stat = utl.ubus("dawn", "get_hearing_map", { })
+            local name, macs
+            for name, macs in pairs(stat) do
+            %>
+                <li>
+                    <strong>SSID is: </strong><%= name %><br />
+                </li>
+                <ul>
+                <%
+                local mac, data
+                for mac, data in pairs(macs) do
+                %>
+                <li>
+                    <strong>Client MAC is: </strong><%= mac %><br />
+                </li>
+                <ul>
+                <%
+                local mac2, data2
+                for mac2, data2 in pairs(data) do
+                %>
+                    <li>
+                        <strong>AP is: </strong><%= mac2 %><br />
+                        <strong>Frequency is: </strong><%= "%.3f" %( data2.freq / 1000 ) %> GHz (Channel: <%= "%d" %( status.frequency_to_channel(data2.freq) ) %>)<br />
+                        <strong>HT support is: </strong><%= (data2.ht_capabilities == true and data2.ht_support == true) and "available" or "not available" %><br />
+                        <strong>VHT support is: </strong><%= (data2.vht_capabilities == true and data2.vht_support == true) and "available" or "not available" %><br />
+                        <!--
+                        <strong>AP HT support is: </strong><%= (data2.ht_support == true) and "available" or "not available" %><br />
+                        <strong>AP VHT support is: </strong><%= (data2.vht_support == true) and "available" or "not available" %><br />
+                        <strong>Client HT support is: </strong><%= (data2.ht_capabilities == true) and "available" or "not available" %><br />
+                        <strong>Client VHT support is: </strong><%= (data2.vht_capabilities == true) and "available" or "not available" %><br />
+                        --!>
+                        <strong>Signal is: </strong><%= "%d" %data2.signal %><br />
+                        <strong>Channel Utilization is: </strong><%= "%d" %data2.channel_utilization %><br />
+                        <strong>Station connected to AP is: </strong><%= "%d" %data2.num_sta %><br />
+                        <strong>Score is: </strong><%= "%d" %data2.score %><br />
+                    </li>
+                <%
+                end
+                %>
+                </ul>
+            <%
+            end
+            %>
+            </ul>
+        <%
+        end
+        %>
+		</ul>
+	]])
+end
+
+return m

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
@@ -1,0 +1,92 @@
+m = Map("Network Overview", translate("Network Overview"))
+m.pageaction = false
+
+s = m:section(NamedSection, "__networkoverview__")
+
+function s.render(self, sid)
+	local tpl = require "luci.template"
+	local json = require "luci.json"
+	local utl = require "luci.util"
+	tpl.render_string([[
+		<table class="table" style="border: 1px solid grey;">
+			<thead style="background-color: grey; color: white;">
+				<tr>
+						<th>SSID</th>
+						<th>MAC</th>
+						<th>Channel Utilization</th>
+						<th>Frequency</th>
+						<th>Stations</th>
+						<th>HT Sup</th>
+						<th>VHT Sup</th>
+				</tr>
+			</thead>
+			<tbody>
+			<%
+			local status = require "luci.tools.ieee80211"
+			local utl = require "luci.util"
+			local sys = require "luci.sys"
+			local hosts = sys.net.host_hints()
+			local stat = utl.ubus("dawn", "get_network", { })
+			local name, macs
+			for name, macs in pairs(stat) do
+				local mac, data
+				for mac, data in pairs(macs) do
+			%>
+				<tr class="center">
+					<td><%= name %></td>
+					<td><%= mac %></td>
+					<td><%= "%.2f" %(data.channel_utilization / 2.55) %> %</td>
+					<td><%= "%.3f" %( data.freq / 1000 ) %> GHz (Channel: <%= "%d" %( status.frequency_to_channel(data.freq) ) %>)</td>
+					<td><%= "%d" %data.num_sta %></td>
+					<td><%= (data.ht_support == true) and "available" or "not available" %></td>
+					<td><%= (data.vht_support == true) and "available" or "not available" %></td>
+				</tr>
+				<tr>
+					<td colspan="7"><hr></td>
+				</tr>
+				<tr>
+					<td colspan="2" class="center"><strong>Clients</strong></td>
+					<td colspan="4">
+					<table class="table" style="border: 1px solid grey;">
+					<thead style="background-color: grey; color: white;">
+						<tr>
+							<th>MAC</th>
+							<th>HT</th>
+							<th>VHT</th>
+							<th>Signal</th>
+						</tr>
+					</thead>
+					<tbody>
+					<%
+					local mac2, data2
+					for clientmac, clientvals in pairs(data) do
+						if (type(clientvals) == "table") then 
+					%>
+						<tr class="center">
+							<td><%= clientmac %></td>
+							<td><%= (clientvals.ht == true) and "available" or "not available" %></td>
+							<td><%= (clientvals.vht == true) and "available" or "not available" %></td>
+							<td><%= "%d" %clientvals.signal %></td>
+						</tr>
+					<%
+						end
+					end
+					%>
+					</tbody>
+					</table>
+				</tr>
+				<tr>
+					<td colspan="7"><hr></td>
+				</tr>
+				<%
+				end
+				%>
+			<%
+			end
+			%>
+			</tbody>
+		</table>
+	]])
+end
+
+return m

--- a/applications/luci-app-dawn/luasrc/tools/ieee80211.lua
+++ b/applications/luci-app-dawn/luasrc/tools/ieee80211.lua
@@ -1,0 +1,18 @@
+module("luci.tools.ieee80211", package.seeall)
+
+function frequency_to_channel(freq)
+	if (freq == 2484) then
+		return 14;
+	elseif (freq < 2484) then
+		return (freq - 2407) / 5;
+	elseif (freq >= 4910 and freq <= 4980) then
+		return (freq - 4000) / 5;
+	elseif (freq <= 45000) then
+		return (freq - 5000) / 5;
+	elseif (freq >= 58320 and freq <= 64800) then
+		return (freq - 56160) / 2160;
+	else
+		return 0;
+	end
+end
+


### PR DESCRIPTION
Dawn is a decentralized WiFi controller.
Just install dawn and the APs will find each other via umdns. They periodically exchange information about connected clients, wireless statistics and other needed information. With that, the daemon load balances clients between different APs through association control.

Luci-app-dawn is the graphical user interface.
It allows to:
- Configure dawn
- View Wireless Network Overview
- View Hearing Map

The hearing map is the list of all probe requests seen from a client from all APs that are running the controller.

![networkoverview](https://user-images.githubusercontent.com/10708466/77821955-91de1700-70ee-11ea-9303-8dbfde82aae2.png)

![hearingmapoverview](https://user-images.githubusercontent.com/10708466/77822045-6c9dd880-70ef-11ea-9f3a-6fa706f3fbc3.png)

![configurationdawn](https://user-images.githubusercontent.com/10708466/77822024-3eb89400-70ef-11ea-8f69-60ef4ce07ce8.png)

https://github.com/openwrt/packages/pull/11648