### PR TITLE
luci-app-https-dns-proxy: Add LibreDNS as a DoH provider

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
@@ -1,0 +1,6 @@
+return {
+	name = "LibreDNS",
+	label = _("LibreDNS (No Ads)"),
+	resolver_url = "https://doh.libredns.gr/ads",
+	bootstrap_dns = "116.202.176.26"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
@@ -1,0 +1,6 @@
+return {
+	name = "LibreDNS",
+	label = _("LibreDNS"),
+	resolver_url = "https://doh.libredns.gr/dns-query",
+	bootstrap_dns = "116.202.176.26"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -88,7 +88,9 @@ s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), translat
 		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html">]]
     .. "AdGuard.com" .. [[</a>]] .. ", "
 		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
-    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+    .. "CleanBrowsing.org" .. [[</a>]] .. " "
+                .. [[ <a href="https://libredns.gr/">]]
+    .. "Libredns.gr" .. [[</a]] .. " " .. translate("and") .. " "
 		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
     .. "Quad9.net" .. [[</a>]] .. ".")
 s3.template = "cbi/tblsection"

--- a/applications/luci-app-https-dns-proxy/po/en/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/en/https-dns-proxy.po
@@ -88,6 +88,14 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua:3
+msgid "LibreDNS"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua:3
+msgid "LibreDNS (No Ads)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua:3
 msgid "ODVR (nic.cz)"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -85,6 +85,14 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua:3
+msgid "LibreDNS"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua:3
+msgid "LibreDNS (No Ads)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua:3
 msgid "ODVR (nic.cz)"
 msgstr ""


### PR DESCRIPTION
LibreDNS (libredns.gr) is a Doh service provided by LibreOps(libreops.cc), a group
of hackers around the world that are (re-)decentralizing the net.
Trying offering distributed, free (as in freedom) services to the world.
Always based on Free Open Source Software.

Signed-off-by: Konstantinos Stamou (Dinos) <github@f3rr3t.net>