### PR TITLE
build/i18n-merge-master: ignore apps deleted in master

### DIFF
--- a/build/i18n-merge-master.pl
+++ b/build/i18n-merge-master.pl
@@ -7,9 +7,14 @@ if (open F, '-|', 'find', $ARGV[0] || '.', '-type', 'f', '-name', '*.po') {
 		(my $ref = $path) =~ s/\.po$/\.master.po/;
 
 		printf 'Updating %s ', $path;
-		system("git show --format=\%B 'master:$path' > '$ref'");
-		system('msgmerge', '-N', '-o', $path, $ref, $path);
-		system('msgattrib', '--no-obsolete', '-o', $path, $path);
+		my $returnCode = system("git show --format=\%B 'master:$path' > '$ref'");
+		if ( $returnCode == 0 )
+		{
+			system('msgmerge', '-N', '-o', $path, $ref, $path);
+			system('msgattrib', '--no-obsolete', '-o', $path, $path);
+		} else {
+			print "...failed due to git error.\n";
+		}
 		unlink($ref);
 	}
 


### PR DESCRIPTION
Refine the code to ignore apps that have been deleted from master but still exist in release branches. E.g. luci-app-samba

Previously the unhandled git error from non-existing master mangled the .po files in the release branch: the 18n header was removed and all non-ASCII chars were deleted from translation.

Fix this by processing only those files where 'git show' succeeds.

I author this in 19.07, as it can be tested there. (I will later cherry-pick it to master)

----------------

Background:

@jow- 
I have been using the merge-master script that you adapted from the idea from @urbalazs in the weblate discussion 

Generally it works ok, but has some quirks.

Two issues:

1 )
mostly information for you & others:
The working workflow requires running i18n-sync both before and after i18n-merge-master.

The first i18n-sync run is to get the 19.07 repo in sync with the 19.07 apps, 
then the backport of translations from the master is done with merge-master, and 
finally a second run of i18n-sync to cleanup (as otherwise the merge-master seems to destroy some strings that are still needed).

That was mostly just a workflow FYI for you.
This PR does not attempt to fix that.

2 )
The actual issue fixed by this PR is that i18n-merge-master mishandles apps that have been deleted in master, but still exist in the release branch. For example, luci-app-samba translations get deleted, if merge-master is now run in 19.07.

I traced it to `system("git show --format=\%B 'master:$path' > '$ref'");` producing an error instead of the proper contents, and as there is no error checking, the wrong content gets passed to msgmerge etc., which leads into mangling the .po file.
```
		system("git show --format=\%B 'master:$path' > '$ref'");
		system('msgmerge', '-N', '-o', $path, $ref, $path);
```

For most languages, only the info header gets removed from the output , but for cyrilic and asian languages, most of the translations get destroyed or modified as only ASCII seems to be accepted. Apparently the UTF-8 string in the header is really needed.

The solution is to have an error check after "git show".
(git show seems to produce shell error code 0 with a valid file and 128 with a non-existent reference.)

Example about Ukraine:

perus@ub2004:/Openwrt/github/luci$ git checkout -- .
perus@ub2004:/Openwrt/github/luci$ ./build/i18n-merge-master.pl applications/luci-app-samba/po/uk/samba.po
Updating applications/luci-app-samba/po/uk/samba.po fatal: Path 'applications/luci-app-samba/po/uk/samba.po' exists on disk, but not in 'master'.
..... done.
applications/luci-app-samba/po/uk/samba.po:18: invalid multibyte sequence
applications/luci-app-samba/po/uk/samba.po:18: invalid multibyte sequence
applications/luci-app-samba/po/uk/samba.po:18: invalid multibyte sequence
applications/luci-app-samba/po/uk/samba.po:18: invalid multibyte sequence
...

Changes in the po file:
```
diff --git a/applications/luci-app-samba/po/uk/samba.po b/applications/luci-app-samba/po/uk/samba.po
index 821301c8c..f87f9a155 100644
--- a/applications/luci-app-samba/po/uk/samba.po
+++ b/applications/luci-app-samba/po/uk/samba.po
@@ -1,104 +1,85 @@
-msgid ""
-msgstr ""
-"Project-Id-Version: \n"
-"PO-Revision-Date: 2020-02-19 13:29+0000\n"
-"Last-Translator: Yurii Petrashko <yuripet@gmail.com>\n"
-"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationssamba/uk/>\n"
-"Language: uk\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 3.11\n"
-
 #: applications/luci-app-samba/luasrc/model/cbi/samba.lua:64
 msgid "Allow guests"
-msgstr "Дозволити гостьовий вхід"
+msgstr "  "
 
 #: applications/luci-app-samba/luasrc/model/cbi/samba.lua:17
 msgid "Allow system users to reach their home directories via network shares"
-msgstr ""
-"Дозволити користувачам системи досягати своїх домашніх каталогів через "
-"спільні мережеві ресурси"
+msgstr "          "
 ```

The same happens also for European languages with accents.
```
--- a/applications/luci-app-samba/po/ca/samba.po
+++ b/applications/luci-app-samba/po/ca/samba.po
@@ -1,21 +1,3 @@
-#  samba.pot
-#  generated from ./applications/luci-samba/luasrc/i18n/samba.en.lua
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2009-06-10 03:40+0200\n"
-"PO-Revision-Date: 2019-10-21 07:49+0000\n"
-"Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
-"Language-Team: Catalan <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationssamba/ca/>\n"
-"Language: ca\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.9.1-dev\n"
-
 #: applications/luci-app-samba/luasrc/model/cbi/samba.lua:64
 msgid "Allow guests"
 msgstr "Permet convidats"
@@ -36,15 +18,15 @@ msgstr ""
 
 #: applications/luci-app-samba/luasrc/model/cbi/samba.lua:69
 msgid "Create mask"
-msgstr "Crea màscara"
+msgstr "Crea mscara"
 
 #: applications/luci-app-samba/luasrc/model/cbi/samba.lua:14
 msgid "Description"
-msgstr "Descripció"
+msgstr "Descripci"
```

After this PR, the file gets ignored:
```
Updating ./applications/luci-app-squid/po/nb_NO/squid.po .... done.
Updating ./applications/luci-app-squid/po/fr/squid.po .... done.
Updating ./applications/luci-app-samba/po/zh_Hant/samba.po fatal: Path 'applications/luci-app-samba/po/zh_Hant/samba.po' exists on disk, but not in 'master'.
...failed due to git error.
Updating ./applications/luci-app-samba/po/mr/samba.po fatal: Path 'applications/luci-app-samba/po/mr/samba.po' exists on disk, but not in 'master'.
...failed due to git error.
Updating ./applications/luci-app-samba/po/el/samba.po fatal: Path 'applications/luci-app-samba/po/el/samba.po' exists on disk, but not in 'master'.
...failed due to git error.

```
