### PR TITLE
luci-app-transmission: add the read permissions for widgets

### DIFF
--- a/applications/luci-app-transmission/root/usr/share/rpcd/acl.d/luci-app-transmission.json
+++ b/applications/luci-app-transmission/root/usr/share/rpcd/acl.d/luci-app-transmission.json
@@ -3,6 +3,8 @@
 		"description": "Grant UCI access for luci-app-transmission",
 		"read": {
 			"file": {
+				"/etc/group": [ "read" ],
+				"/etc/passwd": [ "read" ],
 				"/usr/share/transmission/web/index.html": [ "list" ]
 			},
 			"ubus": {


### PR DESCRIPTION
Currently, the `UserSelect` and `GroupSelect` widgets provided by widgets.js have been broken by the loss of read permissions.

Before:
![before](https://user-images.githubusercontent.com/30111323/81264455-01dba780-9074-11ea-8479-1114469b68ae.png)

After:
![after](https://user-images.githubusercontent.com/30111323/81264624-4b2bf700-9074-11ea-8a47-bfcc48ca245f.png)

Signed-off-by: Van Waholtz <vanwaholtz@gmail.com>