### PR TITLE
luci-app-vnstat2: fix ACL rules, disable button on insufficient ACLs

### DIFF
--- a/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
+++ b/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
@@ -8,6 +8,8 @@
 'require form';
 'require tools.widgets as widgets';
 
+var isReadonlyView = !L.hasViewPermission() || null;
+
 return view.extend({
 	handleDeleteModal: function(m, iface, ev) {
 		L.showModal(_('Delete interface <em>%h</em>').format(iface), [
@@ -88,7 +90,8 @@ return view.extend({
 					this.interfaces[i],
 					E('button', {
 						'class': 'btn cbi-button-remove',
-						'click': ui.createHandlerFn(view, 'handleDeleteModal', m, this.interfaces[i])
+						'click': ui.createHandlerFn(view, 'handleDeleteModal', m, this.interfaces[i]),
+						'disabled': isReadonlyView
 					}, [ _('Delete…') ])
 				]);
 			}

--- a/applications/luci-app-vnstat2/root/usr/share/rpcd/acl.d/luci-app-vnstat2.json
+++ b/applications/luci-app-vnstat2/root/usr/share/rpcd/acl.d/luci-app-vnstat2.json
@@ -6,7 +6,8 @@
 			"file": {
 				"/usr/bin/vnstat --json f 1": [ "exec" ],
 				"/usr/bin/vnstati -[5dhmsty] -i * -o -": [ "exec" ]
-			}
+			},
+			"uci": [ "vnstat" ]
 		},
 		"write": {
 			"file": {


### PR DESCRIPTION
This fixes the missing uci read ACL rule, and disables the delete button when the granted permissions are read-only.

Signed-off-by: Jan Hoffmann <jan@3e8.eu>