### PR TITLE
[18.06] luci-app-https-dns-proxy: add CIRA Canadian Shiled

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=3
+PKG_RELEASE:=5
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
@@ -1,7 +1,7 @@
 module("luci.controller.https-dns-proxy", package.seeall)
 function index()
 	if nixio.fs.access("/etc/config/https-dns-proxy") then
-		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS Over HTTPS Proxy"))
+		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS HTTPS Proxy"))
 		entry({"admin", "services", "https-dns-proxy", "action"}, call("https_dns_proxy_action"), nil).leaf = true
 	end
 end

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-family",
+	label = _("CIRA Canadian Shield (Family)"),
+	resolver_url = "https://family.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.30,149.112.122.30,2620:10A:80BB::30,2620:10A:80BC::30",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-private",
+	label = _("CIRA Canadian Shield (Private)"),
+	resolver_url = "https://private.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.10,149.112.122.10,2620:10A:80BB::10,2620:10A:80BC::10",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
@@ -1,0 +1,8 @@
+return {
+	name = "cira-canadian-shield-protected",
+	label = _("CIRA Canadian Shield (Protected)"),
+	resolver_url = "https://protected.canadianshield.cira.ca/dns-query",
+	bootstrap_dns = "149.112.121.20,149.112.122.20,2620:10A:80BB::20,2620:10A:80BC::20",
+	help_link = "https://www.cira.ca/cybersecurity-services/canadian-shield/",
+	help_link_text = "CIRA Canadian Shield"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -49,24 +49,22 @@ function get_provider_name(value)
 	return translate("Unknown Provider")
 end
 
-local tmpfsStatus, tmpfsStatusCode
+local packageStatus, packageStatusCode
 local ubusStatus = util.ubus("service", "list", { name = packageName })
-local tmpfsVersion = tostring(util.trim(sys.exec("opkg list-installed " .. packageName .. " | awk '{print $3}'")))
+local packageVersion = tostring(util.trim(sys.exec("opkg list-installed " .. packageName .. " | awk '{print $3}'"))) or ""
 
-if not tmpfsVersion or tmpfsVersion == "" then
-	tmpfsStatusCode = -1
-	tmpfsVersion = ""
-	tmpfsStatus = packageName .. " " .. translate("is not installed or not found")
+if packageVersion == "" then
+	packageStatusCode = -1
+	packageStatus = translatef("%s is not installed or not found", packageName)
 else  
-	tmpfsVersion = " [" .. packageName .. " " .. tmpfsVersion .. "]"
 	if not ubusStatus or not ubusStatus[packageName] then
-		tmpfsStatusCode = 0
-		tmpfsStatus = translate("Stopped")
-		if not luci.sys.init.enabled(packageName) then
-			tmpfsStatus = tmpfsStatus .. " (" .. translate("disabled") .. ")"
+		packageStatusCode = 0
+		packageStatus = translate("Stopped")
+		if not sys.init.enabled(packageName) then
+			packageStatus = packageStatus .. " (" .. translate("disabled") .. ")"
 		end
 	else
-		tmpfsStatusCode, tmpfsStatus = 1, ""
+		packageStatusCode, packageStatus = 1, ""
 		for n = 1,1000 do
 			if ubusStatus and ubusStatus[packageName] and 
 				 ubusStatus[packageName]["instances"] and 
@@ -83,7 +81,7 @@ else
 				end
 				la = la or "127.0.0.1"
 				lp = lp or n + 5053
-				tmpfsStatus = tmpfsStatus .. translate("Running") .. ": " .. get_provider_name(url) .. " " .. translate("DoH") .. " " .. translate("at") .. " " .. la .. ":" .. lp .. "\n"
+				packageStatus = packageStatus .. translatef("Running: %s DoH at %s:%s", get_provider_name(url), la, lp) .. "\n"
 			else
 				break
 			end
@@ -91,29 +89,28 @@ else
 	end
 end
 
-m = Map("https-dns-proxy", translate("DNS Over HTTPS Proxy Settings"))
+m = Map("https-dns-proxy", translate("DNS HTTPS Proxy Settings"))
 
-h = m:section(TypedSection, "_dummy", translate("Service Status") .. tmpfsVersion)
+h = m:section(TypedSection, "_dummy", translatef("Service Status [%s %s]", packageName, packageVersion))
 h.template = "cbi/nullsection"
 ss = h:option(DummyValue, "_dummy", translate("Service Status"))
-if tmpfsStatusCode == -1 then
+if packageStatusCode == -1 then
 	ss.template = packageName .. "/status"
-	ss.value = tmpfsStatus
+	ss.value = packageStatus
 else
-		if tmpfsStatusCode == 0 then
+		if packageStatusCode == 0 then
 			ss.template = packageName .. "/status"
 		else
 			ss.template = packageName .. "/status-textarea"
 		end
-	ss.value = tmpfsStatus
+	ss.value = packageStatus
 	buttons = h:option(DummyValue, "_dummy")
 	buttons.template = packageName .. "/buttons"
 end
 
 create_helper_text()
-s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), translate("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of ")
-		.. [[ <a href="]] .. dispatcher.build_url("admin/network/dhcp") .. [[">]]
-		.. translate("DHCP and DNS") .. [[</a>]] .. "." .. helperText)
+s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), 
+	translatef("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of <a href=\"%s\">DHCP and DNS</a>.", dispatcher.build_url("admin/network/dhcp")) .. helperText)
 s3.template = "cbi/tblsection"
 s3.sortable  = false
 s3.anonymous = true

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,12 +1,28 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:58
+msgid "%s is not installed or not found"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua:3
 msgid "AdGuard (Family Protection)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua:3
 msgid "AdGuard (Standard)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua:3
