### PR TITLE
[19.07] luci-app-simple-adblock: needs curl as dep

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -8,7 +8,7 @@ PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
 LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
-LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock
+LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock +curl
 LUCI_PKGARCH:=all
 PKG_RELEASE:=46
 


### PR DESCRIPTION
Curl is needed to download any of the blocklists.