### PR TITLE
luci-app: https-dns-proxy adding cloudflare family and security

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua
@@ -1,0 +1,8 @@
+return {
+	name = "Cloudflare-Family",
+	label = _("Cloudflare (Family Protection)"),
+	resolver_url = "https://family.cloudflare-dns.com/dns-query/",
+	bootstrap_dns = "1.1.1.3,1.0.0.3"
+	help_link = "https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families/setup-instructions/dns-over-https/",
+	help_link_text = "cloudflare.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua
@@ -1,0 +1,8 @@
+return {
+	name = "Cloudflare-Security",
+	label = _("Cloudflare (Security Filter)"),
+	resolver_url = "https://security.cloudflare-dns.com/dns-query/",
+	bootstrap_dns = "1.1.1.2,1.0.0.2"
+	help_link = "https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families/setup-instructions/dns-over-https/",
+	help_link_text = "cloudflare.com"
+}

--- a/applications/luci-app-https-dns-proxy/po/ar/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/ar/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/bg/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/bg/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/bn_BD/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/bn_BD/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/ca/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/ca/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/cs/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/cs/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/de/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/de/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr "CleanBrowsing (Sicherheitsfilter)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Sicherheitsfilter)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Familienfilter)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/el/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/el/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/en/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/en/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/es/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/es/https-dns-proxy.po
@@ -53,6 +53,14 @@ msgstr "CleanBrowsing (Filtro de seguridad)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Filtro de seguridad)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Filtro familiar)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr "Proxy DNS HTTPS"

--- a/applications/luci-app-https-dns-proxy/po/fi/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/fi/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/fr/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/fr/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr "CleanBrowsing (Filtre Sécurité)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Filtre Sécurité)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Filtre Famille)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/he/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/he/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/hi/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/hi/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/hu/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/hu/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr "CleanBrowsing (biztonsági szűrő)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (biztonsági szűrő)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (családszűrő)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/it/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/it/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/ja/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/ja/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/ko/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/ko/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/mr/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/mr/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr "क्लीन ब्राउझिंग (सुरक्षा फ�
 msgid "Cloudflare"
 msgstr "क्लाउडफ्लेअर"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/ms/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/ms/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/nb_NO/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/nb_NO/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/pl/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/pl/https-dns-proxy.po
@@ -51,6 +51,14 @@ msgstr "CleanBrowsing (Filtr bezpieczeństwa)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Filtr bezpieczeństwa)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Filtr rodzinny)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr "DNS HTTPS Proxy"

--- a/applications/luci-app-https-dns-proxy/po/pt/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/pt/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr "CleanBrowsing (Filtro de Segurança)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Filtro de Segurança)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Filtro para a Familia)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr "Proxy HTTPS de DNS"

--- a/applications/luci-app-https-dns-proxy/po/pt_BR/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/pt_BR/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr "CleanBrowsing (Filtro de Segurança)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Filtro de Segurança)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Filtro Familiar)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr "Proxy DNS HTTPS"

--- a/applications/luci-app-https-dns-proxy/po/ro/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/ro/https-dns-proxy.po
@@ -51,6 +51,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/ru/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/ru/https-dns-proxy.po
@@ -51,6 +51,14 @@ msgstr "CleanBrowsing (Фильтр безопасности)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Фильтр безопасности)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Семейный фильтр)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/sk/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/sk/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/sv/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/sv/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -41,6 +41,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/tr/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/tr/https-dns-proxy.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/uk/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/uk/https-dns-proxy.po
@@ -51,6 +51,14 @@ msgstr "CleanBrowsing (Безпечний фільтр)"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare (Безпечний фільтр)"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare (Сімейний фільтр)"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/vi/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/vi/https-dns-proxy.po
@@ -44,6 +44,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/zh_Hans/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/zh_Hans/https-dns-proxy.po
@@ -56,6 +56,14 @@ msgstr "CleanBrowsing（安全筛选器）"
 msgid "Cloudflare"
 msgstr "Cloudflare"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr "Cloudflare（安全筛选器）"
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr "Cloudflare（家庭过滤器）"
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/po/zh_Hant/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/zh_Hant/https-dns-proxy.po
@@ -56,6 +56,14 @@ msgstr ""
 msgid "Cloudflare"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-security.lua:3
+msgid "Cloudflare (Security Filter)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-family.lua:3
+msgid "Cloudflare (Family Filter)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""


### PR DESCRIPTION
Cloudflare has just announced DNS filtering for families.
Making those options available in luci.

Signed-off-by: Cason Adams <casonadams@protonmail.com>