### PR TITLE
[18.06] luci-app-advanced-reboot: bugfix: new board names for Linksys WRT-devices

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -10,10 +10,9 @@ LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot supported Linksys and ZyXEL routers to\
 	an alternative partition. Also provides Web UI to shut down (power off) your device. 	Supported dual-partition\
 	routers are listed at https://github.com/openwrt/luci/blob/master/applications/luci-app-advanced-reboot/README.md
-
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=52
+PKG_RELEASE:=54
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -26,7 +26,7 @@ If your device is not in the list above, however it is a [dual-firmware device](
 
 ## Screenshot (luci-app-advanced-reboot)
 
-![screenshot](https://raw.githubusercontent.com/stangri/openwrt_packages/master/screenshots/luci-app-advanced-reboot/screenshot02.png "screenshot")
+![screenshot](https://cdn.jsdelivr.net/gh/stangri/openwrt_packages@master/screenshots/luci-app-advanced-reboot/screenshot02.png "screenshot")
 
 ## How to install
 
@@ -37,7 +37,7 @@ opkg update
 opkg install luci-app-advanced-reboot
 ```
 
-If the ```luci-app-advanced-reboot``` package is not found in the official feed/repo for your version of OpenWrt/LEDE Project, you will need to [add a custom repo to your router](https://github.com/stangri/openwrt_packages/blob/master/README.md#on-your-router) first.
+If the ```luci-app-advanced-reboot``` package is not found in the official feed/repo for your version of OpenWrt/LEDE Project, you will need to add a custom repo to your router following instructions on [GitHub](https://github.com/stangri/openwrt_packages/blob/master/README.md#on-your-router)/[jsDelivr](https://cdn.jsdelivr.net/gh/stangri/openwrt_packages@master/README.md#on-your-router) first.
 
 ## Notes/Known Issues
 

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-e4200v2-ea4500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-e4200v2-ea4500.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "E4200v2/EA4500",
-	boardName = "linksys-viper",
+	boardNames = { "linksys-viper", "linksys,viper" },
 	partition1MTD = "mtd3",
 	partition2MTD = "mtd5",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea3500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea3500.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "EA3500",
-	boardName = "linksys-audi",
+	boardNames = { "linksys-audi", "linksys,audi" },
 	partition1MTD = "mtd3",
 	partition2MTD = "mtd5",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea6350v3.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea6350v3.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "EA6350v3",
-	boardName = "linksys-ea6350v3",
+	boardNames = { "linksys-ea6350v3", "linksys,ea6350v3" },
 	partition1MTD = "mtd10",
 	partition2MTD = "mtd12",
 	labelOffset = 192,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8300.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8300.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "EA8300",
-	boardName = "linksys-ea8300",
+	boardNames = { "linksys-ea8300", "linksys,ea8300" },
 	partition1MTD = "mtd10",
 	partition2MTD = "mtd12",
 	labelOffset = 192,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea8500.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "EA8500",
-	boardName = "linksys-ea8500",
+	boardNames = { "linksys-ea8500", "linksys,ea8500" },
 	partition1MTD = "mtd13",
 	partition2MTD = "mtd15",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1200ac.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1200ac.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "WRT1200AC",
-	boardName = "linksys-caiman",
+	boardNames = { "linksys-caiman", "linksys,caiman", "linksys,wrt1200ac" },
 	partition1MTD = "mtd4",
 	partition2MTD = "mtd6",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900ac.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900ac.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
-	deviceName = "WRT1900AC",
-	boardName = "linksys-mamba",
+	deviceName = "WRT1900ACv1",
+	boardNames = { "linksys-mamba", "linksys,mamba", "linksys,wrt1900ac-v1" },
 	partition1MTD = "mtd4",
 	partition2MTD = "mtd6",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acs.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acs.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "WRT1900ACS",
-	boardName = "linksys-shelby",
+	boardNames = { "linksys-shelby", "linksys,shelby", "linksys,wrt1900acs" },
 	partition1MTD = "mtd4",
 	partition2MTD = "mtd6",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acv2.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt1900acv2.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "WRT1900ACv2",
-	boardName = "linksys-cobra",
+	boardNames = { "linksys-cobra", "linksys,cobra", "linksys,wrt1900ac-v2" },
 	partition1MTD = "mtd4",
 	partition2MTD = "mtd6",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt3200acm.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt3200acm.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "WRT3200ACM",
-	boardName = "linksys-rango",
+	boardNames = { "linksys-rango", "linksys,rango", "linksys,wrt3200acm" },
 	partition1MTD = "mtd5",
 	partition2MTD = "mtd7",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt32x.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-wrt32x.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "WRT32X",
-	boardName = "linksys-venom",
+	boardNames = { "linksys-venom", "linksys,venom", "linksys,wrt32x" },
 	partition1MTD = "mtd5",
 	partition2MTD = "mtd7",
 	labelOffset = nil,

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/zyxel-nbg6817.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/zyxel-nbg6817.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "ZyXEL",
 	deviceName = "NBG6817",
-	boardName = "nbg6817",
+	boardNames = { "nbg6817" },
 	partition1MTD = "mmcblk0p4",
 	partition2MTD = "mmcblk0p7",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
+++ b/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
@@ -1,78 +1,119 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:171
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:10
 msgid "Advanced Reboot"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:36
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:60
 msgid "Alternative"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm:24
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm:20
 msgid "Cancel"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:42
 msgid "Changes applied."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:131
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:132
 msgid "Compressed"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm:10
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm:10
 msgid "Confirm"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:36
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:60
 msgid "Current"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:18
 msgid "ERROR:"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:28
 msgid "Firmware"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/root/usr/share/rpcd/acl.d/luci-app-advanced-reboot.json:3
+msgid "Grant UCI and file access for luci-app-advanced-reboot"
+msgstr ""
+
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:45
 msgid "Loading"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:213
 msgid "No access to fw_printenv or fw_printenv!"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:26
 msgid "Partition"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:23
 msgid "Partitions"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:94
 msgid "Perform power off..."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm:10
 msgid "Power Off Device"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm:25
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm:21
 msgid "Proceed"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:29
 msgid "Reboot"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm:10
 msgid "Reboot Device to an Alternative Partition"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:50
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:74
 msgid "Reboot to alternative partition..."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:45
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:69
 msgid "Reboot to current partition"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:192
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:264
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:9
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:297
 msgid "Shutting down..."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:27
 msgid "Status"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:39
 msgid "System"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:193
 msgid ""
 "The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -80,6 +121,7 @@ msgid ""
 "settings."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:265
 msgid ""
 "The system is rebooting to an alternative partition now.<br /> DO NOT POWER "
 "OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It "
@@ -87,27 +129,47 @@ msgid ""
 "again, depending on your settings."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:298
 msgid ""
 "The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It "
 "might be necessary to renew the address of your computer to reach the device "
 "again, depending on your settings."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:144
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:145
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:248
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:249
 msgid "Unable to find Dual Boot Flag Partition."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:220
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:221
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:234
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:235
 msgid "Unable to obtain firmware environment variable: %s."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:256
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:257
 msgid "Unable to set Dual Boot Flag Partition entry for partition: %s."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:226
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:227
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:240
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:241
 msgid "Unable to set firmware environment variable: %s to %s."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:126
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:127
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:131
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:132
 msgid "Unknown"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm:12
 msgid ""
 "WARNING: An alternative partition might have its own settings and completely "
 "different firmware.<br /><br /> As your network configuration and WiFi SSID/"
@@ -119,29 +181,37 @@ msgid ""
 "to reboot device to an alternative partition."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm:12
 msgid ""
 "WARNING: Power off might result in a reboot on a device which doesn't "
 "support power off.<br /><br /> Click \"Proceed\" below to power off your "
 "device."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm:46
 msgid "Waiting for changes to be applied..."
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:83
 msgid "Warning: Device (%s) is unknown or isn't a dual-partition device!"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:14
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:97
 msgid "Warning: This system does not support powering off!"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:85
 msgid "Warning: Unable to obtain device information!"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:45
 msgid "attempting to mount alternative partition (mtd%s)"
 msgstr ""
 
+#: applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua:54
 msgid "attempting to unmount alternative partition (mtd%s)"
 msgstr ""

--- a/applications/luci-app-advanced-reboot/root/usr/share/rpcd/acl.d/luci-app-advanced-reboot.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/rpcd/acl.d/luci-app-advanced-reboot.json
@@ -1,0 +1,96 @@
+{
+	"luci-app-advanced-reboot": {
+		"description": "Grant UCI and file access for luci-app-advanced-reboot",
+		"read": {
+			"cgi-io": [
+				"exec"
+			],
+			"file": {
+				"/usr/lib/lua/luci/advanced-reboot/devices/*": [
+					"read"
+				],
+				"/sys/devices/virtual/ubi/ubi*/mtd_num": [
+					"read"
+				],
+				"/etc/os-release": [
+					"read"
+				],
+				"/alt/rom/etc/os-release": [
+					"read"
+				],
+				"/usr/sbin/fw_printenv *": [
+					"exec"
+				],
+				"/usr/sbin/fw_setenv *": [
+					"exec"
+				],
+				"/usr/sbin/ubiattach *": [
+					"exec"
+				],
+				"/usr/sbin/ubiblock *": [
+					"exec"
+				],
+				"/usr/sbin/ubidetach *": [
+					"exec"
+				],
+				"/usr/sbin/ubinfo *": [
+					"exec"
+				],
+				"/bin/cat *": [
+					"exec"
+				],
+				"/usr/bin/cat *": [
+					"exec"
+				],
+				"/bin/dd *": [
+					"exec"
+				],
+				"/usr/bin/dd *": [
+					"exec"
+				],
+				"/bin/hexdump *": [
+					"exec"
+				],
+				"/usr/bin/hexdump *": [
+					"exec"
+				],
+				"/bin/logger -t advanced-reboot *": [
+					"exec"
+				],
+				"/usr/bin/logger -t advanced-reboot *": [
+					"exec"
+				],
+				"/bin/mkdir *": [
+					"exec"
+				],
+				"/usr/bin/mkdir *": [
+					"exec"
+				],
+				"/bin/mount *": [
+					"exec"
+				],
+				"/usr/bin/mount *": [
+					"exec"
+				],
+				"/bin/printf *": [
+					"exec"
+				],
+				"/usr/bin/printf *": [
+					"exec"
+				],
+				"/bin/rm *": [
+					"exec"
+				],
+				"/usr/bin/rm *": [
+					"exec"
+				],
+				"/lib/functions.sh": [
+					"exec"
+				]
+			},
+			"uci": [
+				"network"
+			]
+		}
+	}
+}


### PR DESCRIPTION
This update fixes https://github.com/openwrt/luci/issues/4135. While technically not required on stable branches, I'd prefer the stable branch PRs be merged as well to ease the supported device maintenance.

As this is a bugfix, I suggest this is merged as is and I will implement the dd_helper script in a future revision.

Signed-off-by: Stan Grishin <stangri@melmac.net>