### PR TITLE
Update href for Bootstrap "brand"

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -41,7 +41,7 @@
 		<header>
 			<div class="fill">
 				<div class="container">
-					<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
+					<a class="brand" href="<% if luci.dispatcher.context.authsession then %><%=url('admin/status/overview')%><% else %>#<% end %>"><%=boardinfo.hostname or "?"%></a>
 					<ul class="nav" id="topmenu" style="display:none"></ul>
 					<div id="indicators" class="pull-right"></div>
 				</div>

--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -41,7 +41,7 @@
 		<header>
 			<div class="fill">
 				<div class="container">
-					<a class="brand" href="<% if luci.dispatcher.context.authsession then %><%=url('admin/status/overview')%><% else %>#<% end %>"><%=boardinfo.hostname or "?"%></a>
+					<a class="brand" href="/"><%=boardinfo.hostname or "?"%></a>
 					<ul class="nav" id="topmenu" style="display:none"></ul>
 					<div id="indicators" class="pull-right"></div>
 				</div>

--- a/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
+++ b/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
@@ -39,7 +39,7 @@
 <div id="menubar">
 	<h2 class="navigation"><a id="navigation" name="navigation"><%:Navigation%></a></h2>
 
-	<span class="hostname"><%=(boardinfo.hostname or "?")%></span>
+	<span class="hostname"><a href="/"><%=(boardinfo.hostname or "?")%></a></span>
 	<span class="distversion"><%=ver.distversion%></span>
 	<span id="indicators"></span>
 </div>


### PR DESCRIPTION
In the Material theme, clicking on the logo takes you to the status page.
This seems logical, and is very helpful. But in Bootstrap, it doesn't
do anything, so just pulling the same href from Material to Bootstrap,
so the link works in Bootstrap as well.