### PR TITLE
[19.07] luci-app-simple-adblock: bugfix: remove escaped double-quotes from translateable resources

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=45
+PKG_RELEASE:=46
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua
@@ -1,7 +1,7 @@
 module("luci.controller.simple-adblock", package.seeall)
 function index()
 	if nixio.fs.access("/etc/config/simple-adblock") then
-		entry({"admin", "services", "simple-adblock"}, cbi("simple-adblock"), _("Simple AdBlock"))
+		entry({"admin", "services", "simple-adblock"}, cbi("simple-adblock"), _("Simple AdBlock")).acl_depends = { "luci-app-simple-adblock" }
 		entry({"admin", "services", "simple-adblock", "action"}, call("simple_adblock_action"), nil).leaf = true
 	end
 end

--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
@@ -191,7 +191,7 @@ if fs.access(sysfs_path) then
 end
 if #leds ~= 0 then
 	o4 = s:taboption("basic", Value, "led", translate("LED to indicate status"),
-		translatef("Pick the LED not already used in <a href=\"%s\">System LED Configuration</a>.", dispatcher.build_url("admin", "system", "leds")))
+		translatef("Pick the LED not already used in %sSystem LED Configuration%s.", "<a href=\"" .. dispatcher.build_url("admin", "system", "leds") .. "\">", "</a>"))
 	o4.rmempty = false
 	o4:value("", translate("none"))
 	for k, v in ipairs(leds) do

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -223,8 +223,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:194
-msgid ""
-"Pick the LED not already used in <a href=\"%s\">System LED Configuration</a>."
+msgid "Pick the LED not already used in %sSystem LED Configuration%s."
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:207


### PR DESCRIPTION

Signed-off-by: Stan Grishin <stangri@melmac.net>