### PR TITLE
luci-app-https-dns-proxy: Move help links to providers files

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
@@ -2,5 +2,7 @@ return {
 	name = "AdGuard-Family",
 	label = _("AdGuard (Family Protection)"),
 	resolver_url = "https://dns-family.adguard.com/dns-query",
-	bootstrap_dns = "176.103.130.132,176.103.130.134"
+	bootstrap_dns = "176.103.130.132,176.103.130.134",
+	help_link = "https://adguard.com/en/adguard-dns/overview.html",
+	help_link_text = "AdGuard.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
@@ -2,5 +2,7 @@ return {
 	name = "AdGuard-Standard",
 	label = _("AdGuard (Standard)"),
 	resolver_url = "https://dns.adguard.com/dns-query",
-	bootstrap_dns = "176.103.130.130,176.103.130.131"
+	bootstrap_dns = "176.103.130.130,176.103.130.131",
+	help_link = "https://adguard.com/en/adguard-dns/overview.html",
+	help_link_text = "AdGuard.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
@@ -1,6 +1,8 @@
 return {
-	name = "LibreDNS",
+	name = "LibreDNS (No Ads)",
 	label = _("LibreDNS (No Ads)"),
 	resolver_url = "https://doh.libredns.gr/ads",
-	bootstrap_dns = "116.202.176.26"
+	bootstrap_dns = "116.202.176.26",
+	help_link = "https://libredns.gr/",
+	help_link_text = "LibreDNS.gr"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
@@ -2,5 +2,7 @@ return {
 	name = "LibreDNS",
 	label = _("LibreDNS"),
 	resolver_url = "https://doh.libredns.gr/dns-query",
-	bootstrap_dns = "116.202.176.26"
+	bootstrap_dns = "116.202.176.26",
+	help_link = "https://libredns.gr/",
+	help_link_text = "LibreDNS.gr"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
@@ -2,5 +2,7 @@ return {
 	name = "Quad9-Recommended",
 	label = _("Quad 9 (Recommended)"),
 	resolver_url = "https://dns.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.9,149.112.112.112"
+	bootstrap_dns = "9.9.9.9,149.112.112.112",
+	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
+	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
@@ -2,5 +2,7 @@ return {
 	name = "Quad9-Unsecured",
 	label = _("Quad 9 (Unsecured)"),
 	resolver_url = "https://dns10.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.10,149.112.112.10"
+	bootstrap_dns = "9.9.9.10,149.112.112.10",
+	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
+	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
@@ -2,5 +2,7 @@ return {
 	name = "Quad9-ECS",
 	label = _("Quad 9 (Secured with ECS Support)"),
 	resolver_url = "https://dns11.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.11,149.112.112.11"
+	bootstrap_dns = "9.9.9.11,149.112.112.11",
+	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
+	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
@@ -2,5 +2,7 @@ return {
 	name = "Quad9-Secured",
 	label = _("Quad 9 (Secured)"),
 	resolver_url = "https://dns9.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.9,149.112.112.9"
+	bootstrap_dns = "9.9.9.9,149.112.112.9",
+	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
+	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
@@ -2,5 +2,7 @@ return {
 	name = "CleanBrowsing-Adult",
 	label = _("CleanBrowsing (Adult Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/adult-filter/",
-	bootstrap_dns = "185.228.168.168"
+	bootstrap_dns = "185.228.168.168",
+	help_link = "https://cleanbrowsing.org/guides/dnsoverhttps",
+	help_link_text = "CleanBrowsing.org"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
@@ -2,5 +2,7 @@ return {
 	name = "CleanBrowsing-Family",
 	label = _("CleanBrowsing (Family Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/family-filter/",
-	bootstrap_dns = "185.228.168.168"
+	bootstrap_dns = "185.228.168.168",
+	help_link = "https://cleanbrowsing.org/guides/dnsoverhttps",
+	help_link_text = "CleanBrowsing.org"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
@@ -2,5 +2,7 @@ return {
 	name = "CleanBrowsing-Security",
 	label = _("CleanBrowsing (Security Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/security-filter/",
-	bootstrap_dns = "185.228.168.168"
+	bootstrap_dns = "185.228.168.168",
+	help_link = "https://cleanbrowsing.org/guides/dnsoverhttps",
+	help_link_text = "CleanBrowsing.org"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -7,6 +7,33 @@ local uci = require("luci.model.uci").cursor()
 
 local packageName = "https-dns-proxy"
 local providers_dir = "/usr/lib/lua/luci/" .. packageName .. "/providers/"
+local helperText = ""
+
+function create_helper_text()
+	local initText = "<br />" .. translate("For more information on different options check") .. " "
+	for filename in fs.dir(providers_dir) do
+		local p_func = loadfile(providers_dir .. filename)
+		setfenv(p_func, { _ = i18n.translate })
+		local p = p_func()
+		if p.help_link then
+			local url, domain
+			url = p.help_link
+			domain = p.help_link_text or url:match('^%w+://([^/]+)')
+			if not helperText:find(domain) then
+				if helperText == "" then
+					helperText = initText
+				else
+					helperText = helperText .. ", "
+				end
+				helperText = helperText .. [[<a href="]] .. url .. [[">]] .. domain .. [[</a>]]
+			end
+		end
+	end
+	if helperText ~= "" then
+		local a = helperText:gsub('(.*),%s.*$', '%1')
+		helperText = a .. " " .. translate("and") .. helperText:sub(#a + 2) .. "."
+	end
+end
 
 function get_provider_name(value)
 	for filename in fs.dir(providers_dir) do
@@ -83,19 +110,10 @@ else
 	buttons.template = packageName .. "/buttons"
 end
 
+create_helper_text()
 s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), translate("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of ")
 		.. [[ <a href="]] .. dispatcher.build_url("admin/network/dhcp") .. [[">]]
-		.. translate("DHCP and DNS") .. [[</a>]] .. "."
-    .. "<br />"
-    .. translate("For more information on different options check ")
-		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html">]]
-    .. "AdGuard.com" .. [[</a>]] .. ", "
-		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
-    .. "CleanBrowsing.org" .. [[</a>]] .. " "
-                .. [[ <a href="https://libredns.gr/">]]
-    .. "Libredns.gr" .. [[</a]] .. " " .. translate("and") .. " "
-		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
-    .. "Quad9.net" .. [[</a>]] .. ".")
+		.. translate("DHCP and DNS") .. [[</a>]] .. "." .. helperText)
 s3.template = "cbi/tblsection"
 s3.sortable  = false
 s3.anonymous = true

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -25,7 +25,7 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:88
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:116
 msgid "DHCP and DNS"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr ""
 msgid "DNS Over HTTPS Proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:67
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:94
 msgid "DNS Over HTTPS Proxy Settings"
 msgstr ""
 
@@ -49,11 +49,11 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:59
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
 msgid "DoH"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:146
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:166
 msgid "EDNS client subnet"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:90
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:13
 msgid "For more information on different options check"
 msgstr ""
 
@@ -69,20 +69,8 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:114
 msgid "Instances"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:129
-msgid "Listen address"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:142
-msgid "Listen port"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/js.htm:52
-msgid "Loading"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua:3
@@ -93,11 +81,23 @@ msgstr ""
 msgid "LibreDNS (No Ads)"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:149
+msgid "Listen address"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:162
+msgid "Listen port"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/js.htm:52
+msgid "Loading"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua:3
 msgid "ODVR (nic.cz)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:149
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:169
 msgid "Proxy server"
 msgstr ""
 
@@ -121,16 +121,16 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:102
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:122
 msgid "Resolver"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:59
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
 msgid "Running"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:69
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:71
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:96
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:98
 msgid "Service Status"
 msgstr ""
 
@@ -142,33 +142,33 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:37
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:64
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:22
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:49
 msgid "Unknown Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:114
 msgid ""
 "When you add/remove any instances below, they will be used to override the "
 "'DNS forwardings' section of"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:94
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:34
 msgid "and"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:59
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
 msgid "at"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:39
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:66
 msgid "disabled"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:32
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:59
 msgid "is not installed or not found"
 msgstr ""
 


### PR DESCRIPTION
The help links (used when a certain DoH provider offers various filters on their servers) were hard-coded in the model/cbi file, they have now been moved to the providers pluggable files.

PS. As per Contributions Guidelines I'm requesting a merge access.

Signed-off-by: Stan Grishin <stangri@melmac.net>