### PR TITLE
luci-app-dawn: stop adding not used config files

### DIFF
--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
@@ -1,4 +1,4 @@
-m = Map("Hearing Map", translate("Hearing Map"))
+m = Map("dawn", "Hearing Map", translate("Hearing Map"))
 m.pageaction = false
 
 s = m:section(NamedSection, "__hearingmap__")

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
@@ -1,4 +1,4 @@
-m = Map("Network Overview", translate("Network Overview"))
+m = Map("dawn", "Network Overview", translate("Network Overview"))
 m.pageaction = false
 
 s = m:section(NamedSection, "__networkoverview__")


### PR DESCRIPTION
Fixes https://github.com/berlin-open-wireless-lab/DAWN/issues/64.

The app adds config files under /etc/config/ for the Hearing Map and the Network Overview. Change to SimpleForm fixes the issue.