### PR TITLE
luci-app-nextdns: add uci read permissions

### DIFF
--- a/applications/luci-app-nextdns/root/usr/share/rpcd/acl.d/luci-app-nextdns.json
+++ b/applications/luci-app-nextdns/root/usr/share/rpcd/acl.d/luci-app-nextdns.json
@@ -2,6 +2,7 @@
 	"luci-app-nextdns": {
 		"description": "Grant logread access to LuCI app nextdns",
 		"read": {
+			"uci": ["nextdns"],
 			"file": {
 				"/sbin/logread": [ "exec" ]
 			}


### PR DESCRIPTION
Fixes  uci read permissions to nextdns.

Signed-off-by: Jeff Collins <jeffcollins9292@gmail.com>