### PR TITLE
luci-app-bmx7: fix "nothing goes except topology"

### DIFF
--- a/applications/luci-app-bmx7/root/www/cgi-bin/bmx7-info
+++ b/applications/luci-app-bmx7/root/www/cgi-bin/bmx7-info
@@ -90,9 +90,11 @@ if [ "${QUERY##*/}" == "all" ]; then
 	QALL=1
 fi
 
-if [ "$QUERY" == '$info' ]; then
+if [ "$QUERY" == '%24info' ]; then
 	echo '{ "info": [ '
 	print_query status
+#sleep for bad code, see 
+sleep 2
 	echo -n ","
 	print_query interfaces && echo -n "," || echo -n '{ "interfaces": "" },'
 	print_query links && echo -n "," || echo -n '{ "links": "" },'
@@ -100,7 +102,7 @@ if [ "$QUERY" == '$info' ]; then
 	echo "] }"
 fi
 
-if [ "$QUERY" == '$neighbours' ]; then
+if [ "$QUERY" == '%24neighbours' ]; then
 	QALL=1
 	echo '{ "neighbours": [ '
 	echo '{ "originators": '
@@ -111,11 +113,11 @@ if [ "$QUERY" == '$neighbours' ]; then
 	echo "} ] }"
 	exit 0
 
-else if [ "$QUERY" == '$tunnels' ]; then
+else if [ "$QUERY" == '%24tunnels' ]; then
 	bmx7 -c --jshow tunnels /r=0
 	exit 0
 
-	else if [ "$QUERY" == '$originators' ]; then
+	else if [ "$QUERY" == '%24originators' ]; then
 		bmx7 -c --jshow originators /r=0
 		exit 0
 


### PR DESCRIPTION
nice to see luci-app-bmx7, but nothing goes except the topology sub-page.
here is a fix for all other status pages. modern webbrowsers do convert the $ to %24.
info-page is reloaded too much atm, so i delayed it for two seconds.
it would be nice to make the code even better in future, f.z. parameters in URLs should not contain $.
but i cant find the code where it is been called atm
so, but, this workaround will repair all non-working pages (except Topology) on luci-app-bmx7
Signed-off-by: Ufo <ufo@rund.freifunk.net>
p.s. do i have to pull-request this for openwrt-1907 repo too? would be a nice small test for opkg upgrade