### PR TITLE
luci-mod-network: diagnostics.js: pass IP version flag to ping/ping6

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
@@ -28,7 +28,7 @@ return view.extend({
 	handlePing: function(ev, cmd) {
 		var exec = cmd || 'ping',
 		    addr = ev.currentTarget.parentNode.previousSibling.value,
-		    args = (exec == 'ping') ? [ '-c', '5', '-W', '1', addr ] : [ '-c', '5', addr ];
+		    args = (exec == 'ping') ? [ '-4', '-c', '5', '-W', '1', addr ] : [ '-6', '-c', '5', addr ];
 
 		return this.handleCommand(exec, args);
 	},


### PR DESCRIPTION
discovered when iputils-ping is installed diag cant ping the v4 of domains with both A and AAAA records.

tested on snapshots with ping utils:
- iputils-ping_20190709
- BusyBox v1.31.1 (busybox ping)