### PR TITLE
Correct link for brand / logo

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -41,7 +41,7 @@
 		<header>
 			<div class="fill">
 				<div class="container">
-					<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
+					<a class="brand" href="<% if luci.dispatcher.context.authsession then %><%=url('admin/status/overview')%><% else %>#<% end %>"><%=boardinfo.hostname or "?"%></a>
 					<ul class="nav" id="topmenu" style="display:none"></ul>
 					<div id="indicators" class="pull-right"></div>
 				</div>


### PR DESCRIPTION
In the Material theme, clicking on the logo takes you to the status page - as it should, makes sense. But in Bootstrap, it doesn't do anything => just pulling the same href from Material to Bootstrap, so the link works in Bootstrap also.

Thanks!