### PR TITLE
luci-app-commands: fix escaping of additional shell chars

### DIFF
--- a/applications/luci-app-commands/luasrc/controller/commands.lua
+++ b/applications/luci-app-commands/luasrc/controller/commands.lua
@@ -144,7 +144,7 @@ local function parse_cmdline(cmdid, args)
 		end
 
 		for i, v in ipairs(argv) do
-			if v:match("[^%w%.%-i/]") then
+			if v:match("[^%w%.%-i/|]") then
 				argv[i] = '"%s"' % v:gsub('"', '\\"')
 			end
 		end


### PR DESCRIPTION
Do not escape pipe on cmd line
backport of https://github.com/openwrt/luci/pull/3064 for openwrt-18.06