### PR TITLE
[18.06] luci-app-https-dns-proxy: bugfix: remove escaped double-quotes from translateable resources

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
@@ -1,7 +1,7 @@
 module("luci.controller.https-dns-proxy", package.seeall)
 function index()
 	if nixio.fs.access("/etc/config/https-dns-proxy") then
-		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS HTTPS Proxy"))
+		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS HTTPS Proxy")).acl_depends = { "luci-app-https-dns-proxy" }
 		entry({"admin", "services", "https-dns-proxy", "action"}, call("https_dns_proxy_action"), nil).leaf = true
 	end
 end

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -110,7 +110,7 @@ end
 
 create_helper_text()
 s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), 
-	translatef("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of <a href=\"%s\">DHCP and DNS</a>.", dispatcher.build_url("admin/network/dhcp")) .. helperText)
+	translatef("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of %sDHCP and DNS%s.", "<a href=\"" .. dispatcher.build_url("admin/network/dhcp") .. "\">", "</a>") .. helperText)
 s3.template = "cbi/tblsection"
 s3.sortable  = false
 s3.anonymous = true

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -164,7 +164,7 @@ msgstr ""
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:113
 msgid ""
 "When you add/remove any instances below, they will be used to override the "
-"'DNS forwardings' section of <a href=\"%s\">DHCP and DNS</a>."
+"'DNS forwardings' section of %sDHCP and DNS%s."
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:34


### PR DESCRIPTION

Signed-off-by: Stan Grishin <stangri@melmac.net>