+msgid "CIRA Canadian Shield (Family)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua:3
+msgid "CIRA Canadian Shield (Private)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua:3
+msgid "CIRA Canadian Shield (Protected)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua:3
@@ -25,16 +41,12 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:116
-msgid "DHCP and DNS"
-msgstr ""
-
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
-msgid "DNS Over HTTPS Proxy"
+msgid "DNS HTTPS Proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:94
-msgid "DNS Over HTTPS Proxy Settings"
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:92
+msgid "DNS HTTPS Proxy Settings"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua:3
@@ -49,11 +61,7 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
-msgid "DoH"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:166
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:163
 msgid "EDNS client subnet"
 msgstr ""
 
@@ -69,7 +77,7 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:114
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:112
 msgid "Instances"
 msgstr ""
 
@@ -81,11 +89,11 @@ msgstr ""
 msgid "LibreDNS (No Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:149
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:146
 msgid "Listen address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:162
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:159
 msgid "Listen port"
 msgstr ""
 
@@ -97,7 +105,7 @@ msgstr ""
 msgid "ODVR (nic.cz)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:169
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:166
 msgid "Proxy server"
 msgstr ""
 
@@ -121,17 +129,20 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:122
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:119
 msgid "Resolver"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
-msgid "Running"
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:84
+msgid "Running: %s DoH at %s:%s"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:96
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:98
 msgid "Service Status"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:94
+msgid "Service Status [%s %s]"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:41
@@ -142,7 +153,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:64
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:62
 msgid "Stopped"
 msgstr ""
 
@@ -150,26 +161,18 @@ msgstr ""
 msgid "Unknown Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:114
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:113
 msgid ""
 "When you add/remove any instances below, they will be used to override the "
-"'DNS forwardings' section of"
+"'DNS forwardings' section of <a href=\"%s\">DHCP and DNS</a>."
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:34
 msgid "and"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:86
-msgid "at"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:66
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:64
 msgid "disabled"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:59
-msgid "is not installed or not found"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/cn.rubyfish.dns.lua:3


### PR DESCRIPTION
This patch adds support for CIRA Canadian Shield DoH servers and drops "Over" from "DNS Over HTTPS Proxy" in controller/and CBI for more compact title.

Signed-off-by: Stan Grishin <stangri@melmac.net>