### PR TITLE
luci-base: Show used memory instead of Free

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
@@ -23,7 +23,7 @@ return L.Class.extend({
 	title: _('Memory'),
 
 	load: function() {
-		return L.resolveDefault(callSystemInfo(), {});
+		return L.resolveDefault(callSystemInfo(), {}); 
 	},
 
 	render: function(systeminfo) {

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
@@ -32,7 +32,7 @@ return L.Class.extend({
 
 		var fields = [
 			_('Total Available'), (mem.available) ? mem.available : (mem.total && mem.free && mem.buffered) ? mem.free + mem.buffered : null, mem.total,
-			_('Free'),            (mem.total && mem.free) ? mem.free : null, mem.total,
+			_('Used'),            (mem.total && mem.free) ? (mem.total - mem.free) : null, mem.total,
 			_('Buffered'),        (mem.total && mem.buffered) ? mem.buffered : null, mem.total
 		];
 


### PR DESCRIPTION
This makes sure solid/blue bar shows the used memory. Fix #3682

Signed-off-by: Howard Su howard0su@gmail.com