### PR TITLE
set mediaurlbase only when it is the first time to be installed

### DIFF
--- a/themes/luci-theme-bootstrap/root/etc/uci-defaults/30_luci-theme-bootstrap
+++ b/themes/luci-theme-bootstrap/root/etc/uci-defaults/30_luci-theme-bootstrap
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$PKG_UPGRADE" != 1 ]; then
+	uci get luci.themes.Bootstrap >/dev/null 2>&1 || \
 	uci batch <<-EOF
 		set luci.themes.Bootstrap=/luci-static/bootstrap
 		set luci.main.mediaurlbase=/luci-static/bootstrap

--- a/themes/luci-theme-material/root/etc/uci-defaults/30_luci-theme-material
+++ b/themes/luci-theme-material/root/etc/uci-defaults/30_luci-theme-material
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$PKG_UPGRADE" != 1 ]; then
+	uci get luci.themes.Material >/dev/null 2>&1 || \
 	uci batch <<-EOF
 		set luci.themes.Material=/luci-static/material
 		set luci.main.mediaurlbase=/luci-static/material

--- a/themes/luci-theme-openwrt-2020/root/etc/uci-defaults/30_luci-theme-openwrt-2020
+++ b/themes/luci-theme-openwrt-2020/root/etc/uci-defaults/30_luci-theme-openwrt-2020
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$PKG_UPGRADE" != 1 ]; then
+	uci get luci.themes.OpenWrt2020 >/dev/null 2>&1 || \
 	uci batch <<-EOF
 		set luci.themes.OpenWrt2020=/luci-static/openwrt2020
 		set luci.main.mediaurlbase=/luci-static/openwrt2020

--- a/themes/luci-theme-openwrt/root/etc/uci-defaults/30_luci-theme-openwrt
+++ b/themes/luci-theme-openwrt/root/etc/uci-defaults/30_luci-theme-openwrt
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$PKG_UPGRADE" != 1 ]; then
+	uci get luci.themes.OpenWrt >/dev/null 2>&1 || \
 	uci batch <<-EOF
 		set luci.themes.OpenWrt=/luci-static/openwrt.org
 		set luci.main.mediaurlbase=/luci-static/openwrt.org

--- a/themes/luci-theme-rosy/root/etc/uci-defaults/30_luci-theme-rosy
+++ b/themes/luci-theme-rosy/root/etc/uci-defaults/30_luci-theme-rosy
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$PKG_UPGRADE" != 1 ]; then
+	uci get luci.themes.Rosy >/dev/null 2>&1 || \
 	uci batch <<-EOF
 		set luci.themes.Rosy=/luci-static/rosy
 		set luci.main.mediaurlbase=/luci-static/rosy


### PR DESCRIPTION
If we build multi-themes into firmware, each of them set itself
to be the default theme, what theme should it be?

To make it clear, we only set mediaurlbase if the theme is the
first time to be installed/built-in.

This resolve the issue that theme always change to somewhat default
after upgrading the firmware even with a config-keep-upgrade
