### PR TITLE
luci-app-wireguard: show hint in status page if no entry defined yet

### DIFF
--- a/applications/luci-app-wireguard/luasrc/view/wireguard.htm
+++ b/applications/luci-app-wireguard/luasrc/view/wireguard.htm
@@ -182,6 +182,17 @@
 <h2>WireGuard Status</h2>
 
 <div class="cbi-section">
+
+<% if next(data) == nil then %>
+	<div class="table cbi-section-table">
+		<div class="tr cbi-section-table-row">
+			<p>
+				<em><%:This section contains no values yet%></em>
+			</p>
+		</div>
+	</div>
+<% end %>
+
 <%-
 local ikey, iface
 for ikey, iface in pairs(data) do


### PR DESCRIPTION
If nothing is configured yet for wireguard, you only see an empty box, not knowing whether there happened an error not displaying anything, machine still busy, ...

This patch adds the standard message "This section contains no values yet" for better user guidance.