### PR TITLE
luci-app-simple-adblock: bugfix: get package version from opkg

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=44
+PKG_RELEASE:=45
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -1,100 +1,100 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:165
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:161
 msgid "%s Error: %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:163
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:159
 msgid "%s Error: %s %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:146
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:142
 msgid "%s is blocking %s domains (with %s)."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:80
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:76
 msgid "%s is not installed or not found"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
 msgid "Add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
 msgid "Add IPv6 entries to block-list."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:206
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:202
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:260
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:256
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:178
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:174
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
 msgid "Blacklisted Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:278
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
 msgid "Blacklisted Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:289
 msgid "Blacklisted Hosts URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:136
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:132
 msgid "Cache file containing %s domains found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:156
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:152
 msgid "Collected Errors"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:140
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:136
 msgid "Compressed cache file found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:180
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
 msgid "Controls system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:251
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
 msgid "Curl download retry"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:222
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:218
 msgid "DNS Service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:224
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:220
 msgid "DNSMASQ Additional Hosts"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:225
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:221
 msgid "DNSMASQ Config"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:227
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:223
 msgid "DNSMASQ IP Set"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:229
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:225
 msgid "DNSMASQ Servers File"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
 msgid "Delay (in seconds) for on-boot start"
 msgstr ""
 
@@ -102,27 +102,27 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:266
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:262
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:237
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:233
 msgid "Do not add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:257
 msgid "Do not store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:256
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:252
 msgid "Do not use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
 msgid "Download time-out (in seconds)"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:85
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:81
 msgid "Downloading"
 msgstr ""
 
@@ -130,20 +130,20 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:267
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:263
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
 msgid "Enables debug output to /tmp/simple-adblock.log."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:86
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:82
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:88
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:84
 msgid "Fail"
 msgstr ""
 
@@ -151,56 +151,56 @@ msgstr ""
 msgid "Force Re-Download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:84
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:80
 msgid "Force Reloading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:184
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:251
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:278
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
 msgid "Individual domains to be blacklisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:273
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:269
 msgid "Individual domains to be whitelisted."
 msgstr ""
 
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:130
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:134
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:138
 msgid "Info"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:197
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:193
 msgid "LED to indicate status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:255
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:251
 msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:187
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:183
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
@@ -208,66 +208,65 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:151
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:147
 msgid "Message"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:180
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:204
 msgid ""
 "Pick the DNS resolution option to create the adblock list for, see the <a "
 "href=\"%s#dns-resolution-option\" target=\"_blank\">README</a> for details."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:194
 msgid ""
 "Pick the LED not already used in <a href=\"%s\">System LED Configuration</a>."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:211
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:207
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:209
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:210
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:212
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:213
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:214
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:216
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:219
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:215
 msgid "Please note that %s is not supported on this system."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:83
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:79
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
 msgid "Run service after set delay on boot."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:120
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:130
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:143
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:116
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:126
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:139
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:114
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:110
 msgid "Service Status [%s]"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua:4
-#: applications/luci-app-simple-adblock/root/usr/share/luci/menu.d/luci-app-simple-adblock.json:3
 msgid "Simple AdBlock"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:108
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:104
 msgid "Simple AdBlock Settings"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:255
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:251
 msgid "Simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:178
 msgid "Some output"
 msgstr ""
 
@@ -275,7 +274,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:82
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:78
 msgid "Starting"
 msgstr ""
 
@@ -283,142 +282,142 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:81
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:77
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:262
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:258
 msgid "Store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:260
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:256
 msgid "Store compressed cache file on router"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:89
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:85
 msgid "Success"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:181
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:177
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:124
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:120
 msgid "Task"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
 msgid "URLs to lists of domains to be blacklisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:283
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:279
 msgid "URLs to lists of domains to be whitelisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:289
 msgid "URLs to lists of hosts to be blacklisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:228
 msgid "Unbound AdBlock List"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:257
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:253
 msgid "Use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:183
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:179
 msgid "Verbose output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:87
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:83
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:271
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:267
 msgid "Whitelist and Blocklist Management"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:283
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:279
 msgid "Whitelisted Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:273
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:269
 msgid "Whitelisted Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:92
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:88
 msgid "failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:90
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:86
 msgid "failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:102
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:98
 msgid "failed to create blocklist or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:98
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:94
 msgid "failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:105
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:101
 msgid "failed to download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:96
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:92
 msgid "failed to format data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:101
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:97
 msgid "failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:97
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:93
 msgid "failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:94
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:90
 msgid "failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:106
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:102
 msgid "failed to parse"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:95
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:91
 msgid "failed to process whitelist"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:104
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:100
 msgid "failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:99
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:95
 msgid "failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:91
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:87
 msgid "failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:93
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:89
 msgid "failed to sort data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:103
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:99
 msgid "failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:100
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:96
 msgid "failed to unpack compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:200
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:196
 msgid "none"
 msgstr ""


### PR DESCRIPTION
This patch properly sets version and status info for the first launch on fresh install, without these values, some Web UI items are not displayed.

Signed-off-by: Stan Grishin <stangri@melmac.net>