### PR TITLE
luci-app-simple-adblock: bugfix: proper processing of failed downloads; decrease reliance on shell commands; proper acl.d file

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=46
+PKG_RELEASE:=48
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -1,100 +1,100 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:161
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:217
 msgid "%s Error: %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:159
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:215
 msgid "%s Error: %s %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:142
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
 msgid "%s is blocking %s domains (with %s)."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:76
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:131
 msgid "%s is not installed or not found"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:290
 msgid "Add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
 msgid "Add IPv6 entries to block-list."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:202
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:258
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:256
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:174
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:230
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
 msgid "Blacklisted Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
 msgid "Blacklisted Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:289
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
 msgid "Blacklisted Hosts URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:132
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
 msgid "Cache file containing %s domains found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:152
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
 msgid "Collected Errors"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:136
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:192
 msgid "Compressed cache file found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:228
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
 msgid "Controls system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:303
 msgid "Curl download retry"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:218
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
 msgid "DNS Service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:220
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:276
 msgid "DNSMASQ Additional Hosts"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:221
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:277
 msgid "DNSMASQ Config"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:223
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:279
 msgid "DNSMASQ IP Set"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:225
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:281
 msgid "DNSMASQ Servers File"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:295
 msgid "Delay (in seconds) for on-boot start"
 msgstr ""
 
@@ -102,27 +102,27 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:262
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:318
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:233
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:289
 msgid "Do not add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:257
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:313
 msgid "Do not store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:252
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
 msgid "Do not use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:299
 msgid "Download time-out (in seconds)"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:81
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:136
 msgid "Downloading"
 msgstr ""
 
@@ -130,20 +130,20 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:263
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:319
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
 msgid "Enables debug output to /tmp/simple-adblock.log."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:82
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:137
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:84
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:139
 msgid "Fail"
 msgstr ""
 
@@ -151,60 +151,56 @@ msgstr ""
 msgid "Force Re-Download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:80
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:135
 msgid "Force Reloading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:184
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:240
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json:3
-msgid "Grant UCI access for luci-app-simple-adblock"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:303
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
 msgid "Individual domains to be blacklisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:269
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
 msgid "Individual domains to be whitelisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:130
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:134
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:190
 msgid "Info"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:193
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:249
 msgid "LED to indicate status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:251
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:307
 msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:183
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
@@ -212,65 +208,64 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:147
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:203
 msgid "Message"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:204
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:260
 msgid ""
 "Pick the DNS resolution option to create the adblock list for, see the <a "
 "href=\"%s#dns-resolution-option\" target=\"_blank\">README</a> for details."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:194
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:250
 msgid "Pick the LED not already used in %sSystem LED Configuration%s."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:207
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:209
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:210
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:212
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:215
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:263
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:264
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:266
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:268
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:271
 msgid "Please note that %s is not supported on this system."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:79
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:134
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:295
 msgid "Run service after set delay on boot."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:116
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:126
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:139
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:195
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:110
-msgid "Service Status [%s]"
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:166
+msgid "Service Status [%s %s]"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua:4
-#: applications/luci-app-simple-adblock/root/usr/share/luci/menu.d/luci-app-simple-adblock.json:3
 msgid "Simple AdBlock"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:104
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:160
 msgid "Simple AdBlock Settings"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:251
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:307
 msgid "Simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:178
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
 msgid "Some output"
 msgstr ""
 
@@ -278,7 +273,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:78
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:133
 msgid "Starting"
 msgstr ""
 
@@ -286,142 +281,146 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:299
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:77
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:132
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:258
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:314
 msgid "Store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:256
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
 msgid "Store compressed cache file on router"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:85
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:140
 msgid "Success"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:177
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:233
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:120
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
 msgid "Task"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
 msgid "URLs to lists of domains to be blacklisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:279
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
 msgid "URLs to lists of domains to be whitelisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:289
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
 msgid "URLs to lists of hosts to be blacklisted."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:228
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
 msgid "Unbound AdBlock List"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:253
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:309
 msgid "Use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:179
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:235
 msgid "Verbose output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:83
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:138
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:267
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:323
 msgid "Whitelist and Blocklist Management"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:279
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
 msgid "Whitelisted Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:269
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
 msgid "Whitelisted Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:88
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:143
 msgid "failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:86
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:141
 msgid "failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:98
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:153
 msgid "failed to create blocklist or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:94
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:149
 msgid "failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:101
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:156
 msgid "failed to download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:92
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:147
 msgid "failed to format data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:97
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:152
 msgid "failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:93
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:148
 msgid "failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:90
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:145
 msgid "failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:102
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
 msgid "failed to parse"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:91
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:146
 msgid "failed to process whitelist"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:100
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:155
 msgid "failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:95
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:150
 msgid "failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:87
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:142
 msgid "failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:89
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:144
 msgid "failed to sort data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:99
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:154
 msgid "failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:96
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:151
 msgid "failed to unpack compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:196
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:158
+msgid "no HTTPS/SSL support on device"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:252
 msgid "none"
 msgstr ""

--- a/applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json
+++ b/applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json
@@ -1,11 +1,38 @@
 {
 	"luci-app-simple-adblock": {
-		"description": "Grant UCI access for luci-app-simple-adblock",
+		"description": "Grant UCI and file access for luci-app-simple-adblock",
 		"read": {
-			"uci": [ "simple-adblock" ]
+			"cgi-io": [
+				"exec"
+			],
+			"file": {
+				"/usr/lib/opkg/status": [
+					"read"
+				],
+				"/sys/class/leds/*": [
+					"read"
+				],
+				"/var/run/simple-adblock.*": [
+					"read"
+				],
+				"/etc/init.d/simple-adblock *": [
+					"exec"
+				],
+				"/usr/sbin/dnsmasq *": [
+					"exec"
+				],
+				"/usr/sbin/ipset *": [
+					"exec"
+				]
+			},
+				"uci": [
+				"simple-adblock"
+			]
 		},
 		"write": {
-			"uci": [ "simple-adblock" ]
+			"uci": [
+				"simple-adblock"
+			]
 		}
 	}
 }


### PR DESCRIPTION
This update contains the following:
1. Better processing of failed downloads (should be merged in sync with the principal package PR https://github.com/openwrt/packages/pull/12333)
2. Decrease reliance on shell commands (grep, awk, wc) and use Lua instead
3. The acl.d file now lists everything used by the application

Signed-off-by: Stan Grishin <stangri@melmac.net>