### PR TITLE
luci-app-adblock: disable textarea spellcheck

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
@@ -25,6 +25,7 @@ return view.extend({
 			E('p', {},
 				E('textarea', {
 					'style': 'width: 100% !important; padding: 5px; font-family: monospace',
+					'spellcheck': 'false',
 					'wrap': 'off',
 					'rows': 25
 				}, [ blacklist != null ? blacklist : '' ])

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
@@ -25,6 +25,7 @@ return view.extend({
 			E('p', {},
 				E('textarea', {
 					'style': 'width: 100% !important; padding: 5px; font-family: monospace',
+					'spellcheck': 'false',
 					'wrap': 'off',
 					'rows': 25
 				}, [ whitelist != null ? whitelist : '' ])


### PR DESCRIPTION
* disable spellcheck for black- and whitelist textareas

Signed-off-by: Dirk Brenken <dev@brenken.org>