### PR TITLE
luci-proto-gre: Protocol extension for GRE tunnels

### DIFF
--- a/protocols/luci-proto-gre/Makefile
+++ b/protocols/luci-proto-gre/Makefile
@@ -1,0 +1,21 @@
+#
+# Based on luci-proto-ipip.
+# Credited author of luci-proto-ipip is Roger Pueyo Centelles <roger.pueyo@guifi.net>
+# Copyright 2016 Roger Pueyo Centelles <roger.pueyo@guifi.net>
+#
+# Modified by Jan Betik <jan.betik@svine.su>
+# Copyright 2020 Jan Betik <jan.betik@svine.su>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for GRE tunnels (RFC2784)
+LUCI_DEPENDS:=+gre
+
+PKG_MAINTAINER:=Jan Betik <jan.betik@svine.su>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
@@ -1,0 +1,96 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre4-.+$/);
+
+return network.registerProtocol('gre', {
+	getI18n: function() {
+		return _('GRE tunnel over IPv4');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre4-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peeraddr', _("Remote IPv4 address or FQDN"), _("The IPv4 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip4addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ipaddr', _("Local IPv4 address"), _("The local IPv4 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip4addr("nomask")';
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Override TOS'), _("Specify a TOS (Type of Service). Can be either <code>inherit</code> (the outer      header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'df', _("Don't Fragment"), _("Enable the DF (Don't Fragment) flag of the encapsulating packets."));
+		o.default = o.enabled;
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
@@ -1,0 +1,101 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre4t-.+$/);
+
+return network.registerProtocol('gretap', {
+	getI18n: function() {
+		return _('GRETAP tunnel over IPv4');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre4t-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peeraddr', _("Remote IPv4 address or FQDN"), _("The IPv4 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip4addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ipaddr', _("Local IPv4 address"), _("The local IPv4 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip4addr("nomask")';
+
+		o = s.taboption('general', widgets.NetworkSelect, 'network', _("Network interface"), _("Logical network to which the tunnel will be added (bridged) (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Override TOS'), _("Specify a TOS (Type of Service). Can be either <code>inherit</code> (the outer      header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'df', _("Don't Fragment"), _("Enable the DF (Don't Fragment) flag of the encapsulating packets."));
+		o.default = o.enabled;
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
@@ -1,0 +1,98 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre6-.+$/);
+
+return network.registerProtocol('grev6', {
+	getI18n: function() {
+		return _('GRE tunnel over IPv6');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre6-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peer6addr', _("Remote IPv6 address or FQDN"), _("The IPv6 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip6addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ip6addr', _("Local IPv6 address"), _("The local IPv6 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip6addr("nomask")';
+
+		o = s.taboption('general', widgets.NetworkSelect, 'weakif', _("Source interface"), _("Logical network from which to select the local endpoint if local IPv6 address is empty and no WAN IPv6 is available (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Traffic Class'), _("Specify a Traffic Class. Can be either <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
@@ -1,0 +1,103 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre6t-.+$/);
+
+return network.registerProtocol('grev6tap', {
+	getI18n: function() {
+		return _('GRETAP tunnel over IPv6');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre6t-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peer6addr', _("Remote IPv6 address or FQDN"), _("The IPv6 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip6addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ip6addr', _("Local IPv6 address"), _("The local IPv6 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip6addr("nomask")';
+
+		o = s.taboption('general', widgets.NetworkSelect, 'weakif', _("Source interface"), _("Logical network from which to select the local endpoint if local IPv6 address is empty and no WAN IPv6 is available (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('general', widgets.NetworkSelect, 'network', _("Network interface"), _("Logical network to which the tunnel will be added (bridged) (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Traffic Class'), _("Specify a Traffic Class. Can be either <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});


### PR DESCRIPTION
I'm running several GRE tunnels to different locations and
the option to see and to configure GRE tunnels in LuCI was not
crucial but nice to have.

My motivation was to simplify the management of GRE tunnels; and also to help other people asking on the internet for this functionality.

Debugged and tested on router Turris 1.1, powerpc 8540, OpenWrt 19.07.

![GRE_add_new_interface](https://user-images.githubusercontent.com/23101792/78401238-96c42e80-75f8-11ea-9487-8ad1a9117f8b.png)
![GRE_advanced_settings](https://user-images.githubusercontent.com/23101792/78401240-988df200-75f8-11ea-853a-5f28a78d66a9.png)
![GRE_advanced_settings_continue](https://user-images.githubusercontent.com/23101792/78401243-9a57b580-75f8-11ea-92d9-17a334099737.png)
![GRE_general_settings](https://user-images.githubusercontent.com/23101792/78401244-9af04c00-75f8-11ea-9122-bbef20d72aba.png)





Signed-off-by: Jan Betik <jan.betik@svine.su>