### PR TITLE
Allow to disable descriptions row in TableSection + descriptions render fix

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2421,7 +2421,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 						(typeof(opt.width) == 'number') ? opt.width+'px' : opt.width;
 			}
 
-			if (this.sortable || this.extedit || this.addremove || has_more)
+			if (this.sortable || this.extedit || this.addremove || has_more || has_action)
 				trEl.appendChild(E('div', {
 					'class': 'th cbi-section-table-cell cbi-section-actions'
 				}));

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2266,6 +2266,16 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 	 */
 
 	/**
+	 * If set to `true`, the header row with the options descriptions will
+	 * not be displayed. By default, descriptions row is automatically displayed
+	 * when at least one option has a description.
+	 *
+	 * @name LuCI.form.TableSection.prototype#nodescriptions
+	 * @type boolean
+	 * @default false
+	 */
+
+	/**
 	 * The `TableSection` implementation does not support option tabbing, so
 	 * its implementation of `tab()` will always throw an exception when
 	 * invoked.
@@ -2402,7 +2412,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 			trEls.appendChild(trEl);
 		}
 
-		if (has_descriptions) {
+		if (has_descriptions && !this.nodescriptions) {
 			var trEl = E('div', {
 				'class': 'tr cbi-section-table-descr ' + anon_class
 			});


### PR DESCRIPTION
Add 'nodescriptions' property to the TableSection class that allows to disable displaying table header row with descriptions.

Also fixed descriptions row rendering at actions column for some cases.