### PR TITLE
luci-app-dawn: add hostname and interface name

### DIFF
--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
@@ -41,7 +41,7 @@ function s.render(self, sid)
 								<div class="th">VHT Sup</div>
 							</div>
 							<div class="tr">
-								<div class="td"><%= mac %></div>
+								<div class="td"><%= mac %> <%= data.iface %> <%= data.hostname %></div>
 								<div class="td"><%= "%.2f" %(data.channel_utilization / 2.55) %> %</div>
 								<div class="td"><%= "%.3f" %( data.freq / 1000 ) %> GHz (Channel: <%= "%d" %( status.frequency_to_channel(data.freq) ) %>)</div>
 								<div class="td"><%= "%d" %data.num_sta %></div>


### PR DESCRIPTION
Requires: https://github.com/berlin-open-wireless-lab/DAWN/commit/ffa08dbccddb8c938e427a106c30351c9df6746b

https://github.com/berlin-open-wireless-lab/DAWN/issues/94

@dwmw2 Could u look into this and make the changes according to your needs and modify this? I just added both values.