### PR TITLE
luci-app-commands: do not escape pipe on cmd line

### DIFF
--- a/applications/luci-app-commands/luasrc/controller/commands.lua
+++ b/applications/luci-app-commands/luasrc/controller/commands.lua
@@ -144,7 +144,7 @@ local function parse_cmdline(cmdid, args)
 		end
 
 		for i, v in ipairs(argv) do
-			if v:match("[^%w%.%-i/]") then
+			if v:match("[^%w%.%-i/|]") then
 				argv[i] = '"%s"' % v:gsub('"', '\\"')
 			end
 		end


### PR DESCRIPTION
Signed-off-by: Andi Peh <h4de5@gmx.at>