### PR TITLE
luci-proto-wireguard: fix value validation

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -124,7 +124,14 @@ return network.registerProtocol('wireguard', {
 
 		o = ss.option(form.DynamicList, 'allowed_ips', _('Allowed IPs'), _("Required. IP addresses and prefixes that this peer is allowed to use inside the tunnel. Usually the peer's tunnel IP addresses and the networks the peer routes through the tunnel."));
 		o.datatype = 'ipaddr';
-		o.rmempty = false;
+		o.validate = function(section, value) {
+			var opt = this.map.lookupOption('allowed_ips', section);
+			var ips = opt[0].formvalue(section);
+			if (ips.length == 0) {
+				return _('Value must not be empty');
+			}
+			return true;
+		};
 
 		o = ss.option(form.Flag, 'route_allowed_ips', _('Route Allowed IPs'), _('Optional. Create routes for Allowed IPs for this peer.'));
 

--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -10,6 +10,9 @@ function validateBase64(section_id, value) {
 	if (value.length != 44 || !value.match(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/))
 		return _('Invalid Base64 key string');
 
+	if (value[43] != "=" )
+		return _('Invalid Base64 key string');
+
 	return true;
 }
 


### PR DESCRIPTION
* add warning that `allowed_ips` must not be empty

* verify last base64 string symbol is an `=` sig
If this is not the case I get the following error during connection
```
Thu Apr 30 11:37:42 2020 daemon.notice netifd: wg1 (23647): Key is not the correct length or format: `3UW+WgCasdu1SEOngdwYZm2jc5ogAQx9GQAjCt520g01'
Thu Apr 30 11:37:42 2020 daemon.notice netifd: wg1 (23647): Configuration parsing error
```