### PR TITLE
luci-base: German translation: Use the uniform term "WLAN"

### DIFF
--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -1331,7 +1331,7 @@ msgid ""
 msgstr ""
 "Das Gerät konnte nach Anwendung der Konfigurationsänderungen nicht mehr "
 "erreicht werden. Unter Umständen müssen Sie sich neu verbinden wenn "
-"netzwerkbezogene Einstellungen wie die IP-Adresse oder W-LAN Passwörter "
+"netzwerkbezogene Einstellungen wie die IP-Adresse oder WLAN Passwörter "
 "geändert wurden."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:189
@@ -1886,7 +1886,7 @@ msgstr "Dieses Netzwerk bearbeiten"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:793
 msgid "Edit wireless network"
-msgstr "Drahtlosnetzwerk bearbeiten"
+msgstr "WLAN-Netzwerk bearbeiten"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Emergency"
@@ -2530,7 +2530,7 @@ msgstr "Gewähre Zugriff auf den Routing-Status"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json:120
 msgid "Grant access to wireless status display"
-msgstr "Gewähre Zugriff auf die Drahtlosnetz-Statusanzeige"
+msgstr "Gewähre Zugriff auf die WLAN-Statusanzeige"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:66
 msgid "Group Password"
@@ -4920,7 +4920,7 @@ msgstr "Entfernen"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1906
 msgid "Replace wireless configuration"
-msgstr "Drahtloskonfiguration ersetzen"
+msgstr "WLAN-Konfiguration ersetzen"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:17
 msgid "Request IPv6-address"
@@ -5076,7 +5076,7 @@ msgstr "Firewall neu starten"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:815
 msgid "Restart radio interface"
-msgstr "W-LAN-Gerät neu starten"
+msgstr "WLAN-Gerät neu starten"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:372
 msgid "Restore"
@@ -5951,7 +5951,7 @@ msgid ""
 "The existing wireless configuration needs to be changed for LuCI to function "
 "properly."
 msgstr ""
-"Die existierende Drahtlos-Konfiguration muss geändert werden damit LuCI "
+"Die existierende WLAN-Konfiguration muss geändert werden damit LuCI "
 "richtig funktioniert."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:215
@@ -6550,7 +6550,7 @@ msgid ""
 "restarted to apply the updated configuration."
 msgstr ""
 "Beim Fortfahren werden unbenannte \"wifi-iface\" Sektionen in der "
-"Drahtloskonfiguration mit Namen in der Form <em>wifinet#</em> versehen und "
+"WLAN-Konfiguration mit Namen in der Form <em>wifinet#</em> versehen und "
 "das Netzwerk wird neu gestartet um die geänderte Konfiguration anzuwenden."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:81
@@ -6918,11 +6918,11 @@ msgstr "WLAN-Gerät"
 #: modules/luci-compat/luasrc/model/network.lua:1405
 #: modules/luci-compat/luasrc/model/network.lua:1868
 msgid "Wireless Network"
-msgstr "Drahtlosnetzwerk"
+msgstr "WLAN-Netzwerk"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
 msgid "Wireless Overview"
-msgstr "Drahtlosübersicht"
+msgstr "WLAN-Übersicht"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:922
 msgid "Wireless Security"
@@ -6930,19 +6930,19 @@ msgstr "WLAN-Verschlüsselung"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:735
 msgid "Wireless configuration migration"
-msgstr "Drahtloskonfiguration migrieren"
+msgstr "WLAN-Konfiguration migrieren"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:153
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:193
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:47
 msgid "Wireless is disabled"
-msgstr "W-LAN ist deaktiviert"
+msgstr "WLAN ist deaktiviert"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:153
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:193
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:47
 msgid "Wireless is not associated"
-msgstr "W-LAN ist nicht assoziiert"
+msgstr "WLAN ist nicht assoziiert"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:877
 msgid "Wireless network is disabled"
@@ -7777,10 +7777,10 @@ msgstr "« Zurück"
 #~ msgstr "Zurück zu den Scan-Ergebnissen"
 
 #~ msgid "Broadcom 802.11%s Wireless Controller"
-#~ msgstr "Broadcom 802.11%s W-LAN Adapter"
+#~ msgstr "Broadcom 802.11%s WLAN Adapter"
 
 #~ msgid "Broadcom BCM%04x 802.11 Wireless Controller"
-#~ msgstr "Broadcom BCM%04x 802.11 W-LAN Adapter"
+#~ msgstr "Broadcom BCM%04x 802.11 WLAN Adapter"
 
 #~ msgid ""
 #~ "Channel %d is not available in the %s regulatory domain and has been auto-"
@@ -7827,7 +7827,7 @@ msgstr "« Zurück"
 #~ "\"http://wireguard.com\">wireguard.com</a>."
 
 #~ msgid "Generic 802.11%s Wireless Controller"
-#~ msgstr "Generischer 802.11%s W-LAN Adapter"
+#~ msgstr "Generischer 802.11%s WLAN Adapter"
 
 #~ msgid "HT mode (802.11n)"
 #~ msgstr "HT-Modus (802.11n)"
@@ -7898,7 +7898,7 @@ msgstr "« Zurück"
 #~ "Really delete this wireless network? The deletion cannot be undone! You "
 #~ "might lose access to this device if you are connected via this network."
 #~ msgstr ""
-#~ "Dieses Drahtlosnetzwerk wirklich löschen? Der Schritt kann nicht "
+#~ "Dieses WLAN-Netzwerk wirklich löschen? Der Schritt kann nicht "
 #~ "rückgängig gemacht werden!\n"
 #~ "Der Zugriff auf das Gerät könnte verlorengehen wenn Sie über dieses "
 #~ "Netzwerk verbunden sind."
@@ -8240,7 +8240,7 @@ msgstr "« Zurück"
 #~ msgstr "Dieses Netzwerk aktivieren"
 
 #~ msgid "Hermes 802.11b Wireless Controller"
-#~ msgstr "Hermes 802.11b W-LAN Adapter"
+#~ msgstr "Hermes 802.11b WLAN Adapter"
 
 #~ msgid "Interface reconnected"
 #~ msgstr "Schnittstelle neu verbunden"
@@ -8249,10 +8249,10 @@ msgstr "« Zurück"
 #~ msgstr "Schnittstelle heruntergefahren"
 
 #~ msgid "Prism2/2.5/3 802.11b Wireless Controller"
-#~ msgstr "Prism2/2.5/3 802.11b W-LAN Adapter"
+#~ msgstr "Prism2/2.5/3 802.11b WLAN Adapter"
 
 #~ msgid "RaLink 802.11%s Wireless Controller"
-#~ msgstr "RaLink 802.11%s W-LAN Adapter"
+#~ msgstr "RaLink 802.11%s WLAN Adapter"
 
 #~ msgid ""
 #~ "Really shut down network? You might lose access to this device if you are "


### PR DESCRIPTION
... instead of a mixture of "WLAN", "W-LAN", "Drahtlos" etc.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>