### PR TITLE
luci-base: fix host validation function

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -337,7 +337,7 @@ var ValidatorFactory = baseclass.extend({
 		},
 
 		host: function(ipv4only) {
-			return this.assert(this.apply('hostname') || this.apply(ipv4only == 1 ? 'ip4addr' : 'ipaddr'),
+			return this.assert(this.apply('hostname') || this.apply(ipv4only == 1 ? 'ip4addr' : 'ipaddr', null, ['nomask']),
 				_('valid hostname or IP address'));
 		},
 


### PR DESCRIPTION
Allow only ipv4 or ipv6 addresses without IP mask.
A host IP with mask does not make sense in this context.

Without changing the validation, we could set the IPv4 11.11.11.11/24, which generate the following error on interface start.

```
Wed May 13 09:19:57 2020 daemon.notice netifd: wg1 (10779): Name does not resolve: `11.11.11.11/24:51825'
Wed May 13 09:19:57 2020 daemon.notice netifd: wg1 (10779): Configuration parsing error
```