### PR TITLE
Fix path url link to mounts luci samba page

### DIFF
--- a/applications/luci-app-samba/luasrc/model/cbi/samba.lua
+++ b/applications/luci-app-samba/luasrc/model/cbi/samba.lua
@@ -45,7 +45,7 @@ s.template = "cbi/tblsection"
 s:option(Value, "name", translate("Name"))
 pth = s:option(Value, "path", translate("Path"))
 if nixio.fs.access("/etc/config/fstab") then
-        pth.titleref = luci.dispatcher.build_url("admin", "system", "fstab")
+        pth.titleref = luci.dispatcher.build_url("admin", "system", "mounts")
 end
 
 s:option(Value, "users", translate("Allowed users")).rmempty = true


### PR DESCRIPTION
Reverse link for path from fstab to mounts on luci-app-samba page