### PR TITLE
[18.06] luci-app-ddns: remove duplicate help.gif

### DIFF
--- a/applications/luci-app-ddns/luasrc/view/ddns/global_value.htm
+++ b/applications/luci-app-ddns/luasrc/view/ddns/global_value.htm
@@ -25,7 +25,7 @@
 />
 <br />
 <div class="cbi-value-description">
-	<span class="cbi-value-helpicon"><img src="<%=resource%>/cbi/help.gif" alt="<%:help%>" /></span><%=self.description%>
+	<%=self.description%>
 	<br /><%:Current setting%>: <strong><%=self.date_string%></strong>
 </div>	<!-- div class="cbi-value-description" -->
 </div>	<!-- div class="cbi-value-field" -->


### PR DESCRIPTION
class `cbi-value-description` already contains help.gif
it's not necessary to add one manually

Signed-off-by: Chuck <fanck0605@qq.com>