### PR TITLE
Change the translation of frequency in ntpc to semantically appropriate translation

### DIFF
--- a/applications/luci-app-ser2net/root/usr/share/rpcd/acl.d/luci-app-ser2net.json
+++ b/applications/luci-app-ser2net/root/usr/share/rpcd/acl.d/luci-app-ser2net.json
@@ -1,6 +1,9 @@
 {
 	"luci-app-ser2net": {
 		"description": "Grant access to LuCI app ser2net",
+		"read": {
+			"uci": [ "ser2net" ]
+		},
 		"write": {
 			"uci": [ "ser2net" ]
 		}


### PR DESCRIPTION
Different words are used in Japanese for the frequency of radio waves and  the frequency of repeated work.
And I add 1 translation. 

Signed-off-by: Satoru Yoshida <satoruyoshida@php.net>