### PR TITLE
generic: fix unit symbols and their formatting

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -273,8 +273,8 @@ return view.extend({
 		s.tab('sources', _('Blocklist Sources'), _('List of supported and fully pre-configured adblock sources, already active sources are pre-selected.<br /> \
 			<b><em>To avoid OOM errors, please do not select too many lists!</em></b><br /> \
 			List size information with the respective domain ranges as follows:<br /> \
-			&#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,<br /> \
-			&#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte devices,<br /> \
+			&#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MiB devices,<br /> \
+			&#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MiB devices,<br /> \
 			&#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore support, e.g. x86 or raspberry devices.<br /> \
 			<p>&#xa0;</p>'));
 
@@ -442,7 +442,7 @@ return view.extend({
 		o.datatype = 'range(1,10)';
 		o.rmempty = true;
 
-		o = s.taboption('adv_report', form.Value, 'adb_repchunksize', _('Report Chunk Size'), _('Report chunk size used by tcpdump in MByte.'));
+		o = s.taboption('adv_report', form.Value, 'adb_repchunksize', _('Report Chunk Size'), _('Report chunk size used by tcpdump in MB.'));
 		o.placeholder = '1';
 		o.datatype = 'range(1,10)';
 		o.rmempty = true;

--- a/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
@@ -8,12 +8,7 @@
 
 function secondsToString(time) {
 	var seconds = parseInt(time, 10);
-
-	var hrs   = Math.floor(seconds / 3600);
-	seconds  -= hrs*3600;
-	var mnts = Math.floor(seconds / 60);
-	seconds  -= mnts*60;
-	return String.format("%sh:%sm:%ss", hrs, mnts, seconds);
+	return '%t'.format(seconds);
 }
 
 XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface_status")%>', null,

--- a/applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua
+++ b/applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua
@@ -55,9 +55,9 @@ o:depends("limit_type","static")
 o = s:taboption("limit", ListValue, "static_unit_dl", translate("Default Download Unit"), translate("Default unit for download rate"))
 o.default = def_unit_dl or "kbytes"
 o:depends("limit_type","static")
-o:value("bytes", "Bytes/s")
-o:value("kbytes", "KBytes/s")
-o:value("mbytes", "MBytes/s")
+o:value("bytes", "B/s")
+o:value("kbytes", "kB/s")
+o:value("mbytes", "MB/s")
 
 o = s:taboption("limit", Value, "static_rate_ul", translate("Default Upload Rate"), translate("Default value for upload rate"))
 o.datatype = "uinteger"
@@ -67,19 +67,19 @@ o:depends("limit_type","static")
 o = s:taboption("limit", ListValue, "static_unit_ul", translate("Default Upload Unit"), translate("Default unit for upload rate"))
 o.default = def_unit_ul or "kbytes"
 o:depends("limit_type","static")
-o:value("bytes", "Bytes/s")
-o:value("kbytes", "KBytes/s")
-o:value("mbytes", "MBytes/s")
+o:value("bytes", "B/s")
+o:value("kbytes", "kB/s")
+o:value("mbytes", "MB/s")
 
 --
 -- Dynamic
 --
-o = s:taboption("limit", Value, "dynamic_bw_down", translate("Download Bandwidth (Mbps)"), translate("Default value for download bandwidth"))
+o = s:taboption("limit", Value, "dynamic_bw_down", translate("Download Bandwidth (Mbit/s)"), translate("Default value for download bandwidth"))
 o.default = def_up or '100'
 o.datatype = "uinteger"
 o:depends("limit_type","dynamic")
 
-o = s:taboption("limit", Value, "dynamic_bw_up", translate("Upload Bandwidth (Mbps)"), translate("Default value for upload bandwidth"))
+o = s:taboption("limit", Value, "dynamic_bw_up", translate("Upload Bandwidth (Mbit/s)"), translate("Default value for upload bandwidth"))
 o.default = def_down or '100'
 o.datatype = "uinteger"
 o:depends("limit_type","dynamic")
@@ -141,9 +141,9 @@ if limit_enable == "1" and limit_type == "static" then
 
 	o = x:option(ListValue, "unit", translate("Unit"))
 	o.default = def_unit_dl or "kbytes"
-	o:value("bytes", "Bytes/s")
-	o:value("kbytes", "KBytes/s")
-	o:value("mbytes", "MBytes/s")
+	o:value("bytes", "B/s")
+	o:value("kbytes", "kB/s")
+	o:value("mbytes", "MB/s")
 
 --
 -- Static Limit Rate - Upload Rate
@@ -178,9 +178,9 @@ if limit_enable == "1" and limit_type == "static" then
 
 	o = y:option(ListValue, "unit", translate("Unit"))
 	o.default = def_unit_ul or "kbytes"
-	o:value("bytes", "Bytes/s")
-	o:value("kbytes", "KBytes/s")
-	o:value("mbytes", "MBytes/s")
+	o:value("bytes", "B/s")
+	o:value("kbytes", "kB/s")
+	o:value("mbytes", "MB/s")
 
 end
 
@@ -256,9 +256,9 @@ if limit_mac_enable == "1" then
 
 	o = x:option(ListValue, "drunit", translate("Unit"))
 	o.default = def_unit_dl or "kbytes"
-	o:value("bytes", "Bytes/s")
-	o:value("kbytes", "KBytes/s")
-	o:value("mbytes", "MBytes/s")
+	o:value("bytes", "B/s")
+	o:value("kbytes", "kB/s")
+	o:value("mbytes", "MB/s")
 
 	o = x:option(Value, "urate", translate("Upload Rate"))
 	o.default = def_rate_ul or '50'
@@ -267,9 +267,9 @@ if limit_mac_enable == "1" then
 
 	o = x:option(ListValue, "urunit", translate("Unit"))
 	o.default = def_unit_ul or "kbytes"
-	o:value("bytes", "Bytes/s")
-	o:value("kbytes", "KBytes/s")
-	o:value("mbytes", "MBytes/s")
+	o:value("bytes", "B/s")
+	o:value("kbytes", "kB/s")
+	o:value("mbytes", "MB/s")
 
 end
 

--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -294,8 +294,8 @@ function display(pattern)
 		currentDisplayRows.push([
 			name,
 			ver,
-			pkg.size ? '%.1024mB'.format(pkg.size)
-			         : (altsize ? '~%.1024mB'.format(altsize) : '-'),
+			pkg.size ? '%1024mB'.format(pkg.size)
+			         : (altsize ? '~%1024mB'.format(altsize) : '-'),
 			desc,
 			btn
 		]);
@@ -533,9 +533,9 @@ function renderDependencyItem(dep, info)
 		var text = pkg.name;
 
 		if (pkg.installsize)
-			text += ' (%.1024mB)'.format(pkg.installsize);
+			text += ' (%1024mB)'.format(pkg.installsize);
 		else if (pkg.size)
-			text += ' (~%.1024mB)'.format(pkg.size);
+			text += ' (~%1024mB)'.format(pkg.size);
 
 		li.appendChild(E('span', { 'data-tooltip': pkg.description },
 			[ text, ' ', pkgStatus(pkg, vop, ver, info) ]));
@@ -636,9 +636,9 @@ function handleInstall(ev)
 	    size;
 
 	if (pkg.installsize)
-		size = _('~%.1024mB installed').format(pkg.installsize);
+		size = _('~%1024mB installed').format(pkg.installsize);
 	else if (pkg.size)
-		size = _('~%.1024mB compressed').format(pkg.size);
+		size = _('~%1024mB compressed').format(pkg.size);
 	else
 		size = _('unknown');
 
@@ -662,7 +662,7 @@ function handleInstall(ev)
 		});
 
 	inst = E('p', {},
-		_('Require approx. %.1024mB size for %d package(s) to install.')
+		_('Require approx. %1024mB size for %d package(s) to install.')
 			.format(totalsize, totalpkgs));
 
 	if (deps) {
@@ -824,9 +824,9 @@ function handleRemove(ev)
 	    size, desc;
 
 	if (avail.installsize)
-		size = _('~%.1024mB installed').format(avail.installsize);
+		size = _('~%1024mB installed').format(avail.installsize);
 	else if (avail.size)
-		size = _('~%.1024mB compressed').format(avail.size);
+		size = _('~%1024mB compressed').format(avail.size);
 	else
 		size = _('unknown');
 
@@ -985,7 +985,7 @@ function updateLists(data)
 		    	.sort(function(a, b) { return a.mount > b.mount })[0] || { size: 0, free: 0 };
 
 		pg.firstElementChild.style.width = Math.floor(mount.size ? ((100 / mount.size) * mount.free) : 100) + '%';
-		pg.setAttribute('title', '%s (%.1024mB)'.format(pg.firstElementChild.style.width, mount.free));
+		pg.setAttribute('title', '%s (%1024mB)'.format(pg.firstElementChild.style.width, mount.free));
 
 		parseList(data[1], packages.available);
 		parseList(data[2], packages.installed);

--- a/applications/luci-app-splash/luasrc/model/cbi/splash/splash.lua
+++ b/applications/luci-app-splash/luasrc/model/cbi/splash/splash.lua
@@ -11,8 +11,8 @@ s:option(Value, "leasetime", translate("Clearance time"), translate("Clients tha
 local redir = s:option(Value, "redirect_url", translate("Redirect target"), translate("Clients are redirected to this page after they have accepted the splash. If this is left empty they are redirected to the page they had requested."))
 redir.rmempty = true
 
-s:option(Value, "limit_up", translate("Upload limit"), translate("Clients upload speed is limited to this value (kbyte/s)"))
-s:option(Value, "limit_down", translate("Download limit"), translate("Clients download speed is limited to this value (kbyte/s)"))
+s:option(Value, "limit_up", translate("Upload limit"), translate("Clients upload speed is limited to this value (kB/s)"))
+s:option(Value, "limit_down", translate("Download limit"), translate("Clients download speed is limited to this value (kB/s)"))
 
 s:option(DummyValue, "_tmp", "",
 	translate("Bandwidth limit for clients is only activated when both up- and download limit are set. " ..

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/dns.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/dns.js
@@ -11,7 +11,7 @@ return baseclass.extend({
 
 	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
 		var traffic = {
-			title: "%H: DNS traffic", vlabel: "Bit/s",
+			title: "%H: DNS traffic", vlabel: "bit/s",
 
 			data: {
 				sources: {

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/iwinfo.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/iwinfo.js
@@ -57,8 +57,8 @@ return baseclass.extend({
 		var bitrate = {
 			title: "%H: Average phy rate on %pi",
 			detail: true,
-			vlabel: "MBit/s",
-			number_format: "%5.1lf%sBit/s",
+			vlabel: "Mbit/s",
+			number_format: "%5.1lf%sbit/s",
 			data: {
 				types: [ "bitrate" ],
 				options: {

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -134,10 +134,10 @@ return view.extend({
 			_('Puts extra debugging information into the system log'))
 
 		s.taboption('general', form.Value, 'download', _('Downlink'),
-			_('Value in KByte/s, informational only')).rmempty = true
+			_('Value in kB/s, informational only')).rmempty = true
 
 		s.taboption('general', form.Value, 'upload', _('Uplink'),
-			_('Value in KByte/s, informational only')).rmempty = true
+			_('Value in kB/s, informational only')).rmempty = true
 
 		o = s.taboption('general', form.Value, 'port', _('Port'))
 		o.datatype = 'port'

--- a/applications/luci-app-wireguard/luasrc/view/wireguard.htm
+++ b/applications/luci-app-wireguard/luasrc/view/wireguard.htm
@@ -84,11 +84,11 @@
 		var seconds = (now.getTime() / 1000) - timestamp;
 		var ago = "";
 		if (seconds < 60) {
-			ago = parseInt(seconds) + '<%:s ago%>';
+			ago = parseInt(seconds) + '\u202f<%:s ago%>';
 		} else if (seconds < 3600) {
-			ago = parseInt(seconds / 60) + '<%:m ago%>';
+			ago = parseInt(seconds / 60) + '\u202f<%:min ago%>';
 		} else if (seconds < 86401) {
-			ago = parseInt(seconds / 3600) + '<%:h ago%>';
+			ago = parseInt(seconds / 3600) + '\u202f<%:h ago%>';
 		} else {
 			ago = '<%:over a day ago%>';
 		}

--- a/docs/api/modules/luci.util.html
+++ b/docs/api/modules/luci.util.html
@@ -1151,12 +1151,12 @@ Recognized units are:
  o "d"	- one day    (60*60*24) 
  o "h"	- one hour	 (60*60) 
  o "min"	- one minute (60) 
- o "kb"  - one kilobyte (1024) 
- o "mb"	- one megabyte (1024*1024) 
- o "gb"	- one gigabyte (1024*1024*1024) 
- o "kib" - one si kilobyte (1000) 
- o "mib"	- one si megabyte (1000*1000) 
- o "gib"	- one si gigabyte (1000*1000*1000) 
+ o "kib"	- one kibibyte (1024) 
+ o "mib"	- one mebibyte (1024*1024) 
+ o "gib"	- one gibibyte (1024*1024*1024) 
+ o "kb"	- one kilobyte (1000) 
+ o "mb"	- one megabyte (1000*1000) 
+ o "gb"	- one gigabyte (1000*1000*1000) 
 
 
 

--- a/libs/luci-lib-base/luasrc/util.lua
+++ b/libs/luci-lib-base/luasrc/util.lua
@@ -302,12 +302,12 @@ end
 --  o "d"	- one day    (60*60*24)
 --  o "h"	- one hour	 (60*60)
 --  o "min"	- one minute (60)
---  o "kb"  - one kilobyte (1024)
---  o "mb"	- one megabyte (1024*1024)
---  o "gb"	- one gigabyte (1024*1024*1024)
---  o "kib" - one si kilobyte (1000)
---  o "mib"	- one si megabyte (1000*1000)
---  o "gib"	- one si gigabyte (1000*1000*1000)
+--  o "kib"	- one kibibyte (1024)
+--  o "mib"	- one mebibyte (1024*1024)
+--  o "gib"	- one gibibyte (1024*1024*1024)
+--  o "kb"	- one kilobyte (1000)
+--  o "mb"	- one megabyte (1000*1000)
+--  o "gb"	- one gigabyte (1000*1000*1000)
 function parse_units(ustr)
 
 	local val = 0
@@ -323,14 +323,14 @@ function parse_units(ustr)
 		min = 60,
 
 		-- storage sizes
-		kb  = 1024,
-		mb  = 1024 * 1024,
-		gb  = 1024 * 1024 * 1024,
+		kib  = 1024,
+		mib  = 1024 * 1024,
+		gib  = 1024 * 1024 * 1024,
 
 		-- storage sizes (si)
-		kib = 1000,
-		mib = 1000 * 1000,
-		gib = 1000 * 1000 * 1000
+		kb = 1000,
+		mb = 1000 * 1000,
+		gb = 1000 * 1000 * 1000
 	}
 
 	-- parse input string

--- a/libs/luci-lib-base/luasrc/util.luadoc
+++ b/libs/luci-lib-base/luasrc/util.luadoc
@@ -185,12 +185,12 @@ Recognized units are:
  o "d"	- one day    (60*60*24)
  o "h"	- one hour	 (60*60)
  o "min"	- one minute (60)
- o "kb"  - one kilobyte (1024)
- o "mb"	- one megabyte (1024*1024)
- o "gb"	- one gigabyte (1024*1024*1024)
- o "kib" - one si kilobyte (1000)
- o "mib"	- one si megabyte (1000*1000)
- o "gib"	- one si gigabyte (1000*1000*1000)
+ o "kib"	- one kibibyte (1024)
+ o "mib"	- one mebibyte (1024*1024)
+ o "gib"	- one gibibyte (1024*1024*1024)
+ o "kb"	- one kilobyte (1000)
+ o "mb"	- one megabyte (1000*1000)
+ o "gb"	- one gigabyte (1000*1000*1000)
 
 @class				function
 @name				parse_units

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -630,8 +630,8 @@ String.prototype.format = function()
 						}
 
 						subst = (td > 0)
-							? String.format('%dd %dh %dm %ds', td, th, tm, ts)
-							: String.format('%dh %dm %ds', th, tm, ts);
+							? String.format('%d:%d:%d:%d', td, th, tm, ts)
+							: String.format('%d:%d:%d', th, tm, ts);
 
 						break;
 
@@ -641,7 +641,9 @@ String.prototype.format = function()
 
 						var i = 0;
 						var val = (+param || 0);
-						var units = [ ' ', ' K', ' M', ' G', ' T', ' P', ' E' ];
+						var units = (mf === 1024)
+							? [ ' ', ' Ki', ' Mi', ' Gi', ' Ti', ' Pi', ' Ei' ]
+							: [ ' ', ' k', ' M', ' G', ' T', ' P', ' E' ];
 
 						for (i = 0; (i < units.length) && (val > mf); i++)
 							val /= mf;

--- a/modules/luci-compat/luasrc/tools/webadmin.lua
+++ b/modules/luci-compat/luasrc/tools/webadmin.lua
@@ -9,42 +9,41 @@ local uci  = require "luci.model.uci"
 local ip   = require "luci.ip"
 
 function byte_format(byte)
-	local suff = {"B", "KB", "MB", "GB", "TB"}
+	local suff = {"B", "KiB", "MiB", "GiB", "TiB"}
 	for i=1, 5 do
 		if byte > 1024 and i < 5 then
 			byte = byte / 1024
 		else
-			return string.format("%.2f %s", byte, suff[i]) 
-		end 
+			return string.format("%.2f %s", byte, suff[i])
+		end
 	end
 end
 
 function date_format(secs)
-	local suff = {"min", "h", "d"}
 	local mins = 0
 	local hour = 0
 	local days = 0
-	
+
 	secs = math.floor(secs)
 	if secs > 60 then
 		mins = math.floor(secs / 60)
 		secs = secs % 60
 	end
-	
+
 	if mins > 60 then
 		hour = math.floor(mins / 60)
 		mins = mins % 60
 	end
-	
+
 	if hour > 24 then
 		days = math.floor(hour / 24)
 		hour = hour % 24
 	end
-	
+
 	if days > 0 then
-		return string.format("%.0fd %02.0fh %02.0fmin %02.0fs", days, hour, mins, secs)
+		return string.format("%.0f:%02.0f:%02.0f:%02.0f", days, hour, mins, secs)
 	else
-		return string.format("%02.0fh %02.0fmin %02.0fs", hour, mins, secs)
+		return string.format("%02.0f:%02.0f:%02.0f", hour, mins, secs)
 	end
 end
 
@@ -70,15 +69,15 @@ end
 
 function firewall_find_zone(name)
 	local find
-	
-	luci.model.uci.cursor():foreach("firewall", "zone", 
+
+	luci.model.uci.cursor():foreach("firewall", "zone",
 		function (section)
 			if section.name == name then
 				find = section[".name"]
 			end
 		end
 	)
-	
+
 	return find
 end
 

--- a/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/system.lua
+++ b/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/system.lua
@@ -33,7 +33,7 @@ s:option(DummyValue, "_la", translate("Load")).value =
  string.format("%.2f, %.2f, %.2f", loads[1] / 65535.0, loads[2] / 65535.0, loads[3] / 65535.0)
 
 s:option(DummyValue, "_memtotal", translate("Memory")).value =
- string.format("%.2f MB (%.0f%% %s, %.0f%% %s)",
+ string.format("%.2f MiB (%.0f%% %s, %.0f%% %s)",
   tonumber(memory.total) / 1024 / 1024,
   100 * memory.buffered / memory.total,
   tostring(translate("buffered")),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
@@ -286,13 +286,13 @@ return view.extend({
 				E('div', { 'class': 'table', 'style': 'width:100%;table-layout:fixed' }, [
 					E('div', { 'class': 'tr' }, [
 						E('div', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid green' }, [ _('Phy Rate:') ])),
-						E('div', { 'class': 'td', 'id': 'rate_bw_cur' }, [ '0 MBit/s' ]),
+						E('div', { 'class': 'td', 'id': 'rate_bw_cur' }, [ '0 Mbit/s' ]),
 
 						E('div', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
-						E('div', { 'class': 'td', 'id': 'rate_bw_avg' }, [ '0 MBit/s' ]),
+						E('div', { 'class': 'td', 'id': 'rate_bw_avg' }, [ '0 Mbit/s' ]),
 
 						E('div', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
-						E('div', { 'class': 'td', 'id': 'rate_bw_peak' }, [ '0 MBit/s' ])
+						E('div', { 'class': 'td', 'id': 'rate_bw_peak' }, [ '0 Mbit/s' ])
 					])
 				])
 			]));
@@ -318,9 +318,9 @@ return view.extend({
 			this.updateGraph(ifname, csvg2, [ { line: 'rate', multiply: 0.001 } ], function(svg, info) {
 				var G = svg.firstElementChild, tab = svg.parentNode;
 
-				G.getElementById('label_25').firstChild.data = '%.2f %s'.format(info.label_25, _('MBit/s'));
-				G.getElementById('label_50').firstChild.data = '%.2f %s'.format(info.label_50, _('MBit/s'));
-				G.getElementById('label_75').firstChild.data = '%.2f %s'.format(info.label_75, _('MBit/s'));
+				G.getElementById('label_25').firstChild.data = '%.2f %s'.format(info.label_25, _('Mbit/s'));
+				G.getElementById('label_50').firstChild.data = '%.2f %s'.format(info.label_50, _('Mbit/s'));
+				G.getElementById('label_75').firstChild.data = '%.2f %s'.format(info.label_75, _('Mbit/s'));
 
 				tab.querySelector('#scale2').firstChild.data = _('(%d minute window, %d second interval)').format(info.timeframe, info.interval);
 

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
@@ -138,7 +138,7 @@ return view.extend({
 		 * Logging
 		 */
 
-		o = s.taboption('logging', form.Value, 'log_size', _('System log buffer size'), "kiB")
+		o = s.taboption('logging', form.Value, 'log_size', _('System log buffer size'), "KiB")
 		o.optional    = true
 		o.placeholder = 16
 		o.datatype    = 'uinteger'
@@ -184,7 +184,7 @@ return view.extend({
 		if (L.hasSystemFeature('zram')) {
 			s.tab('zram', _('ZRam Settings'));
 
-			o = s.taboption('zram', form.Value, 'zram_size_mb', _('ZRam Size'), _('Size of the ZRam device in megabytes'));
+			o = s.taboption('zram', form.Value, 'zram_size_mb', _('ZRam Size'), _('Size of the ZRam device in mebibytes'));
 			o.optional    = true;
 			o.placeholder = 16;
 			o.datatype    = 'uinteger';


### PR DESCRIPTION
This commit changes some of previously pending abbreviations to
their official unit symbols, and fixes some of the unit symbols
which had typographical errors. It also fixes the formatting of
some incorrectly formatted symbols to comply with SI, ISO, and IEC
standards.

Signed-off-by: Varun Varada <varuncvarada@gmail.com>