### PR TITLE
[19.07] luci-app-https-dns-proxy: add CIRA Canadian Shiled

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
@@ -1,7 +1,7 @@
 module("luci.controller.https-dns-proxy", package.seeall)
 function index()
 	if nixio.fs.access("/etc/config/https-dns-proxy") then
-		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS Over HTTPS Proxy"))
+		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS HTTPS Proxy"))
 		entry({"admin", "services", "https-dns-proxy", "action"}, call("https_dns_proxy_action"), nil).leaf = true
 	end
 end

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-family",
+	label = _("CIRA Canadian Shield (Family)"),
+	resolver_url = "https://family.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.30,149.112.122.30,2620:10A:80BB::30,2620:10A:80BC::30",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-private",
+	label = _("CIRA Canadian Shield (Private)"),
+	resolver_url = "https://private.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.10,149.112.122.10,2620:10A:80BB::10,2620:10A:80BC::10",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-protected",
+	label = _("CIRA Canadian Shield (Protected)"),
+	resolver_url = "https://protected.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.20,149.112.122.20,2620:10A:80BB::20,2620:10A:80BC::20",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -89,7 +89,7 @@ else
 	end
 end
 
-m = Map("https-dns-proxy", translate("DNS Over HTTPS Proxy Settings"))
+m = Map("https-dns-proxy", translate("DNS HTTPS Proxy Settings"))
 
 h = m:section(TypedSection, "_dummy", translatef("Service Status [%s %s]", packageName, packageVersion))
 h.template = "cbi/nullsection"

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:59
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:58
 msgid "%s is not installed or not found"
 msgstr ""
 
@@ -11,6 +11,18 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua:3
 msgid "AdGuard (Standard)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua:3
+msgid "CIRA Canadian Shield (Family)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua:3
+msgid "CIRA Canadian Shield (Private)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua:3
+msgid "CIRA Canadian Shield (Protected)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua:3
@@ -30,11 +42,11 @@ msgid "Cloudflare"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
-msgid "DNS Over HTTPS Proxy"
+msgid "DNS HTTPS Proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:93
-msgid "DNS Over HTTPS Proxy Settings"
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:92
+msgid "DNS HTTPS Proxy Settings"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua:3
@@ -49,7 +61,7 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:164
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:163
 msgid "EDNS client subnet"
 msgstr ""
 
@@ -65,7 +77,7 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:113
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:112
 msgid "Instances"
 msgstr ""
 
@@ -77,11 +89,11 @@ msgstr ""
 msgid "LibreDNS (No Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:147
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:146
 msgid "Listen address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:160
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:159
 msgid "Listen port"
 msgstr ""
 
@@ -93,7 +105,7 @@ msgstr ""
 msgid "ODVR (nic.cz)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:167
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:166
 msgid "Proxy server"
 msgstr ""
 
@@ -117,19 +129,19 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:120
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:119
 msgid "Resolver"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:85
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:84
 msgid "Running: %s DoH at %s:%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:97
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:96
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:95
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:94
 msgid "Service Status [%s %s]"
 msgstr ""
 
@@ -141,7 +153,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:63
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:62
 msgid "Stopped"
 msgstr ""
 
@@ -149,7 +161,7 @@ msgstr ""
 msgid "Unknown Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:114
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:113
 msgid ""
 "When you add/remove any instances below, they will be used to override the "
 "'DNS forwardings' section of <a href=\"%s\">DHCP and DNS</a>."
@@ -159,7 +171,7 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:65
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:64
 msgid "disabled"
 msgstr ""
 


### PR DESCRIPTION
This patch adds support for CIRA Canadian Shield DoH servers and drops "Over" from "DNS Over HTTPS Proxy" in controller/and CBI for more compact title.

Signed-off-by: Stan Grishin <stangri@melmac.net>