### PR TITLE
luci-app-ttyd: use correct http protocol

### DIFF
--- a/applications/luci-app-ttyd/htdocs/luci-static/resources/view/ttyd/term.js
+++ b/applications/luci-app-ttyd/htdocs/luci-static/resources/view/ttyd/term.js
@@ -7,12 +7,13 @@ return view.extend({
 		return uci.load('ttyd');
 	},
 	render: function() {
-		var port = uci.get_first('ttyd', 'ttyd', 'port') || '7681';
+		var port = uci.get_first('ttyd', 'ttyd', 'port') || '7681',
+			ssl = uci.get_first('ttyd', 'ttyd', 'ssl') || '0';
 		if (port === '0')
 			return E('div', { class: 'alert-message warning' },
 					_('Random ttyd port (port=0) is not supported.<br>Change to a fixed port and try again.'));
 		return E('iframe', {
-			src: window.location.protocol + '//' + window.location.hostname + ':' + port,
+			src: (ssl === '1' ? 'https' : 'http') + '://' + window.location.hostname + ':' + port,
 			style: 'width: 100%; min-height: 500px; border: none; border-radius: 3px; resize: vertical;'
 		});
 	},


### PR DESCRIPTION
Fixes #3831

Since ttyd failed to build ([faillogs](https://downloads.openwrt.org/snapshots/faillogs/x86_64/packages/ttyd/)) and rpcd crashed on x86_64 snapshot, I have not tested.