### PR TITLE
luci-app-acme: Update acme.sh URL, add support for challenge & domain alises.

### DIFF
--- a/applications/luci-app-acme/luasrc/model/cbi/acme.lua
+++ b/applications/luci-app-acme/luasrc/model/cbi/acme.lua
@@ -93,16 +93,25 @@ dom.datatype = "list(string)"
 
 dns = cs:option(Value, "dns", translate("DNS API"),
                 translate("To use DNS mode to issue certificates, set this to the name of a DNS API supported by acme.sh. " ..
-                          "See https://github.com/Neilpang/acme.sh/tree/master/dnsapi for the list of available APIs. " ..
+                          "See https://github.com/acmesh-official/acme.sh/wiki/dnsapi for the list of available APIs. " ..
                           "In DNS mode, the domain name does not have to resolve to the router IP. " ..
                           "DNS mode is also the only mode that supports wildcard certificates. " ..
                           "Using this mode requires the acme-dnsapi package to be installed."))
-dns.optional = true
 
 cred = cs:option(DynamicList, "credentials", translate("DNS API credentials"),
                  translate("The credentials for the DNS API mode selected above. " ..
-                           "See https://github.com/Neilpang/acme.sh/tree/master/dnsapi#how-to-use-dns-api for the format of credentials required by each API. " ..
+                           "See https://github.com/acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required by each API. " ..
                            "Add multiple entries here in KEY=VAL shell variable format to supply multiple credential variables."))
 cred.datatype = "list(string)"
+
+calias = cs:option(Value, "calias", translate("Challenge Alias"),
+                translate("The challenge alias to use for ALL domains. " ..
+                "See https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode for the details of this process. " ..
+                "LUCI only supports one challenge alias per certificate."))
+
+dalias = cs:option(Value, "dalias", translate("Domain Alias"),
+                translate("The domain alias to use for ALL domains. " ..
+                "See https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode for the details of this process. " ..
+                "LUCI only supports one challenge domain per certificate."))
 
 return m


### PR DESCRIPTION
Signed-off-by: Will O'Neill <0100wrxb@gmail.com>

Maintainer: @tohojo 
Compile tested: Snapshot, default target (for makefile download of new URL)
Run tested: ramips_mt7621_DEVICE_ubnt_edgerouter-x (for shell scritp run)

Description:
1) The acme.sh project has moved on github to [acmesh-official](https://github.com/acmesh-official/acme.sh)
2) I have added some simple logic in the script to support challenge and domain aliases. These related functions allow using CNAME records from the main domain to point to a different domain where the script can modify text records.

I am preparing an associated packages commit with the script file changes.