### PR TITLE
luci-base: ui.js: fix function declaration in nested statement

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -1176,7 +1176,7 @@ var UIDropdown = UIElement.extend(/** @lends LuCI.ui.Dropdown.prototype */ {
 			ul.style.maxHeight = (vpHeight * 0.5) + 'px';
 			ul.style.WebkitOverflowScrolling = 'touch';
 
-			function getScrollParent(element) {
+			var getScrollParent = function(element) {
 				var parent = element,
 				    style = getComputedStyle(element),
 				    excludeStaticParent = (style.position === 'absolute');


### PR DESCRIPTION
Fix "SyntaxError: Strict mode does not allow function declarations
in a lexically nested statement" error that may occur in some old
browsers (detected on QtWebKit 5.212).

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>