### PR TITLE
luci.mk: correct titles of zh_Hans and zh_Hant

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -39,8 +39,8 @@ LUCI_LANG.sv=Svenska (Swedish)
 LUCI_LANG.tr=Türkçe (Turkish)
 LUCI_LANG.uk=Українська (Ukrainian)
 LUCI_LANG.vi=Tiếng Việt (Vietnamese)
-LUCI_LANG.zh_Hans=中文 (Chinese)
-LUCI_LANG.zh_Hant=臺灣華語 (Taiwanese)
+LUCI_LANG.zh_Hans=简体中文 (Chinese Simplified)
+LUCI_LANG.zh_Hant=繁體中文 (Chinese Traditional)
 
 # Submenu titles
 LUCI_MENU.col=1. Collections


### PR DESCRIPTION
zh_Hans: 简体中文 (Chinese Simplified)
zh_Hant: 繁體中文 (Chinese Traditional)