### PR TITLE
luci-app-adblock: revert poll/view class changes

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
@@ -1,9 +1,8 @@
 'use strict';
-'require view';
 'require fs';
 'require ui';
 
-return view.extend({
+return L.view.extend({
 	load: function() {
 		return L.resolveDefault(fs.read_direct('/etc/adblock/adblock.blacklist'), '');
 	},

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
@@ -1,5 +1,4 @@
 'use strict';
-'require view';
 'require fs';
 'require ui';
 
@@ -187,7 +186,7 @@ function handleAction(ev) {
 	}
 }
 
-return view.extend({
+return L.view.extend({
 	load: function() {
 		return L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', '+', '50', 'false', 'json']),'');
 	},

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/logread.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/logread.js
@@ -1,9 +1,7 @@
 'use strict';
-'require view';
-'require poll';
 'require fs';
 
-return view.extend({
+return L.view.extend({
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(fs.stat('/sbin/logread'), null),
@@ -12,7 +10,7 @@ return view.extend({
 	},
 	render: function(stat) {
 		var logger = stat[0] ? stat[0].path : stat[1] ? stat[1].path : null;
-		poll.add(function() {
+		L.Poll.add(function() {
 			return L.resolveDefault(fs.exec_direct(logger, ['-e', 'adblock-'])).then(function(res) {
 				var log = document.getElementById("logfile");
 				if (res) {

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -1,6 +1,4 @@
 'use strict';
-'require view';
-'require poll';
 'require fs';
 'require ui';
 'require uci';
@@ -100,7 +98,7 @@ async function handleAction(ev) {
 		}
 	}
 
-	poll.start();
+	L.Poll.start();
 	fs.exec_direct('/etc/init.d/adblock', [ev])
 	var running = 1;
 	while (running === 1) {
@@ -111,10 +109,10 @@ async function handleAction(ev) {
 			}
 		})
 	}
-	poll.stop();
+	L.Poll.stop();
 }
 
-return view.extend({
+return L.view.extend({
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['list']), {}),
@@ -131,7 +129,7 @@ return view.extend({
 		/*
 			poll runtime information
 		*/
-		pollData: poll.add(function() {
+		pollData: L.Poll.add(function() {
 			return L.resolveDefault(fs.read_direct('/tmp/adb_runtime.json'), 'null').then(function(res) {
 				var info = JSON.parse(res);
 				var status = document.getElementById('status');
@@ -144,7 +142,7 @@ return view.extend({
 					} else {
 						if (status.classList.contains("spinning")) {
 							status.classList.remove("spinning");
-							poll.stop();
+							L.Poll.stop();
 						}
 					}
 					if (status.textContent.substr(0,6) === 'paused' && document.getElementById('btn_suspend')) {

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
@@ -1,9 +1,8 @@
 'use strict';
-'require view';
 'require fs';
 'require ui';
 
-return view.extend({
+return L.view.extend({
 	load: function() {
 		return L.resolveDefault(fs.read_direct('/etc/adblock/adblock.whitelist'), '');
 	},


### PR DESCRIPTION
* this partly reverts 3c4bc22 to ensure 19.07.2 compatibility,
  this is only a temporary "fix" as long as we don't have
  adblock 4 backported to 19.07 branch

Signed-off-by: Dirk Brenken <dev@brenken.org>