### PR TITLE
luci-app-https-dns-proxy: add CIRA Canadian Shiled

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
@@ -1,7 +1,7 @@
 module("luci.controller.https-dns-proxy", package.seeall)
 function index()
 	if nixio.fs.access("/etc/config/https-dns-proxy") then
-		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS Over HTTPS Proxy")).acl_depends = { "luci-app-https-dns-proxy" }
+		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS HTTPS Proxy")).acl_depends = { "luci-app-https-dns-proxy" }
 		entry({"admin", "services", "https-dns-proxy", "action"}, call("https_dns_proxy_action"), nil).leaf = true
 	end
 end

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-family",
+	label = _("CIRA Canadian Shield (Family)"),
+	resolver_url = "https://family.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.30,149.112.122.30,2620:10A:80BB::30,2620:10A:80BC::30",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-private",
+	label = _("CIRA Canadian Shield (Private)"),
+	resolver_url = "https://private.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.10,149.112.122.10,2620:10A:80BB::10,2620:10A:80BC::10",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-protected",
+	label = _("CIRA Canadian Shield (Protected)"),
+	resolver_url = "https://protected.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.20,149.112.122.20,2620:10A:80BB::20,2620:10A:80BC::20",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -89,7 +89,7 @@ else
 	end
 end
 
-m = Map("https-dns-proxy", translate("DNS Over HTTPS Proxy Settings"))
+m = Map("https-dns-proxy", translate("DNS HTTPS Proxy Settings"))
 
 h = m:section(TypedSection, "_dummy", translatef("Service Status [%s %s]", packageName, packageVersion))
 h.template = "cbi/nullsection"

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -13,6 +13,18 @@ msgstr ""
 msgid "AdGuard (Standard)"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua:3
+msgid "CIRA Canadian Shield (Family)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua:3
+msgid "CIRA Canadian Shield (Private)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua:3
+msgid "CIRA Canadian Shield (Protected)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua:3
 msgid "CleanBrowsing (Adult Filter)"
 msgstr ""
@@ -30,11 +42,11 @@ msgid "Cloudflare"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
-msgid "DNS Over HTTPS Proxy"
+msgid "DNS HTTPS Proxy"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:92
-msgid "DNS Over HTTPS Proxy Settings"
+msgid "DNS HTTPS Proxy Settings"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua:3


### PR DESCRIPTION
This patch adds support for CIRA Canadian Shield DoH servers and drops "Over" from "DNS Over HTTPS Proxy" in controller/and CBI for more compact title.

Signed-off-by: Stan Grishin <stangri@melmac.net>