### PR TITLE
ucitrack: fix bug for exec with params

### DIFF
--- a/modules/luci-base/root/etc/init.d/ucitrack
+++ b/modules/luci-base/root/etc/init.d/ucitrack
@@ -35,7 +35,7 @@ register_trigger() {
 			;;
 			*)
 				logger -t "ucitrack" "Setting up non-init /etc/config/$config reload handler: $exec"
-				procd_add_config_trigger "config.change" "$config" "$exec"
+				procd_add_config_trigger "config.change" "$config" $exec
 			;;
 		esac
 	fi


### PR DESCRIPTION
In file `/etc/config/ucitrack`
```
config fstab
        option exec '/sbin/block mount'
```
`/sbin/block mount` never be called after fstab changed.

Signed-off-by: 练亮斌 <1129525450@qq.com>