### PR TITLE
luci-app-opkg: update default opkg list dir

### DIFF
--- a/applications/luci-app-opkg/root/usr/libexec/opkg-call
+++ b/applications/luci-app-opkg/root/usr/libexec/opkg-call
@@ -11,7 +11,7 @@ case "$action" in
 	;;
 	list-available)
 		lists_dir=$(sed -rne 's#^lists_dir \S+ (\S+)#\1#p' /etc/opkg.conf /etc/opkg/*.conf 2>/dev/null | tail -n 1)
-		find "${lists_dir:-/tmp/opkg-lists}" -type f '!' -name '*.sig' | xargs -r gzip -cd
+		find "${lists_dir:-/usr/lib/opkg/lists}" -type f '!' -name '*.sig' | xargs -r gzip -cd
 	;;
 	install|update|remove)
 		(


### PR DESCRIPTION
The default opkg lists dir is /usr/lib/opkg/lists rather than /tmp/opkg-lists.
https://git.openwrt.org/?p=project/opkg-lede.git;a=blob;f=libopkg/opkg_conf.h;h=37f95a1a9935d673cbba5f786d58c150a74e2fa7;hb=HEAD#l34