### PR TITLE
luci_app_statistics: Add syslog plugin and activate by default

### DIFF
--- a/applications/luci-app-statistics/Makefile
+++ b/applications/luci-app-statistics/Makefile
@@ -18,7 +18,8 @@ LUCI_DEPENDS:= \
 	+collectd-mod-memory \
 	+collectd-mod-interface \
 	+collectd-mod-load \
-	+collectd-mod-network
+	+collectd-mod-network \
+	+collectd-mod-syslog
 
 define Package/luci-app-statistics/conffiles
 /etc/config/luci_statistics

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/syslog.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/syslog.js
@@ -1,0 +1,33 @@
+'use strict';
+'require baseclass';
+'require form';
+
+return baseclass.extend({
+	title: _('Syslog Plugin Configuration'),
+	description: _('The SysLog plugin receives log messages from the daemon and dispatches them to syslog.'),
+
+	addFormOptions: function(s) {
+		var o, ss;
+
+		o = s.option(form.Flag, 'enable', _('Enable this plugin'));
+		o.default = '0';
+
+		o = s.option(form.ListValue, 'LogLevel', _('Log level'), _('Sets the syslog log-level.'));
+		o.value('err');
+		o.value('warning');
+		o.value('notice');
+		o.value('info');
+		o.value('debug');
+		o.rmempty = false;
+
+		o = s.option(form.ListValue, 'NotifyLevel', _('Notify level'), _('Controls which notifications should be sent to syslog.'));
+		o.value('FAILURE');
+		o.value('WARNING');
+		o.value('OKAY');
+		o.rmempty = false;
+    },
+
+	configSummary: function(section) {
+		return _('Syslog enabled');
+	}
+});

--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -23,6 +23,11 @@ config statistics 'collectd_rrdtool'
 	option RRASingle '1'
 	option RRATimespans '1hour 1day 1week 1month 1year'
 
+config statistics 'collectd_syslog'
+	option enable '1'
+	option LogLevel 'warning'
+	option NotifyLevel 'WARNING'
+
 config statistics 'collectd_csv'
 	option enable '0'
 	option StoreRates '0'

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -279,6 +279,11 @@ plugins = {
 		{ "Timestamp" },
 		{ }
 	},
+	syslog = {
+		{ "LogLevel", "NotifyLevel" },
+		{ },
+		{ }
+    },
 }
 
 local plugin_dir = "/usr/share/luci/statistics/plugins/"

--- a/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/syslog.json
+++ b/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/syslog.json
@@ -1,0 +1,5 @@
+{
+	"title": "Syslog",
+	"category": "output"
+}
+


### PR DESCRIPTION
Without the syslog plugin the syslog gets spammed by collectd 'notice' entries, especially when sending data from other devices.
With this plugin you can specify the log and notify level and usually warning is a suitable default setting.

Contents of this change:
- Added dependency to the syslog plugin to pull it in automatically
- Entry to the config file with default settings enabled and level set to warning
- Configuration dialog for luci
- Definition for the configuration file generator /usr/bin/stat-genconfig

Signed-off-by: Tobias Waldvogel <tobias.waldvogel@gmail.com>