### PR TITLE
New options under YouTube SafeSearch

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -298,12 +298,15 @@ return view.extend({
 		o.placeholder = '53 853 5353';
 		o.rmempty = true;
 
-		o = s.taboption('general', form.Flag, 'adb_safesearch', _('Enable SafeSearch'), _('Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and pixabay.'));
+		o = s.taboption('general', form.Flag, 'adb_safesearch', _('Enable SafeSearch'), _('Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and Pixabay.'));
 		o.rmempty = false;
 
-		o = s.taboption('general', form.Flag, 'adb_safesearchmod', _('SafeSearch Moderate'), _('Enable moderate SafeSearch filters for youtube.'));
+		o = s.taboption('general', form.ListValue, 'adb_safesearchmod', _('YouTube SafeSearch'), _('Choose restrictive, moderated or disabled SafeSearch filters for youtube. Please note: even Moderate filter might be to restrictive for some content, e.g. music.'));
 		o.depends('adb_safesearch', '1');
-		o.rmempty = true;
+		o.value('disabled');
+		o.value('moderated');
+		o.value('restrictive')
+		o.rmempty = false;
 
 		o = s.taboption('general', form.Flag, 'adb_report', _('DNS Report'), _('Gather DNS related network traffic via tcpdump and provide a DNS Report on demand. \
 			Please note: this needs additional \'tcpdump-mini\' package installation and a full adblock service restart to take effect.'));

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -301,10 +301,10 @@ return view.extend({
 		o = s.taboption('general', form.Flag, 'adb_safesearch', _('Enable SafeSearch'), _('Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and Pixabay.'));
 		o.rmempty = false;
 
-		o = s.taboption('general', form.ListValue, 'adb_safesearchmod', _('YouTube SafeSearch'), _('Choose restrictive, moderated or disabled SafeSearch filters for youtube. Please note: even Moderate filter might be to restrictive for some content, e.g. music.'));
+		o = s.taboption('general', form.ListValue, 'adb_safesearchmod', _('YouTube SafeSearch'), _('Choose restrictive, moderate or disabled SafeSearch filters for YouTube. Please note: even moderate filter might be to restrictive for some content, e.g. music.'));
 		o.depends('adb_safesearch', '1');
 		o.value('disabled');
-		o.value('moderated');
+		o.value('moderate');
 		o.value('restrictive')
 		o.rmempty = false;
 

--- a/applications/luci-app-adblock/po/ar/adblock.po
+++ b/applications/luci-app-adblock/po/ar/adblock.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -154,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -187,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -195,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -218,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -268,15 +275,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -290,19 +293,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,11 +315,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -324,7 +327,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -343,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -355,7 +358,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -365,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -383,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -396,7 +399,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -417,7 +420,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -429,13 +432,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -445,7 +448,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -473,35 +476,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -528,23 +531,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -556,13 +555,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -572,11 +571,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -596,23 +595,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -664,7 +663,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -678,11 +677,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -691,7 +690,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -706,11 +705,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -718,14 +721,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/bg/adblock.po
+++ b/applications/luci-app-adblock/po/bg/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -147,26 +154,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -180,7 +187,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +195,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +218,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,15 +268,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -283,19 +286,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +308,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +320,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -336,7 +339,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -348,7 +351,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -358,7 +361,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -376,7 +379,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -389,7 +392,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -410,7 +413,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -422,13 +425,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -438,7 +441,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -466,35 +469,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -521,23 +524,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -549,13 +548,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -565,11 +564,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -589,23 +588,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -657,7 +656,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -671,11 +670,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -699,11 +698,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -711,14 +714,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/bn_BD/adblock.po
+++ b/applications/luci-app-adblock/po/bn_BD/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -153,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -186,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,15 +274,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,19 +292,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +314,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +326,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -342,7 +345,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -354,7 +357,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -364,7 +367,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -382,7 +385,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -395,7 +398,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -416,7 +419,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -428,13 +431,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -444,7 +447,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -472,35 +475,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -527,23 +530,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -555,13 +554,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -571,11 +570,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,23 +594,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -663,7 +662,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -677,11 +676,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -690,7 +689,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -705,11 +704,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -717,14 +720,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ca/adblock.po
+++ b/applications/luci-app-adblock/po/ca/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Retard addicional en segons de l’activador abans que comenci el processament "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Domini blocat"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Fonts de la llista negra"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -155,26 +162,26 @@ msgstr ""
 msgid "Count"
 msgstr "Recompte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Directori del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Reinicialització de fitxers del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -188,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Notificació per correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Adreça de destinatari de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,15 +276,11 @@ msgstr "Edita la llista blanca"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,19 +294,19 @@ msgstr "Data de finalització"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +316,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Purga la memòria cau del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +328,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Força el DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +359,7 @@ msgstr "Darrera execució"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +369,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +387,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Llista d’utilitats de baixada admeses i plenament preconfigurades."
 
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Servei de prioritat baixa"
 
@@ -418,7 +421,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -430,13 +433,13 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -446,7 +449,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -474,35 +477,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -529,23 +532,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Desa"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -557,13 +556,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -573,11 +572,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,23 +596,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +664,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +678,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -692,7 +691,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
@@ -707,11 +706,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -719,15 +722,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/cs/adblock.po
+++ b/applications/luci-app-adblock/po/cs/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatečné zpoždění v sekundách před začátkem zpracování blokování reklamy."
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Odpověd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "Blokované domény"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Zdroje seznamů blokování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -154,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Adresář DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Resetování souboru DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -187,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -195,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -218,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Oznámení e-mailem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Adresa příjemce e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -268,15 +275,11 @@ msgstr "Upravit whitelist"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -290,19 +293,19 @@ msgstr "Datum ukončení"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,11 +315,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Vyprázdnit mezipaměť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -324,7 +327,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Vynutit lokální DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -343,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -355,7 +358,7 @@ msgstr "Poslední spuštění"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -365,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -383,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Seznam podporovaných a plně předkonfigurovaných nástrojů pro stahování."
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Služba s nízkou prioritou"
 
@@ -418,7 +421,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -430,13 +433,13 @@ msgstr "Dotaz"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adresa příjemce pro e-maily s upozorněním."
 
@@ -446,7 +449,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -474,35 +477,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Počet bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Velikost bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Adresář sestav"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Rozhraní sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -529,23 +532,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Uložit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -557,13 +556,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -573,11 +572,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,23 +596,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Pozastavit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Cílový adresář pro vygenerovaný blokovací seznam 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +664,7 @@ msgstr ""
 msgid "Time"
 msgstr "Čas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +678,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
@@ -692,7 +691,7 @@ msgstr "Prodleva spuštění"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
@@ -707,11 +706,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -719,15 +722,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/de/adblock.po
+++ b/applications/luci-app-adblock/po/de/adblock.po
@@ -43,7 +43,7 @@ msgstr "Füge diese (Sub-)Domain zur lokalen Blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Füge diese (Sub-)Domain zur lokalen Whiteklist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr "Zusätzliche Jail-Sperrliste"
 
@@ -51,7 +51,7 @@ msgstr "Zusätzliche Jail-Sperrliste"
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Zusätzliche Verzögerung (in Sekunden) bis zur Verarbeitung durch den "
@@ -73,15 +73,15 @@ msgstr "Fortgeschrittene Berichtseinstellungen"
 msgid "Answer"
 msgstr "Antwort"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Basis-Temp-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +110,7 @@ msgstr "Blockierte Domain"
 msgid "Blocked Domains"
 msgstr "Gesperrte Domains"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Sperrliste Backup"
 
@@ -126,7 +126,7 @@ msgstr "Sperrlisten abfragen..."
 msgid "Blocklist Sources"
 msgstr "Blockierlisten-Quellen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -143,6 +143,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Abbrechen"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -166,7 +173,7 @@ msgstr ""
 msgid "Count"
 msgstr "Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -175,19 +182,19 @@ msgstr ""
 "sofort ab dem Booten oder im Fall von Downloadfehlern zur Verfügung zu haben."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "DNS-Backend"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS-Datei zurücksetzen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -201,7 +208,7 @@ msgstr "DNS Anforderungen (blockiert)"
 msgid "DNS Requests (total)"
 msgstr "DNS-Abfragen (gesamt)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "DNS-Restart-Timeout"
 
@@ -209,15 +216,15 @@ msgstr "DNS-Restart-Timeout"
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Deaktiviere DNS-Zulassen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Deaktiviere DNS-Restarts"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -225,7 +232,7 @@ msgstr ""
 "Deaktiviere das Triggern von Neustarts des DNS-Backends durch Adblock per "
 "Autoload/inotify-Funktionsaufrufe."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
 
@@ -234,39 +241,39 @@ msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
 msgid "Domain"
 msgstr "Domäne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Downloadparameter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Download-Warteschlange"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Email-Benachrichtigszähler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Email-Profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail-Empfängeradresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Email-Absenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "Email-Betreff"
 
@@ -284,15 +291,11 @@ msgstr "Whiteliste bearbeiten"
 msgid "Enable SafeSearch"
 msgstr "Aktiviere SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Aktiviere den Adblock-Dienst."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Aktiviere ausführliche Debug-Logs im Fehlerfall."
 
@@ -306,19 +309,19 @@ msgstr "Enddatum"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
-msgstr "Erzwinge SafeSearch für Google, Bing, DuckDuckGo, Yandex und Pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Bestehende Job(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr "Externe DNS-Abfragedomain"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -330,11 +333,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filterkriterien wie z.B. Datum, Domain oder Client (optional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "DNS-Cache leeren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 
@@ -342,7 +345,7 @@ msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 msgid "Force Local DNS"
 msgstr "Lokales DNS erzwingen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -364,7 +367,7 @@ msgstr "Zugriff auf adblock LuCI app erlauten"
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "Jail-Verzeichnis"
 
@@ -376,7 +379,7 @@ msgstr "Letzter Lauf"
 msgid "Latest DNS Requests"
 msgstr "Letzte DNS-Abfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Liste an verfügbaren Netzwerkschnittstellen die von tcpdump verwendet werden "
@@ -391,7 +394,7 @@ msgstr ""
 "triggern. Wähle \"unspecified\", um einen herkömmlichen Start-Timeout-"
 "Mechanismuss anstatt eines Netzwerk-Triggers zu verwenden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -420,7 +423,7 @@ msgstr ""
 "mehr RAM und zusätzlich eine Multicore-CPU, z.B entpsrechende x86- oder "
 "RaspberryPi-Geräte.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste der unterstützten und vollständig vorkonfigurierten Download-"
@@ -435,7 +438,7 @@ msgstr "Lokale DNS-Ports"
 msgid "Log View"
 msgstr "Log-Ansicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Dienst mit niedriger Priorität"
 
@@ -456,7 +459,7 @@ msgstr "Aktuell noch keine Adblock-Logs vorhanden!"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "\"msmtp\"-Profil, das für Adblock-Benachrichtigunsmails verwendet wird."
@@ -469,7 +472,7 @@ msgstr "Abfrage"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Frage aktive Sperrlisten und Backups über eine spezifische Domain ab."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -477,7 +480,7 @@ msgstr ""
 "Erhöhe den Benachrichtigunszähler um Emails zu erhalten, wenn die Gesamtzahl "
 "der Blocklisten kleiner gleich diesem Schwellwert ist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Empfängeradresse für Adblock-Benachrichtigungs-E-Mails."
 
@@ -489,7 +492,7 @@ msgstr ""
 "Leite alle DNS-Anfragen an die \"Lan\"-Zone auf den lokalen DNS-Resolver um, "
 "gilt sowohl für UDP und TCP-Protokolle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -520,35 +523,35 @@ msgstr "Aktualisiere Timer..."
 msgid "Refresh..."
 msgstr "Aktualisiere..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Berichte Datenblock-Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Berichte Datenblock-Größe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Verzeichnis für Berichte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Berichte-Schnittstelle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr "Berichte Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr "Berichte Datenblock-Nutzung durch tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Berichte von tcpdump verwendete Datenblockgröße in MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -578,17 +581,13 @@ msgstr "Run-Interfaces"
 msgid "Run Utils"
 msgstr "Run-Werkzeuge"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr "moderates SafeSearch"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Speichern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -596,7 +595,7 @@ msgstr ""
 "Sende relevante Adblock-Benachrichtigungen per Email. Hinweis: Hierzu muss "
 "das \"msmtp\"-Zusatzpaket installiert sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Absenderadresse für Adblock-Benachrichtigungsmails."
 
@@ -608,7 +607,7 @@ msgstr "(Er)Setze einen neuen Adblock-Job"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -616,7 +615,7 @@ msgstr ""
 "Größe der Download-Warteschlange für laufende Downloads (inkl. Platzbedarf "
 "für Sortieren, Zusammenführen)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr "Quellen (Größe, Fokus)"
 
@@ -628,11 +627,11 @@ msgstr ""
 "Leerzeichengetrennte Liste von DNS-relevanten Firewall-Ports, die zwingend "
 "lokal sein müssen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Leerzeichengetrennte Liste an Ports die von tcpdump genutzt werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Spezielle Konfigurationseinstellungen für das gewählte Download-Programm."
@@ -653,7 +652,7 @@ msgstr "Status / Version"
 msgid "Suspend"
 msgstr "Anhalten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -662,7 +661,7 @@ msgstr ""
 "\" gesetzt, hier sollte besser ein USB-Stick oder anderer lokaler Speicher "
 "verwendet werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -671,11 +670,11 @@ msgstr ""
 "hier sollte besser ein USB-Stick oder anderer lokaler Speicher verwendet "
 "werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Zielverzeichnis für die erzeugte Sperrliste 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Zielverzeichnis für die erzeugte Jail-Sperrliste \"adb_list.jail\"."
 
@@ -737,7 +736,7 @@ msgstr ""
 msgid "Time"
 msgstr "Zeit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Timeout für erfolgreichen DNS-Backend-Startvorgang."
 
@@ -753,11 +752,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top-10 Statistiken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr "Betreff für Adblock-Benachrichtigungsmails."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Verzögerung Trigger-Bedingung"
 
@@ -766,7 +765,7 @@ msgstr "Verzögerung Trigger-Bedingung"
 msgid "Unable to save changes: %s"
 msgstr "Konnte Änderungen nicht speichern: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
@@ -783,11 +782,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Whiteliste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -795,17 +798,29 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "Max. Größe des Result-Sets"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
+
+#~ msgid ""
+#~ "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
+#~ "pixabay."
+#~ msgstr ""
+#~ "Erzwinge SafeSearch für Google, Bing, DuckDuckGo, Yandex und Pixabay."
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "moderates SafeSearch"
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/el/adblock.po
+++ b/applications/luci-app-adblock/po/el/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Λίστα Μπλοκαρισμένων πηγών"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -153,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr "Μέτρηση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "κατάλογος DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Επαναφορά αρχείου DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -186,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,15 +274,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,19 +292,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +314,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +326,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -342,7 +345,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -354,7 +357,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -364,7 +367,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -382,7 +385,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -395,7 +398,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -416,7 +419,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -428,13 +431,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -444,7 +447,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -472,35 +475,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -527,23 +530,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -555,13 +554,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -571,11 +570,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,23 +594,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -663,7 +662,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -677,11 +676,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -690,7 +689,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -705,11 +704,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -717,15 +720,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/en/adblock.po
+++ b/applications/luci-app-adblock/po/en/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -153,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -186,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,15 +274,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,19 +292,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +314,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +326,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -342,7 +345,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -354,7 +357,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -364,7 +367,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -382,7 +385,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -395,7 +398,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -416,7 +419,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -428,13 +431,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -444,7 +447,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -472,35 +475,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -527,23 +530,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -555,13 +554,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -571,11 +570,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,23 +594,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -663,7 +662,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -677,11 +676,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -690,7 +689,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -705,11 +704,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -717,14 +720,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -46,7 +46,7 @@ msgstr "Agregue este (sub) dominio a su lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Agregue este (sub) dominio a su lista blanca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr "Lista de bloqueo adicional de la cárcel"
 
@@ -54,7 +54,7 @@ msgstr "Lista de bloqueo adicional de la cárcel"
 msgid "Additional Settings"
 msgstr "Configuración adicional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
@@ -76,15 +76,15 @@ msgstr "Configuración avanzada de informes"
 msgid "Answer"
 msgstr "Responder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Directorio de temperatura base"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -113,7 +113,7 @@ msgstr "Dominio bloqueado"
 msgid "Blocked Domains"
 msgstr "Dominios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Copia de seguridad de lista de bloqueo"
 
@@ -129,7 +129,7 @@ msgstr "Consulta de lista de bloqueo..."
 msgid "Blocklist Sources"
 msgstr "Fuentes de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -147,6 +147,16 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
+"Selecciona restrictivo (restrictive), moderado (moderate) o desactiva (disabled) SafeSearch para YouTube. "
+"Nota: incluso seleccionando un filtro moderado este podría ser demasidao restrictivo con algún contenido, "
+"por ejemplo, música."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -170,7 +180,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -179,19 +189,19 @@ msgstr ""
 "caso de errores de descarga o durante el inicio."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "Backend de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Directorio DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Restablecimiento de archivos DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -205,7 +215,7 @@ msgstr "Solicitudes DNS (bloqueadas)"
 msgid "DNS Requests (total)"
 msgstr "Solicitudes DNS (total)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "Tiempo de espera de reinicio de DNS"
 
@@ -213,15 +223,15 @@ msgstr "Tiempo de espera de reinicio de DNS"
 msgid "Date"
 msgstr "Fecha"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Desactivar Permitir DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Desactivar Reinicios de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,7 +239,7 @@ msgstr ""
 "Desactivar los reinicios activados por adblock para back-end dns con "
 "funciones de carga automática/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
 
@@ -238,39 +248,39 @@ msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Descargar parámetros"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Descargar Cola"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Notificación del E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Conteo de notificaciones por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Perfil de E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario del E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente del E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "Tema de E-Mail"
 
@@ -288,15 +298,11 @@ msgstr "Editar lista blanca"
 msgid "Enable SafeSearch"
 msgstr "Activar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "Activar filtros moderados de SafeSearch para YouTube."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Activa el servicio Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activar el registro detallado de depuración en caso de errores de "
@@ -312,21 +318,19 @@ msgstr "Fecha final"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
-"Hacer cumplir SafeSearch para google, bing, duckduckgo, yandex, youtube y "
-"pixabay."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Trabajo(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr "Dominio de búsqueda de DNS externo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -339,11 +343,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterios de filtro como fecha, dominio o cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Vaciar caché de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 
@@ -351,7 +355,7 @@ msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 msgid "Force Local DNS"
 msgstr "Forzar DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -374,7 +378,7 @@ msgstr "Conceder acceso a la aplicación adblock de LuCI"
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "Directorio de la cárcel"
 
@@ -386,7 +390,7 @@ msgstr "Último inicio"
 msgid "Latest DNS Requests"
 msgstr "Últimas solicitudes de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de dispositivos de red disponibles utilizados por tcpdump."
 
@@ -399,7 +403,7 @@ msgstr ""
 "Elija 'No especificado' para usar un tiempo de espera de inicio clásico en "
 "lugar de un disparador de red."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -428,7 +432,7 @@ msgstr ""
 "MByte,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) necesita más RAM y soporte "
 "multinúcleo, p. ej. x86 o dispositivos Raspberry.<br /><p></p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
@@ -442,7 +446,7 @@ msgstr "Puertos DNS locales"
 msgid "Log View"
 msgstr "Vista de registro"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Servicio con prioridad baja"
 
@@ -463,7 +467,7 @@ msgstr "¡Aún no hay registros relacionados con adblock!"
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil utilizado por 'msmtp' para notificaciones de E-Mails adblock."
 
@@ -477,7 +481,7 @@ msgstr ""
 "Consulta listas de bloqueo activas y copias de seguridad para un dominio "
 "específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -485,7 +489,7 @@ msgstr ""
 "Aumente el recuento de notificaciones para obtener correos electrónicos si "
 "el recuento general de la lista de bloqueo es menor o igual al límite dado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Dirección del receptor para la notificación de bloqueos electrónicos."
 
@@ -497,7 +501,7 @@ msgstr ""
 "Redireccionar todas las consultas DNS desde la zona 'lan' al solucionador "
 "DNS local, se aplica al protocolo UDP y TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -528,35 +532,35 @@ msgstr "Actualizar temporizador..."
 msgid "Refresh..."
 msgstr "Actualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Informe de recuento de fragmentos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Tamaño del fragmento de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Directorio de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Interfaz de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr "Informar puertos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr "Informe el recuento de fragmentos utilizado por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informe el tamaño del fragmento utilizado por tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -586,17 +590,13 @@ msgstr "Ejecutar interfaces"
 msgid "Run Utils"
 msgstr "Ejecutar utilidades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr "SafeSearch Moderado"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -604,7 +604,7 @@ msgstr ""
 "Enviar correos electrónicos de notificación relacionados con adblock. Tenga "
 "en cuenta: esto necesita una instalación adicional del paquete 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Dirección del remitente para los correos electrónicos de notificación de "
@@ -618,7 +618,7 @@ msgstr "Establecer/Reemplazar un nuevo trabajo de adblock"
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -626,7 +626,7 @@ msgstr ""
 "Tamaño de la cola de descarga para el procesamiento de descarga (incluida la "
 "clasificación, fusión, etc.) en paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr "Fuentes (tamaño, enfoque)"
 
@@ -638,11 +638,11 @@ msgstr ""
 "Lista separada por espacios de puertos de firewall relacionados con DNS que "
 "deben forzarse localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de puertos separados por espacios utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opciones de configuración especiales para la utilidad de descarga "
@@ -664,7 +664,7 @@ msgstr "Estado / Versión"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -673,7 +673,7 @@ msgstr ""
 "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
 "otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -682,12 +682,12 @@ msgstr ""
 "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
 "otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo generada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo de cárcel generada 'adb_list."
@@ -753,7 +753,7 @@ msgstr ""
 msgid "Time"
 msgstr "Hora"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tiempo de espera para esperar un reinicio de backend de DNS exitoso."
 
@@ -769,11 +769,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 estadísticas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr "Tema para los correos electrónicos de notificación de adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
@@ -782,7 +782,7 @@ msgstr "Retraso de disparo"
 msgid "Unable to save changes: %s"
 msgstr "No se pueden guardar los cambios: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
@@ -799,11 +799,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista blanca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -811,17 +815,30 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "máx. tamaño del conjunto de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr "llamado (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr "crudo (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "Activar filtros moderados de SafeSearch para YouTube."
+
+#~ msgid ""
+#~ "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
+#~ "pixabay."
+#~ msgstr ""
+#~ "Hacer cumplir SafeSearch para google, bing, duckduckgo, yandex, youtube y "
+#~ "pixabay."
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "SafeSearch Moderado"
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/fi/adblock.po
+++ b/applications/luci-app-adblock/po/fi/adblock.po
@@ -43,7 +43,7 @@ msgstr "Lisää tämä (ali-)verkkonimi kieltolistallesi."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lisää tämä (ali-)verkkonimi sallittujen listallesi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ylimääräinen odotusaika sekunteina ennen adblock-käsittelyn aloittamista."
@@ -72,15 +72,15 @@ msgstr "Raportoinnin lisäasetukset"
 msgid "Answer"
 msgstr "Vastaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Varmuuskopiohakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Oletushakemisto väliaikaistiedostoille"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -109,7 +109,7 @@ msgstr "Estetty verkkonimi"
 msgid "Blocked Domains"
 msgstr "Estetyt verkkonimet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Kieltolistan varmuuskopio"
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Estolistojen lähteet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -139,6 +139,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Peruuta"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -158,26 +165,26 @@ msgstr ""
 msgid "Count"
 msgstr "Määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "DNS-sovellus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS-tiedoston resetointi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -191,7 +198,7 @@ msgstr "DNS-kyselyt (estetyt)"
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 
@@ -199,15 +206,15 @@ msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 msgid "Date"
 msgstr "Päivä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Estä DNS:n salliminen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Estä DNS:n uudelleenkäynnistykset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -215,7 +222,7 @@ msgstr ""
 "Estä adblockin aiheuttamat DNS-sovelluksen uudelleenkäynnistykset autoload/"
 "inotify-funktioilla."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -224,39 +231,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Verkkonimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Latausparametrit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Latausjono"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Sähköposti-ilmoitus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Sähköposti-ilmoitusten määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Sähköpostiprofiili"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Sähköposti: vastaanottajan osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Sähköposti: lähettäjän osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "Sähköposti: otsikko"
 
@@ -274,15 +281,11 @@ msgstr "Editoi sallittujen lista"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Ota Adblock-palvelu käyttöön."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Runsas lokisisältö toimintojen virheiden etsimistä varten."
 
@@ -296,19 +299,19 @@ msgstr "Päättymisaika"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Nykyiset työt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,11 +321,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Suodatintekijät kuten päivä, verkkonimi tai asiakas (valinnainen)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Tyhjennä DNS-välimuisti"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Tyhjennä DNS-välimuisti ennen Adblock-sääntöjen käsittelyä"
 
@@ -330,7 +333,7 @@ msgstr "Tyhjennä DNS-välimuisti ennen Adblock-sääntöjen käsittelyä"
 msgid "Force Local DNS"
 msgstr "Pakota paikallinen DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -349,7 +352,7 @@ msgstr "Salli pääsy Adblock-asetuksiin"
 msgid "Information"
 msgstr "Tietoja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr "Viimeksi ajettu"
 msgid "Latest DNS Requests"
 msgstr "Viimeiset DNS-kyselyt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -371,7 +374,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -389,7 +392,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Tuetut ja valmiiksi asetetut lataustyökalut"
 
@@ -402,7 +405,7 @@ msgstr "Paikalliset DNS-portit"
 msgid "Log View"
 msgstr "Lokinäkymä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Matala sovelluksen prioriteetti"
 
@@ -423,7 +426,7 @@ msgstr "Ei vielä Adblock-lokeja!"
 msgid "Overview"
 msgstr "Yhteenveto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -435,13 +438,13 @@ msgstr "Kysely"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Vastaanottajan sähköpostiosoite Adblockin ilmoituksille."
 
@@ -453,7 +456,7 @@ msgstr ""
 "Ohjaa kaikki LAN-vyöhykkeeltä tulevat DNS-kyselyt paikalliselle DNS-"
 "palvelimelle, sekä UDP- että TCP-protokollat."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -481,35 +484,35 @@ msgstr "Päivitysajastin..."
 msgid "Refresh..."
 msgstr "Päivitä..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Raporttipalojen määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Raporttipalojen koko"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Raporttihakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Raportoitava sovitin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr "Raportoitavat portit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -536,23 +539,19 @@ msgstr "Ajettavat sovittimet"
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Tallenna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Lähettäjän osoite Adblockin sähköposti-ilmoituksille."
 
@@ -564,13 +563,13 @@ msgstr ""
 msgid "Settings"
 msgstr "Asetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr "Lähteet (koko, fokus)"
 
@@ -580,11 +579,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -604,23 +603,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -672,7 +671,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -686,11 +685,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -699,7 +698,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -714,11 +713,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -726,14 +729,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/fr/adblock.po
+++ b/applications/luci-app-adblock/po/fr/adblock.po
@@ -43,7 +43,7 @@ msgstr "Ajout sous-domaine au réseau local blacklisté."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Ajout sous-domaine au réseau local whitelisté."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr "Additionnel Bannis Blocklisté"
 
@@ -51,7 +51,7 @@ msgstr "Additionnel Bannis Blocklisté"
 msgid "Additional Settings"
 msgstr "Paramètres additionnels"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Délai de déclenchement supplémentaire en secondes avant que le bloqueur de "
@@ -73,15 +73,15 @@ msgstr "Paramètres de rapport avancés"
 msgid "Answer"
 msgstr "Répondre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Répertoire Temporaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +110,7 @@ msgstr "Domaines bloqués"
 msgid "Blocked Domains"
 msgstr "Domaines bloqués"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Sauvegarde de la liste de blocage"
 
@@ -126,7 +126,7 @@ msgstr "Demande Blocklist..."
 msgid "Blocklist Sources"
 msgstr "Sources des listes de blocage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -144,6 +144,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Annuler"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -168,7 +175,7 @@ msgstr ""
 msgid "Count"
 msgstr "Compteur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -177,19 +184,19 @@ msgstr ""
 "utilisées en cas d'erreurs de téléchargement ou lors du démarrage."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "Backend du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Répertoire du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Réinitialiser le fichier de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -203,7 +210,7 @@ msgstr "Requêtes DNS (bloquées)"
 msgid "DNS Requests (total)"
 msgstr "Requêtes DNS (totales)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "Délai de redémarrage DNS"
 
@@ -211,15 +218,15 @@ msgstr "Délai de redémarrage DNS"
 msgid "Date"
 msgstr "Date"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Désactiver l'autorisation DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Désactiver les redémarrages DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,7 +234,7 @@ msgstr ""
 "Désactiver les redémarrages déclenchés par adblock pour les backends dns "
 "avec des fonctions d'auto-chargement/notification."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
 
@@ -236,39 +243,39 @@ msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
 msgid "Domain"
 msgstr "Domaine"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Paramètres Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Queue de Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Notifications par e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Nombre de notifications par courrier électronique"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Profile Email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Adresse e-mail du destinataire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Adresse électronique de l'expéditeur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "Objet du courrier électronique"
 
@@ -286,15 +293,11 @@ msgstr "Modifier la liste blanche"
 msgid "Enable SafeSearch"
 msgstr "Activé Safesearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "Activez les filtres SafeSearch modérés pour youtube."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Activé le service adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activez la journalisation verbale de débogage en cas d'erreurs de traitement."
@@ -309,21 +312,19 @@ msgstr "Date de fin"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
-"Mise en œuvre de SafeSearch pour google, bing, duckduckgo, yandex, youtube "
-"et pixabay."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Travaux en cours"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr "Domaine de recherche DNS externe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +337,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Critère filtre comme la date, domaine, client (option)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Vider le cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Videz également le cache DNS avant le traitement des adblocs."
 
@@ -348,7 +349,7 @@ msgstr "Videz également le cache DNS avant le traitement des adblocs."
 msgid "Force Local DNS"
 msgstr "Forcer le DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -371,7 +372,7 @@ msgstr "Donner tout accès à l'application LuCI adblock"
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "Répertoire des bannis"
 
@@ -383,7 +384,7 @@ msgstr "Dernière exécution"
 msgid "Latest DNS Requests"
 msgstr "Dernière Requêtes DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste des périphériques réseau disponibles utilisés par tcpdump."
 
@@ -396,7 +397,7 @@ msgstr ""
 "l'adblock. Choisissez \"non spécifié\" pour utiliser un délai de démarrage "
 "classique au lieu d'un déclencheur réseau."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -427,7 +428,7 @@ msgstr ""
 "besoin de plus de RAM et de support Multicore, par exemple des appareils x86 "
 "ou Raspberry.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste des utilitaires de téléchargement pris en charge et entièrement pré-"
@@ -442,7 +443,7 @@ msgstr "Ports DNS locaux"
 msgid "Log View"
 msgstr "Vue du journal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Service en priorité basse"
 
@@ -463,7 +464,7 @@ msgstr "Pas encore de journaux liés à l'adblock !"
 msgid "Overview"
 msgstr "Aperçu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilisé par \"msmtp\" pour les e-mails de notification adblock."
 
@@ -477,7 +478,7 @@ msgstr ""
 "Recherchez des listes de blocage actives et des sauvegardes pour un domaine "
 "spécifique."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -486,7 +487,7 @@ msgstr ""
 "électroniques si le nombre total de blocages est inférieur ou égal à la "
 "limite donnée."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Adresse du destinataire pour les e-mails de notification du bloqueur de "
@@ -500,7 +501,7 @@ msgstr ""
 "Rediriger toutes les requêtes DNS de la zone \"lan\" vers le résolveur DNS "
 "local, s'applique aux protocoles UDP et TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -532,35 +533,35 @@ msgstr "Rafraîchir l'horloge..."
 msgid "Refresh..."
 msgstr "Rafraichi..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Rapporter le nombre de morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Rapporter la taille des morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Rapporter le Répertoire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Rapporter l'Interface"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr "Rapport des Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr "Signalez le nombre de morceaux utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Indiquez la taille des morceaux utilisés par tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -590,17 +591,13 @@ msgstr "Interfaces de travail"
 msgid "Run Utils"
 msgstr "Outils de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr "SafeSearch Modéré"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Enregistrer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -608,7 +605,7 @@ msgstr ""
 "Envoyer des e-mails de notification relatifs à l'adblock. Veuillez noter que "
 "l'installation du paquet \"msmtp\" supplémentaire est nécessaire."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Adresse de l'expéditeur des courriers électroniques de notification de "
@@ -622,7 +619,7 @@ msgstr "Définir/remplacer un nouveau travail d'adblock"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -630,7 +627,7 @@ msgstr ""
 "Taille de la file d'attente pour le traitement des téléchargements (y "
 "compris le tri, la fusion, etc.) en parallèle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr "Sources (Taille, Focus)"
 
@@ -642,11 +639,11 @@ msgstr ""
 "Liste séparée par espace des ports de pare-feu liés au DNS qui doivent être "
 "forcés localement."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Liste des ports utilisés par tcpdump, séparés par des espaces."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Options de configuration spéciales pour l'utilitaire de téléchargement "
@@ -668,7 +665,7 @@ msgstr "Statut / Version"
 msgid "Suspend"
 msgstr "Mettre en pause"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -676,7 +673,7 @@ msgstr ""
 "Répertoire cible pour les fichiers de rapports liés au DNS. La valeur par "
 "défaut est '/tmp', veuillez utiliser plutot une clé usb ou un disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -685,12 +682,12 @@ msgstr ""
 "défaut est '/tmp', veuillez utiliser de préférence une clé usb ou un autre "
 "disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Répertoire cible pour la liste de blocage générée \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Répertoire cible pour la liste de blocage générée \"adb_list.jail\"."
 
@@ -756,7 +753,7 @@ msgstr ""
 msgid "Time"
 msgstr "Heure"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Délai d'attente pour un redémarrage réussi du backend du DNS."
 
@@ -772,11 +769,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 Statistiques"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr "Objet pour les notifications par e-mails d'adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
@@ -785,7 +782,7 @@ msgstr "Délai de déclenchement"
 msgid "Unable to save changes: %s"
 msgstr "Sauvegarde Impossible : %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
@@ -802,11 +799,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Liste Blanche..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -814,17 +815,30 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "taille max. des résultats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "Activez les filtres SafeSearch modérés pour youtube."
+
+#~ msgid ""
+#~ "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
+#~ "pixabay."
+#~ msgstr ""
+#~ "Mise en œuvre de SafeSearch pour google, bing, duckduckgo, yandex, "
+#~ "youtube et pixabay."
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "SafeSearch Modéré"
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/he/adblock.po
+++ b/applications/luci-app-adblock/po/he/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -147,26 +154,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -180,7 +187,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +195,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +218,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,15 +268,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -283,19 +286,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +308,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +320,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -336,7 +339,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -348,7 +351,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -358,7 +361,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -376,7 +379,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -389,7 +392,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -410,7 +413,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -422,13 +425,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -438,7 +441,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -466,35 +469,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -521,23 +524,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -549,13 +548,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -565,11 +564,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -589,23 +588,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -657,7 +656,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -671,11 +670,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -699,11 +698,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -711,14 +714,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hi/adblock.po
+++ b/applications/luci-app-adblock/po/hi/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -147,26 +154,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -180,7 +187,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +195,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +218,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,15 +268,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -283,19 +286,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +308,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +320,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -336,7 +339,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -348,7 +351,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -358,7 +361,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -376,7 +379,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -389,7 +392,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -410,7 +413,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -422,13 +425,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -438,7 +441,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -466,35 +469,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -521,23 +524,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -549,13 +548,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -565,11 +564,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -589,23 +588,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -657,7 +656,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -671,11 +670,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -699,11 +698,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -711,14 +714,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hu/adblock.po
+++ b/applications/luci-app-adblock/po/hu/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "További aktiválókésleltetés másodpercben, mielőtt a reklámblokkolás "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Válasz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Blokkolt tartomány"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Blokkolási lista forrásai"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -136,6 +136,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Mégse"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -155,26 +162,26 @@ msgstr ""
 msgid "Count"
 msgstr "Darabszám"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS könyvtár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS fájlvisszaállítás"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -188,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Tartomány"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "E-mail értesítés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "E-mail fogadócím"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,15 +276,11 @@ msgstr "Fehérlista szerkesztése"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,19 +294,19 @@ msgstr "Befejezési dátum"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +316,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "DNS gyorsítótár kiürítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +328,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Helyi DNS kényszerítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +359,7 @@ msgstr "Utolsó futás"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +369,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +387,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "A támogatott és teljesen előre beállított letöltési segédprogramok listája."
@@ -398,7 +401,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Alacsony prioritású szolgáltatás"
 
@@ -419,7 +422,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -431,13 +434,13 @@ msgstr "Lekérdezés"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Fogadó címe a reklámblokkoló értesítési e-mailekhez."
 
@@ -447,7 +450,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -475,35 +478,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Darabok számának jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Darabok méretének jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Könyvtár jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Csatoló jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -530,23 +533,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Mentés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -558,13 +557,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -574,11 +573,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -598,23 +597,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Célkönyvtár az előállított „adb_list.overall” blokkolási listához."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -668,7 +667,7 @@ msgstr ""
 msgid "Time"
 msgstr "Idő"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -682,11 +681,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
@@ -695,7 +694,7 @@ msgstr "Aktiváló késleltetése"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
@@ -710,11 +709,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -722,15 +725,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -46,7 +46,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Tempo addizionale in secondi di attesa prima che adblock si avvii."
 
@@ -74,15 +74,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Risposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Directory del Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -107,7 +107,7 @@ msgstr "Dominio bloccato"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -123,7 +123,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Fonti lista di Blocco"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -136,6 +136,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -156,26 +163,26 @@ msgstr ""
 msgid "Count"
 msgstr "Numero"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Directory DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Reset File DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -189,7 +196,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -197,21 +204,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -220,39 +227,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Notifica E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail destinatario"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,15 +277,11 @@ msgstr "Modifica Lista Bianca"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -292,19 +295,19 @@ msgstr "Data Fine"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -314,11 +317,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Pulisci Cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -326,7 +329,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Forza DNS Locale"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -345,7 +348,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -357,7 +360,7 @@ msgstr "Ultimo Avvio"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -367,7 +370,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -385,7 +388,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Elenco delle utility di download supportate e completamente preconfigurate."
@@ -399,7 +402,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Serviio a bassa priorità"
 
@@ -420,7 +423,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riassunto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -432,13 +435,13 @@ msgstr "Interrogazione"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Indirizzo del destinatario per e-mail di notifica di blocco degli annunci."
@@ -449,7 +452,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,35 +480,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Directory dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -532,23 +535,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Salva"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -560,13 +559,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -576,11 +575,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -600,23 +599,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Sospendi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Directory per la lista di blocco generata 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -669,7 +668,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -683,11 +682,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Ritardo Innesco"
 
@@ -696,7 +695,7 @@ msgstr "Ritardo Innesco"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Registro di Debug Dettagliato"
 
@@ -711,11 +710,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -723,15 +726,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Adblock の処理が開始されるまでの、追加の遅延時間（秒）です。"
 
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "ブロックされたドメイン"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "ブロックリスト提供元"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -154,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "カウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS ファイル リセット"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -187,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -195,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "日付"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -218,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "ドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "ダウンロード ユーティリティ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -268,15 +275,11 @@ msgstr "ホワイトリストの編集"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -290,19 +293,19 @@ msgstr "終了日"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,11 +315,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "DNS キャッシュのクリア"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -324,7 +327,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "ローカル DNS の強制"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -343,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -355,7 +358,7 @@ msgstr "最終実行"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -365,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -383,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "サポートされ、かつ設定済のダウンロード ユーティリティの一覧です。"
 
@@ -396,7 +399,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "低優先度サービス"
 
@@ -417,7 +420,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -429,13 +432,13 @@ msgstr "検索"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知メールの受信アドレスです。"
 
@@ -445,7 +448,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -473,35 +476,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "レポート チャンクカウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "レポート チャンクサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "レポート インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -528,23 +531,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -556,13 +555,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -572,11 +571,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -596,23 +595,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成されたブロックリスト 'adb_list.overall' の保存先ディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -664,7 +663,7 @@ msgstr ""
 msgid "Time"
 msgstr "時刻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -678,11 +677,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
@@ -691,7 +690,7 @@ msgstr "トリガ遅延"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
@@ -706,11 +705,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -718,15 +721,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ko/adblock.po
+++ b/applications/luci-app-adblock/po/ko/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -147,26 +154,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -180,7 +187,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +195,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +218,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,15 +268,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -283,19 +286,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +308,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +320,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -336,7 +339,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -348,7 +351,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -358,7 +361,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -376,7 +379,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -389,7 +392,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -410,7 +413,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -422,13 +425,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -438,7 +441,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -466,35 +469,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -521,23 +524,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -549,13 +548,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -565,11 +564,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -589,23 +588,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -657,7 +656,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -671,11 +670,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -699,11 +698,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -711,14 +714,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/mr/adblock.po
+++ b/applications/luci-app-adblock/po/mr/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -153,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -186,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,15 +274,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,19 +292,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +314,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +326,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -342,7 +345,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -354,7 +357,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -364,7 +367,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -382,7 +385,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -395,7 +398,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -416,7 +419,7 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -428,13 +431,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -444,7 +447,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -472,35 +475,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -527,23 +530,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -555,13 +554,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -571,11 +570,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,23 +594,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -663,7 +662,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -677,11 +676,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -690,7 +689,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -705,11 +704,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -717,15 +720,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ms/adblock.po
+++ b/applications/luci-app-adblock/po/ms/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Terdapat kelewatan picu dalam saat sebelum proses adblock bermula."
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Jawapan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr "Kawasan Liputan Yang telah disekat"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Punca Senarai Sekatan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -153,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr "Kiraan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Direktori DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Reset fail DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -186,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr "Tarikh"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,15 +274,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,19 +292,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +314,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +326,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -342,7 +345,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -354,7 +357,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -364,7 +367,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -382,7 +385,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -395,7 +398,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -416,7 +419,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -428,13 +431,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -444,7 +447,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -472,35 +475,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -527,23 +530,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -555,13 +554,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -571,11 +570,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,23 +594,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -663,7 +662,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -677,11 +676,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -690,7 +689,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -705,11 +704,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -717,15 +720,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/nb_NO/adblock.po
+++ b/applications/luci-app-adblock/po/nb_NO/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligere utløserforsinkelse i sekunder før behandling av "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Blokkert domene"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Blokklistekilder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -155,26 +162,26 @@ msgstr ""
 msgid "Count"
 msgstr "Antall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS-mappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS-filtilbakestilling"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -188,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dato"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "E-postmerknad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagersadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,15 +276,11 @@ msgstr "Rediger hvitliste"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,19 +294,19 @@ msgstr "Sluttdato"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +316,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Tøm DNS-hurtiglageret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +328,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Tving lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +359,7 @@ msgstr "Sist kjørt"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +369,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +387,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -418,7 +421,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -430,13 +433,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -446,7 +449,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -474,35 +477,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -529,23 +532,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -557,13 +556,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -573,11 +572,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,23 +596,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +664,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +678,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -692,7 +691,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -707,11 +706,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -719,15 +722,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/pl/adblock.po
+++ b/applications/luci-app-adblock/po/pl/adblock.po
@@ -44,7 +44,7 @@ msgstr "Dodaj tę (sub-)domenę do Twojej lokalnej czarnej listy."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Dodaj tę (pod-)domenę do Twojej lokalnej białej listy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr "Dodatkowa lista zablokowanych"
 
@@ -52,7 +52,7 @@ msgstr "Dodatkowa lista zablokowanych"
 msgid "Additional Settings"
 msgstr "Dodatkowe ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalacza w sekundach przed rozpoczęciem przetwarzania "
@@ -74,15 +74,15 @@ msgstr "Zaawansowane ustawienia raportów"
 msgid "Answer"
 msgstr "Odpowiedź"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Podstawowy katalog tymczasowy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,7 +111,7 @@ msgstr "Zablokowana domena"
 msgid "Blocked Domains"
 msgstr "Zablokowane domeny"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Kopia zapasowa listy zablokowanych"
 
@@ -127,7 +127,7 @@ msgstr "Zapytanie..."
 msgid "Blocklist Sources"
 msgstr "Źródła list"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,6 +145,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Anuluj"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -168,7 +175,7 @@ msgstr ""
 msgid "Count"
 msgstr "Licznik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -177,19 +184,19 @@ msgstr ""
 "używane w przypadku błędów pobierania lub podczas uruchamiania."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "Zaplecze DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Katalog DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Resetuj plik DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -203,7 +210,7 @@ msgstr "Żądania DNS (zablokowane)"
 msgid "DNS Requests (total)"
 msgstr "Żądania DNS (ogółem)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "Limit czasu restartu DNS"
 
@@ -211,15 +218,15 @@ msgstr "Limit czasu restartu DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Wyłącz pozwolenie na DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Wyłącz restart DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,7 +234,7 @@ msgstr ""
 "Wyłącz wyzwalane restarty adblocka dla zaplecza DNS z funkcjami Autoload/"
 "Inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
 
@@ -236,39 +243,39 @@ msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
 msgid "Domain"
 msgstr "Domena"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Kolejka pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Powiadomienie email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Licznik powiadomień email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Profil email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Adres email odbiorcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Adres email nadawcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "Temat email"
 
@@ -286,15 +293,11 @@ msgstr "Edycja białej listy"
 msgid "Enable SafeSearch"
 msgstr "Włącz funkcję SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Włącz usługę adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Włącz pełne rejestrowanie debugowania w przypadku błędów przetwarzania."
@@ -309,21 +312,19 @@ msgstr "Data końcowa"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
-"Egzekwowanie SafeSearch dla google, bing, duckduckgo, yandex, youtube i "
-"pixabay."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Istniejące zadania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr "Zewnętrzna domena wyszukiwania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +337,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Kryteria filtrowania takie jak data, domena lub klient (opcjonalnie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Opróżnij pamięć podręczną DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 
@@ -348,7 +349,7 @@ msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 msgid "Force Local DNS"
 msgstr "Wymuś lokalny DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -370,7 +371,7 @@ msgstr "Udziel dostępu LuCI do aplikacji adblock"
 msgid "Information"
 msgstr "Informacja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "Katalog więzienia"
 
@@ -382,7 +383,7 @@ msgstr "Ostatnie uruchomienie"
 msgid "Latest DNS Requests"
 msgstr "Ostatnie zapytania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dostępnych urządzeń sieciowych używanych przez tcpdump."
 
@@ -395,7 +396,7 @@ msgstr ""
 "'nieokreślone', aby użyć klasycznego limitu czasu uruchamiania zamiast "
 "wyzwalacza sieciowego."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -425,7 +426,7 @@ msgstr ""
 "wielordzeniowej, np. urządzenia x86 lub urządzenia typu raspberry.<br /> "
 "<p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista obsługiwanych i wstępnie skonfigurowanych narzędzi do pobierania."
@@ -439,7 +440,7 @@ msgstr "Lokalne porty DNS"
 msgid "Log View"
 msgstr "Widok dziennika"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Usługa niskopriorytetowa"
 
@@ -460,7 +461,7 @@ msgstr "Brak dzienników związanych z adblockiem!"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil używany przez 'msmtp' do powiadamiania o blokadzie email."
 
@@ -474,7 +475,7 @@ msgstr ""
 "Wysyłaj zapytania do aktywnych list blokowania i kopii zapasowych dla "
 "określonej domeny."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -482,7 +483,7 @@ msgstr ""
 "Zwiększ liczbę powiadomień, aby otrzymywać wiadomości email jeśli ogólna "
 "liczba blokowanych list jest mniejsza lub równa podanemu limitowi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adres odbiorcy dla powiadomień email adblocka."
 
@@ -494,7 +495,7 @@ msgstr ""
 "Przekieruj wszystkie zapytania DNS ze strefy LAN do lokalnego programu "
 "obsługi DNS, dotyczy protokołu UDP i TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -524,35 +525,35 @@ msgstr "Odśwież zegar..."
 msgid "Refresh..."
 msgstr "Odświeżanie..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Zgłoś liczbę fragmentów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Zgłoś wielkość porcji"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Katalog raportów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Interfejs raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr "Porty raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr "Raportuj liczbę fragmentów używaną przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Raportuj wielkość fragmentów używaną przez tcpdump w MB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -581,17 +582,13 @@ msgstr "Uruchomione interfejsy"
 msgid "Run Utils"
 msgstr "Uruchomione narzędzia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr "Moderuj filtr SafeSearch"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Zapisz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -599,7 +596,7 @@ msgstr ""
 "Wysyłaj powiadomienia email związane z adblock. Uwaga: wymaga to dodatkowej "
 "instalacji pakietu 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adres nadawcy dla powiadomień emailowych adblocka."
 
@@ -611,7 +608,7 @@ msgstr "Ustaw/Zmień nowe zadanie Adblock"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -619,7 +616,7 @@ msgstr ""
 "Rozmiar kolejki pobierania do przetwarzania plików (w tym sortowanie, "
 "łączenie itp.) równolegle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr "Źródła (wielkość, skupienie)"
 
@@ -631,11 +628,11 @@ msgstr ""
 "Rozdzielona spacjami lista portów zapory związanych z DNS, które należy "
 "wymusić lokalnie."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Rozdzielona spacjami lista portów używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr "Specjalne opcje konfiguracji dla wybranego narzędzia do pobierania."
 
@@ -655,7 +652,7 @@ msgstr "Status/Wersja"
 msgid "Suspend"
 msgstr "Zawieś"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -663,7 +660,7 @@ msgstr ""
 "Katalog docelowy dla plików raportowania. Domyślnie jest to '/ tmp', "
 "najlepiej użyj pamięci USB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -671,12 +668,12 @@ msgstr ""
 "Katalog docelowy dla kopii zapasowych listy zablokowanych. Domyślnie jest to "
 "'/tmp', użyj najlepiej pamięci USB lub innego dysku lokalnego."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy blokowania 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy zablokowanych 'adb_list.jail'."
@@ -740,7 +737,7 @@ msgstr ""
 msgid "Time"
 msgstr "Czas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Limit czasu oczekiwania na pomyślne ponowne uruchomienie zaplecza DNS."
 
@@ -756,11 +753,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr "Temat dla powiadomień email adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
@@ -769,7 +766,7 @@ msgstr "Opóźnienie wyzwalacza"
 msgid "Unable to save changes: %s"
 msgstr "Nie można zapisać zmian: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
@@ -786,11 +783,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Biała lista ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -798,17 +799,30 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "maks. rozmiar zestawu wyników"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
+
+#~ msgid ""
+#~ "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
+#~ "pixabay."
+#~ msgstr ""
+#~ "Egzekwowanie SafeSearch dla google, bing, duckduckgo, yandex, youtube i "
+#~ "pixabay."
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "Moderuj filtr SafeSearch"
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/pt/adblock.po
+++ b/applications/luci-app-adblock/po/pt/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso adicional do trigger em segundos antes do processamento do Adblock "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Domínio Bloqueado"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Origem da Blocklist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -136,6 +136,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -155,26 +162,26 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Repor o ficheiro DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -188,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Ferramenta para descarregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Endereço do destinatário de e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,15 +276,11 @@ msgstr "Editar lista de permissões"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,19 +294,19 @@ msgstr "Data final"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +316,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Limpar o cache de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +328,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Forçar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +359,7 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +369,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +387,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de ferramentas de descarregamento suportadas e completamente pré-"
@@ -399,7 +402,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -420,7 +423,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -432,13 +435,13 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Endereço do destinatário para e-mails de notificação do adblock."
 
@@ -448,7 +451,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -476,35 +479,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Relatar Contagem de Porções"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Tamanho de Porções de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Interface de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -531,23 +534,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -559,13 +558,13 @@ msgstr ""
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -575,11 +574,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -599,24 +598,24 @@ msgstr ""
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Diretório de destino para a lista de blocos 'adb_list.overall' gerada ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -670,7 +669,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -684,11 +683,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
@@ -697,7 +696,7 @@ msgstr "Atraso do Gatilho"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Registro de Depuração Detalhado"
 
@@ -712,11 +711,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -724,15 +727,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/pt_BR/adblock.po
+++ b/applications/luci-app-adblock/po/pt_BR/adblock.po
@@ -46,7 +46,7 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Adicional"
 
@@ -54,7 +54,7 @@ msgstr "Lista de Bloqueio Adicional"
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso de gatilho adicional em segundos antes do processamento do adblock "
@@ -76,15 +76,15 @@ msgstr "Configurações Avançadas do Relatório"
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -114,7 +114,7 @@ msgstr "Domínios Bloqueados"
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -130,7 +130,7 @@ msgstr "Pesquisando a Lista de Bloqueio..."
 msgid "Blocklist Sources"
 msgstr "Fontes de listas de bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -148,6 +148,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -171,7 +178,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -180,19 +187,19 @@ msgstr ""
 "usados em caso de erros de download ou durante a inicialização."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Zerar Arquivo de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -206,7 +213,7 @@ msgstr "Solicitações do DNS (bloqueadas)"
 msgid "DNS Requests (total)"
 msgstr "Solicitações do DNS (total)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -214,15 +221,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Dia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -230,7 +237,7 @@ msgstr ""
 "Desative o bloqueador de anúncios que causar a reinicialização das funções "
 "autoload/inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
 
@@ -239,39 +246,39 @@ msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Fila de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Perfil de E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -289,15 +296,11 @@ msgstr "Editar a Lista Branca"
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço de bloqueio de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
@@ -313,21 +316,19 @@ msgstr "Data Final"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
-"Impõem o SafeSearch para o google, bing, duckduckgo, yandex, youtube e o "
-"pixabay."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -340,11 +341,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Limpar a Cache do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 
@@ -352,7 +353,7 @@ msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 msgid "Force Local DNS"
 msgstr "Usar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -375,7 +376,7 @@ msgstr "Conceda acesso ao aplicativo LuCI adblock"
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
@@ -387,7 +388,7 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Lista de dispositivos da rede disponíveis que foram usados pelo tcpdump."
@@ -401,7 +402,7 @@ msgstr ""
 "Escolha 'não especificado' para usar um tempo de inicialização clássico em "
 "vez de um gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -432,7 +433,7 @@ msgstr ""
 "mais suporte a RAM e Multicore, por exemplo. x86 ou dispositivos raspberry."
 "<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
@@ -445,7 +446,7 @@ msgstr "Portas DNS Locais"
 msgid "Log View"
 msgstr "Exibir o Registro Log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -466,7 +467,7 @@ msgstr "Ainda não há registros relacionados ao bloqueio de anúncio!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Perfil dos E-Mails de notificação do bloqueio de anúncio utilizado por "
@@ -482,7 +483,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -490,7 +491,7 @@ msgstr ""
 "Aumente a contagem de notificações para receber E-Mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Endereço de E-Mail do destinatário para recebimento das notificações do "
@@ -504,7 +505,7 @@ msgstr ""
 "Redirecione todas as consultas de DNS da zona 'lan' para o resolvedor de DNS "
 "local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -536,35 +537,35 @@ msgstr "Atualizando o Temporizador..."
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Contagem de Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Tamanho dos Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Interface do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -594,17 +595,13 @@ msgstr "Executar Interfaces"
 msgid "Run Utils"
 msgstr "Executar Utilitários"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr "SafeSearch Moderado"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Salvar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -612,7 +609,7 @@ msgstr ""
 "Envie E-Mails de notificação relacionados ao bloqueio de anúncios. Note que: "
 "é necessário a instalação adicional do pacote 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Endereço E-Mail do remetente para as notificações do bloqueador de anúncios."
@@ -625,7 +622,7 @@ msgstr "Definir/Substituir um novo trabalho de bloqueio de anúncios"
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -633,7 +630,7 @@ msgstr ""
 "Tamanho da fila de download para o processamento de download (incl. "
 "classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
@@ -645,11 +642,11 @@ msgstr ""
 "Lista separada por espaço das portas de firewall relacionadas ao DNS que "
 "devem ser impostas localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de download selecionado."
@@ -670,7 +667,7 @@ msgstr "Condição Geral / Versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -679,7 +676,7 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
 "outro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -688,11 +685,11 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou outro "
 "disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Caminho do diretório para a lista nega gerada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
@@ -757,7 +754,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -773,13 +770,13 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos E-Mais que serão usados nas notificações do bloqueador "
 "de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
@@ -788,7 +785,7 @@ msgstr "Gatilho de Atraso"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
@@ -805,11 +802,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -817,17 +818,30 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
+
+#~ msgid ""
+#~ "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
+#~ "pixabay."
+#~ msgstr ""
+#~ "Impõem o SafeSearch para o google, bing, duckduckgo, yandex, youtube e o "
+#~ "pixabay."
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "SafeSearch Moderado"
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/ro/adblock.po
+++ b/applications/luci-app-adblock/po/ro/adblock.po
@@ -44,7 +44,7 @@ msgstr "Adăugați acest (sub) domeniu în lista locală de interzise."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adăugați acest (sub) domeniu la lista locală de admise."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Setări Suplimentare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Întârziere adițională înainte ca procesarea adblock-ului să înceapă (în "
@@ -74,15 +74,15 @@ msgstr "Setări Avansate Raport"
 msgid "Answer"
 msgstr "Răspuns"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Director Temporar de Bază"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,7 +111,7 @@ msgstr "Domeniu blocat"
 msgid "Blocked Domains"
 msgstr "Domenii Blocate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Copie de Rezervă Pentru Lista de Blocate"
 
@@ -127,7 +127,7 @@ msgstr "Interogare Lista de Blocare..."
 msgid "Blocklist Sources"
 msgstr "Surse de blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,6 +145,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Renunțare"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -168,7 +175,7 @@ msgstr ""
 msgid "Count"
 msgstr "Număr"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -177,19 +184,19 @@ msgstr ""
 "utilizate în cazul erorilor de descărcare sau în timpul pornirii."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Director DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -203,7 +210,7 @@ msgstr "Cereri DNS (blocate)"
 msgid "DNS Requests (total)"
 msgstr "Cereri DNS (total)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "Timp Repornire DNS"
 
@@ -211,15 +218,15 @@ msgstr "Timp Repornire DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Dezactivare Permite DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Dezactivare Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,7 +234,7 @@ msgstr ""
 "Dezactivează repornirile declanșate de adblock pentru backend-urile dns cu "
 "funcții de autoîncărcare /notificare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
 
@@ -236,39 +243,39 @@ msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
 msgid "Domain"
 msgstr "Domeniu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Descărcare Parametri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Coadă de Descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Notificare e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Număr de Notificări pe E-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Profil E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Adresa E-Mail Expeditor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "Subiect E-Mail"
 
@@ -286,15 +293,11 @@ msgstr "Editare listă albă"
 msgid "Enable SafeSearch"
 msgstr "Activare Căutare Sigură"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "Activare filtre moderate SafeSearch pentru YouTube."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Activare serviciu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activare înregistrare detaliată de depanare în cazul unor erori de procesare."
@@ -309,21 +312,19 @@ msgstr "Data sfârşit"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
-"Forțare căutare sigură pentru google, bing, duckduckgo, yandex, youtube și "
-"pixbay."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Activitate(ăți) existentă(e)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr "Domeniul de căutare DNS extern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +337,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterii de filtrare precum dată, domeniu sau client (opțional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Eliberează cache-ul DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 
@@ -348,7 +349,7 @@ msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 msgid "Force Local DNS"
 msgstr "Forţează DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -371,7 +372,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "Director Închisoare"
 
@@ -383,7 +384,7 @@ msgstr "Ultima rulare"
 msgid "Latest DNS Requests"
 msgstr "Ultimele Cereri DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dispozitivelor de rețea utilizate de tcpdump."
 
@@ -396,7 +397,7 @@ msgstr ""
 "Alegeți „nespecificat” pentru a utiliza un interval de timp de pornire "
 "clasic în loc de declanșarea rețelei."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -425,7 +426,7 @@ msgstr ""
 "&#xa0;<b>XXL</b> (200k-) au nevoie de dispozitive cu mai mult RAM și suport "
 "Multicore, ex. x86 sau raspberry.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -438,7 +439,7 @@ msgstr "Porturi DNS Locale"
 msgid "Log View"
 msgstr "Vizualizare Jurnal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -459,7 +460,7 @@ msgstr "Nu există încă jurnale adblock!"
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilizat de „msmtp” pentru e-mailurile de notificare adblock."
 
@@ -473,7 +474,7 @@ msgstr ""
 "Interogare listă de blocări active și copii de rezervă pentru un anumit "
 "domeniu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -481,7 +482,7 @@ msgstr ""
 "Creșteți numărul de notificări pentru a primi e-mailuri dacă numărul total "
 "de blocări este mai mic sau egal cu limita dată."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -493,7 +494,7 @@ msgstr ""
 "Redirecționare toate interogările DNS din zona „lan” către procesatorul DNS "
 "local, se aplică protocolului UDP și TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -524,35 +525,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -579,23 +580,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Salvează"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -607,13 +604,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -623,11 +620,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -647,23 +644,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Suspendă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -715,7 +712,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -729,11 +726,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
@@ -742,7 +739,7 @@ msgstr "Intârzierea declanșării"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -757,11 +754,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -769,17 +770,27 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "Activare filtre moderate SafeSearch pentru YouTube."
+
+#~ msgid ""
+#~ "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
+#~ "pixabay."
+#~ msgstr ""
+#~ "Forțare căutare sigură pentru google, bing, duckduckgo, yandex, youtube "
+#~ "și pixbay."
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -49,7 +49,7 @@ msgstr "Добавить (под-)домен в ваш локальный чер
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Добавить (под-)домен в ваш локальный белый список."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr "Дополнительный тюремный блоклист"
 
@@ -57,7 +57,7 @@ msgstr "Дополнительный тюремный блоклист"
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Дополнительная задержка в секундах до начала работы Adblock."
 
@@ -77,15 +77,15 @@ msgstr "Расширенные настройки отчетов"
 msgid "Answer"
 msgstr "Ответ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Базовый временный каталог"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -114,7 +114,7 @@ msgstr "Заблокированные домены"
 msgid "Blocked Domains"
 msgstr "Заблокированные домены"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Бэкап черного списка"
 
@@ -131,7 +131,7 @@ msgstr "Запросы к черному списку..."
 msgid "Blocklist Sources"
 msgstr "Источники черных списков"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 #, fuzzy
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
@@ -150,6 +150,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Отменить"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -174,7 +181,7 @@ msgstr ""
 msgid "Count"
 msgstr "Количество"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -183,19 +190,19 @@ msgstr ""
 "загрузкой или во время запуска."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "DNS-серверная часть"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "Папка DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Сброс файла DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -209,7 +216,7 @@ msgstr "DNS запросы (заблокированы)"
 msgid "DNS Requests (total)"
 msgstr "DNS запросов (всего)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "Таймаут перезапуска DNS"
 
@@ -217,15 +224,15 @@ msgstr "Таймаут перезапуска DNS"
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "Отключить DNS ответы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "Отключить перезагрузки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -233,7 +240,7 @@ msgstr ""
 "Отключить триггеры, запускаемые adblock, для dns backends с функциями "
 "автозагрузки/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -242,39 +249,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "Параметры загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "Очередь загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Утилита для скачивания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Уведомление электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "Счётчик e-mail уведомлений"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "Почтовый адрес отправителя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -292,15 +299,11 @@ msgstr "Редактировать Белый список"
 msgid "Enable SafeSearch"
 msgstr "Включить Безопасный Поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "Включите умеренные фильтры Безопастного Поиска для youtube."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "Включить сервис AdBlock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Включите подробное ведение журнала отладки в случае каких-либо ошибок "
@@ -316,19 +319,19 @@ msgstr "Дата окончания"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "Существующая работа(ы)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -341,11 +344,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Критерии фильтрации, такие как дата, домен или клиент (необязательно)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Очистка кэша DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Очистите кэш DNS до обработки adblock."
 
@@ -353,7 +356,7 @@ msgstr "Очистите кэш DNS до обработки adblock."
 msgid "Force Local DNS"
 msgstr "Локальный DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -372,7 +375,7 @@ msgstr "Предоставить доступ к приложению LuCI AdBlo
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "Директория Jail"
 
@@ -384,7 +387,7 @@ msgstr "Последний запуск"
 msgid "Latest DNS Requests"
 msgstr "Последние DNS запросы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr "Список доступных сетевых устройств используемых tcpdump."
 
@@ -394,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -414,7 +417,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Список поддерживаемых и полностью предварительно настроенных утилит для "
@@ -429,7 +432,7 @@ msgstr "Локальные порты DNS"
 msgid "Log View"
 msgstr "Просмотр журнала"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Низкий приоритет службы"
 
@@ -450,7 +453,7 @@ msgstr "Ещё нет журналов, связанных с adblock!"
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -463,13 +466,13 @@ msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 "Запросить активные списки блоков и резервные копии для определенного домена."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Адрес получателя для уведомлений по электронной почте."
 
@@ -479,7 +482,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -507,35 +510,35 @@ msgstr "Обновить таймер..."
 msgid "Refresh..."
 msgstr "Обновить..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "Количество фрагментов отчета"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "Размер фрагментов отчета"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "Папка для отчетов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "Отчет интерфейса"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr "Порты отчетов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -562,23 +565,19 @@ msgstr "Интерфейсы запуска"
 msgid "Run Utils"
 msgstr "Запуск Утилиты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Сохранить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr "E-Mails адрес отправителя для уведомления adblock ."
 
@@ -590,13 +589,13 @@ msgstr ""
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -606,11 +605,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Разделенный пробелами список портов используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -630,23 +629,23 @@ msgstr "Статус / Версия"
 msgid "Suspend"
 msgstr "Приостановить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Папка для созданного списка блокировки 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -700,7 +699,7 @@ msgstr ""
 msgid "Time"
 msgstr "Время"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Тайм-аут ожидания успешного перезапуска серверной части DNS."
 
@@ -714,11 +713,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Топ-10 статистики"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
@@ -727,7 +726,7 @@ msgstr "Задержка запуска"
 msgid "Unable to save changes: %s"
 msgstr "Невозможно сохранить изменения: %ы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
@@ -744,11 +743,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Белый список..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -756,17 +759,20 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "Включите умеренные фильтры Безопастного Поиска для youtube."
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/sk/adblock.po
+++ b/applications/luci-app-adblock/po/sk/adblock.po
@@ -43,7 +43,7 @@ msgstr "Pridať túto (sub-) doménu medzi lokálne zakázané domény."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Pridať túto (sub-) doménu medzi lokálne povolené domény."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Ďalšie nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatočné oneskorenie v sekundách pred začiatkom spracovania blokovania "
@@ -74,15 +74,15 @@ msgstr "Pokročilé nastavenia"
 msgid "Answer"
 msgstr "Odpoveď"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "Základný Temp priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -109,7 +109,7 @@ msgstr "Blokovaná doména"
 msgid "Blocked Domains"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "Záloha zoznamu blokovaných domén"
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Zdroje zoznamov blokovaní"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -139,6 +139,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Zrušiť"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -158,26 +165,26 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS adresár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Inicializácia DNS súboru"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -191,7 +198,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -199,21 +206,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -222,39 +229,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "Upozornenie e-mailom"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "Adresa príjemcu e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -272,15 +279,11 @@ msgstr "Upraviť bielu listinu"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -294,19 +297,19 @@ msgstr "Koncový dátum"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -316,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Vyprázdniť medzipamäť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -328,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -347,7 +350,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informácie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -359,7 +362,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -369,7 +372,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -387,7 +390,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -400,7 +403,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -421,7 +424,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -433,13 +436,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -449,7 +452,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,35 +480,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -532,23 +535,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Uložiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -560,13 +559,13 @@ msgstr ""
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -576,11 +575,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -600,23 +599,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -668,7 +667,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -682,11 +681,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -695,7 +694,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -710,11 +709,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -722,15 +725,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligare trigger fördröjning i sekunder innan Adblock-bearbetningen "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Blockerad domän"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Källor för blockeringslistor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -155,26 +162,26 @@ msgstr ""
 msgid "Count"
 msgstr "Räkna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS-mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS-filåterställning"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -188,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagaradress"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,15 +276,11 @@ msgstr "Redigera vitlista"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,19 +294,19 @@ msgstr "Slutdatum"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +316,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "Töm DNS-cache"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +328,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Tvinga lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +359,7 @@ msgstr "Kördes senast"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +369,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +387,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
 
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "Lågprioriterad tjänst"
 
@@ -418,7 +421,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Översikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -430,13 +433,13 @@ msgstr "Fråga"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -446,7 +449,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -474,35 +477,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -529,23 +532,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Spara"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -557,13 +556,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -573,11 +572,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,23 +596,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Stäng av"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +664,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +678,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -692,7 +691,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -707,11 +706,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -719,15 +722,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -42,7 +42,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -62,15 +62,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -124,6 +124,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -144,26 +151,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -177,7 +184,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -185,21 +192,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -208,39 +215,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -258,15 +265,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -280,19 +283,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -302,11 +305,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -314,7 +317,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -333,7 +336,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -345,7 +348,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -355,7 +358,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -373,7 +376,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -386,7 +389,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -407,7 +410,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -419,13 +422,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -435,7 +438,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -463,35 +466,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -518,23 +521,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -546,13 +545,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -562,11 +561,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -586,23 +585,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -654,7 +653,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -668,11 +667,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -681,7 +680,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -696,11 +695,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -708,14 +711,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/tr/adblock.po
+++ b/applications/luci-app-adblock/po/tr/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 #, fuzzy
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Reklam engelleme işlemi başlamadan önceki ilave tetik gecikmesi."
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Cevap"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Yedek Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "Engellenmiş Alan Adı"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Engelleme Listesi Kaynakları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -155,26 +162,26 @@ msgstr ""
 msgid "Count"
 msgstr "Sayım"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -188,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,15 +276,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,19 +294,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +316,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +328,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +359,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +369,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +387,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -418,7 +421,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -430,13 +433,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -446,7 +449,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -474,35 +477,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -529,23 +532,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -557,13 +556,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -573,11 +572,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,23 +596,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +664,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +678,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -692,7 +691,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -707,11 +706,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -719,15 +722,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/uk/adblock.po
+++ b/applications/luci-app-adblock/po/uk/adblock.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "Скасувати"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -154,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -187,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -195,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -218,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -268,15 +275,11 @@ msgstr "Редагувати білий список"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -290,19 +293,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,11 +315,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -324,7 +327,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -343,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr "Інформація"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -355,7 +358,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -365,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -383,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -396,7 +399,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -417,7 +420,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -429,13 +432,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -445,7 +448,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -473,35 +476,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -528,23 +531,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "Зберегти"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -556,13 +555,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -572,11 +571,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -596,23 +595,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -664,7 +663,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -678,11 +677,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr ""
 
@@ -691,7 +690,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -706,11 +705,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -718,15 +721,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/vi/adblock.po
+++ b/applications/luci-app-adblock/po/vi/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Kích hoạt độ trễ trong vài giây trước khi bắt đầu tiến trình chặn quảng cáo."
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Phản hồi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "Tên miền bị chặn"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Bộ lọc"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:162
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
@@ -154,27 +161,27 @@ msgstr ""
 msgid "Count"
 msgstr "Bộ đếm"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 #, fuzzy
 msgid "DNS Directory"
 msgstr "Thư mục DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "Đặt lại tệp DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -188,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ngày"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,15 +276,11 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,19 +294,19 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +316,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +328,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +359,7 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +369,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +387,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr ""
 
@@ -418,7 +421,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -430,13 +433,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -446,7 +449,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -474,35 +477,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -529,23 +532,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -557,13 +556,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -573,11 +572,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,23 +596,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +664,7 @@ msgstr ""
 msgid "Time"
 msgstr "Thời gian"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +678,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
@@ -692,7 +691,7 @@ msgstr "Kích hoạt độ trễ"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 #, fuzzy
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
@@ -708,11 +707,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -720,15 +723,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/zh_Hans/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hans/adblock.po
@@ -50,7 +50,7 @@ msgstr "添加此域名到本地黑名单"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "添加此域名到本地白名单"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr "额外的封锁禁闭名单"
 
@@ -58,7 +58,7 @@ msgstr "额外的封锁禁闭名单"
 msgid "Additional Settings"
 msgstr "附加设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "事件触发启动前的延时（秒）。"
 
@@ -78,15 +78,15 @@ msgstr "高级报告设置"
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "备份目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr "基础临时目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,7 +111,7 @@ msgstr "已拦截的域名"
 msgid "Blocked Domains"
 msgstr "拦截域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr "黑名单列表的备份"
 
@@ -127,14 +127,14 @@ msgstr "黑名单查询..."
 msgid "Blocklist Sources"
 msgstr "拦截列表来源"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
 "blocklist e.g. for guest wifi or kidsafe configurations."
 msgstr ""
-"构建一个附加的DNS阻止列表，以阻止对除白名单中列出的所有域之外的所有域的访问。请注意：您可以使用此限制性阻止列表，例如用于访客wifi或kidsafe配"
-"置。"
+"构建一个附加的DNS阻止列表，以阻止对除白名单中列出的所有域之外的所有域的访问。"
+"请注意：您可以使用此限制性阻止列表，例如用于访客wifi或kidsafe配置。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
@@ -143,6 +143,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "取消"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -155,9 +162,9 @@ msgid ""
 "master/net/adblock/files/README.md\" target=\"_blank\" rel=\"noreferrer "
 "noopener\" >check the online documentation</a>"
 msgstr ""
-"配置adblock软件包以使用DNS阻止广告/滥用域。有关更多信息，请<a href=\"https://github.com/openwrt/"
-"packages/blob/master/net/adblock/files/README.md\" target=\"_blank\" rel=\""
-"noreferrer noopener\">查看在线文档</a>"
+"配置adblock软件包以使用DNS阻止广告/滥用域。有关更多信息，请<a href=\"https://"
+"github.com/openwrt/packages/blob/master/net/adblock/files/README.md\" target="
+"\"_blank\" rel=\"noreferrer noopener\">查看在线文档</a>"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:205
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
@@ -165,26 +172,26 @@ msgstr ""
 msgid "Count"
 msgstr "计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "创建压缩的阻止列表备份，将在下载错误或启动期间使用它们。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr "DNS后端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS 目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS 文件重置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -198,7 +205,7 @@ msgstr "DNS请求（已阻止）"
 msgid "DNS Requests (total)"
 msgstr "DNS请求（总计）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr "DNS重新启动超时"
 
@@ -206,21 +213,21 @@ msgstr "DNS重新启动超时"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr "禁止 DNS 允许"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr "禁用DNS重新启动"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "禁用具有自动加载/ inotify功能的dns后端的adblock触发的重启。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "禁止选择性DNS白名单(RPZ通过)."
 
@@ -229,39 +236,39 @@ msgstr "禁止选择性DNS白名单(RPZ通过)."
 msgid "Domain"
 msgstr "域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr "下载队列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "E-Mail 通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr "电子邮件通知计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr "电子邮件资料"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail 收件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -279,15 +286,11 @@ msgstr "编辑白名单"
 msgid "Enable SafeSearch"
 msgstr "启用安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr "为YouTube启用适度的安全搜索过滤器."
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr "启用广告屏蔽服务."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出现任何处理错误的情况下启用详细调试日志记录."
 
@@ -301,33 +304,35 @@ msgstr "结束日期"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
-msgstr "强制执行Google，Bing，Duckduckgo，Yandex，youtube和Google的SafeSearc."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr "现有的工作(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr "外部DNS查找域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
-msgstr "外部域，用于检查DNS后端是否成功重启。请注意：要禁用此检查，请将此选项设置为“ false”。"
+msgstr ""
+"外部域，用于检查DNS后端是否成功重启。请注意：要禁用此检查，请将此选项设置为“ "
+"false”。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:156
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "过滤条件，例如日期，域或客户（可选）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 缓存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "还要在处理adblock之前刷新DNS缓存。"
 
@@ -335,14 +340,14 @@ msgstr "还要在处理adblock之前刷新DNS缓存。"
 msgid "Force Local DNS"
 msgstr "强制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
-"通过tcpdump收集与DNS相关的网络流量，并按需提供DNS报告。请注意：这需要额外的“ tcpdump-"
-"mini”软件包安装，并重新启动完整的adblock服务才能生效。"
+"通过tcpdump收集与DNS相关的网络流量，并按需提供DNS报告。请注意：这需要额外的“ "
+"tcpdump-mini”软件包安装，并重新启动完整的adblock服务才能生效。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
 msgid "General Settings"
@@ -356,7 +361,7 @@ msgstr "授予对LuCI应用程序adblock的访问权限"
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr "黑名单目录"
 
@@ -368,7 +373,7 @@ msgstr "最后运行"
 msgid "Latest DNS Requests"
 msgstr "最新的DNS请求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump使用的可用网络设备列表."
 
@@ -376,13 +381,16 @@ msgstr "tcpdump使用的可用网络设备列表."
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
-msgstr "触发adblock启动的可用网络接口列表.选择“未指定”以使用传统的启动超时而不是网络触发器."
+msgstr ""
+"触发adblock启动的可用网络接口列表.选择“未指定”以使用传统的启动超时而不是网络"
+"触发器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
-msgstr "支持的DNS后端列表及其默认列表目录.要覆盖默认路径，请使用“ DNS目录”选项."
+msgstr ""
+"支持的DNS后端列表及其默认列表目录.要覆盖默认路径，请使用“ DNS目录”选项."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
 msgid ""
@@ -395,13 +403,15 @@ msgid ""
 "devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
-"受支持且已完全预先配置的adblock源列表，已预先选择了已激活的源。<br /> <b> <em>为避免OOM错误，请不要选择太多列表！</ em> "
-"</ b> <br />列出各个域范围的大小信息，如下所示：<br />＆＃8226;＆＃xa0; <b> S </ b>（-10k），<b> M </ "
-"b>（10k -30k）和<b> L </ b>（30k-80k）适用于128 MByte设备，<br />＆＃8226;＆＃xa0; <b> XL </"
-" b>（80k-200k）应适用适用于256-512 MB设备，<br />＆＃8226;＆＃xa0; <b> XXL </ "
-"b>（200k-）需要更多的RAM和多核支持，例如x86或树莓派设备。<br /> <p>＆＃xa0; </ p>"
+"受支持且已完全预先配置的adblock源列表，已预先选择了已激活的源。<br /> <b> "
+"<em>为避免OOM错误，请不要选择太多列表！</ em> </ b> <br />列出各个域范围的大"
+"小信息，如下所示：<br />＆＃8226;＆＃xa0; <b> S </ b>（-10k），<b> M </ "
+"b>（10k -30k）和<b> L </ b>（30k-80k）适用于128 MByte设备，<br />＆＃8226;＆"
+"＃xa0; <b> XL </ b>（80k-200k）应适用适用于256-512 MB设备，<br />＆＃8226;＆"
+"＃xa0; <b> XXL </ b>（200k-）需要更多的RAM和多核支持，例如x86或树莓派设备。"
+"<br /> <p>＆＃xa0; </ p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支持和完全预配置的下载工具列表。"
 
@@ -414,7 +424,7 @@ msgstr "本地DNS端口"
 msgid "Log View"
 msgstr "日志视图"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "低优先级服务"
 
@@ -435,7 +445,7 @@ msgstr "尚无与adblock相关的日志！"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp' 用于adblock通知电子邮件的配置文件。"
 
@@ -447,13 +457,14 @@ msgstr "查询"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查询特定域的活动阻止列表和备份."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
-msgstr "如果总体阻止列表总数小于或等于给定的限制，请提高通知数量，以获取电子邮件."
+msgstr ""
+"如果总体阻止列表总数小于或等于给定的限制，请提高通知数量，以获取电子邮件."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知 E-Mail 的收件人地址。"
 
@@ -461,14 +472,17 @@ msgstr "adblock 通知 E-Mail 的收件人地址。"
 msgid ""
 "Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
 "to UDP and TCP protocol."
-msgstr "将所有 DNS 查询从“lan”区域重定向到本地解析器，包括 udp、tcp 协议的端口 ."
+msgstr ""
+"将所有 DNS 查询从“lan”区域重定向到本地解析器，包括 udp、tcp 协议的端口 ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
 "service restart to take effect."
-msgstr "降低adblock后台处理的优先级以减少系统资源.请注意：此更改要求重新启动完整的adblock服务才能生效."
+msgstr ""
+"降低adblock后台处理的优先级以减少系统资源.请注意：此更改要求重新启动完整的"
+"adblock服务才能生效."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:183
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
@@ -491,35 +505,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "报告区块计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "报告区块大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "报告接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -546,23 +560,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -574,13 +584,13 @@ msgstr ""
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -590,11 +600,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -614,23 +624,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -682,7 +692,7 @@ msgstr ""
 msgid "Time"
 msgstr "时间"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -696,11 +706,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "触发延迟"
 
@@ -709,7 +719,7 @@ msgstr "触发延迟"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
@@ -724,11 +734,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,17 +750,26 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Enable moderate SafeSearch filters for youtube."
+#~ msgstr "为YouTube启用适度的安全搜索过滤器."
+
+#~ msgid ""
+#~ "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
+#~ "pixabay."
+#~ msgstr ""
+#~ "强制执行Google，Bing，Duckduckgo，Yandex，youtube和Google的SafeSearc."
 
 #~ msgid ""
 #~ "<b>Caution:</b> To prevent OOM exceptions on low memory devices with less "

--- a/applications/luci-app-adblock/po/zh_Hant/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hant/adblock.po
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "廣告塊處理開始前數秒內的額外觸發延遲。"
 
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Answer"
 msgstr "回覆"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +110,7 @@ msgstr "封锁网域"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,7 +126,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "拉黑檔案清單"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,6 +140,13 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
 msgid "Cancel"
 msgstr "取消"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid ""
+"Choose restrictive, moderate or disabled SafeSearch filters for YouTube. "
+"Please note: even moderate filter might be to restrictive for some content, "
+"e.g. music."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Client"
@@ -159,26 +166,26 @@ msgstr ""
 msgid "Count"
 msgstr "次數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:352
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "DNS Directory"
 msgstr "DNS 目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "DNS File Reset"
 msgstr "DNS檔案重置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
@@ -192,7 +199,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -200,21 +207,21 @@ msgstr ""
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:414
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:405
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -223,39 +230,39 @@ msgstr ""
 msgid "Domain"
 msgstr "網域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "Download Utility"
 msgstr "下載實用程式"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid "E-Mail Notification"
 msgstr "電子郵件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,15 +280,11 @@ msgstr "編輯白名單"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "Enable moderate SafeSearch filters for youtube."
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -295,19 +298,19 @@ msgstr "結束日期"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid ""
-"Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
-"pixabay."
+"Enforcing SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and "
+"Pixabay."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:18
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -317,11 +320,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 快取"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -329,7 +332,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "強制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -348,7 +351,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Jail Directory"
 msgstr ""
 
@@ -360,7 +363,7 @@ msgstr "最後執行"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -370,7 +373,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -388,7 +391,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:362
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支援和完全預配置的下載工具列表。"
 
@@ -401,7 +404,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid "Low Priority Service"
 msgstr "低優先權服務"
 
@@ -422,7 +425,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -434,13 +437,13 @@ msgstr "查詢"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -450,7 +453,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -478,35 +481,35 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report Chunk Count"
 msgstr "報告區塊計數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report Chunk Size"
 msgstr "報告區塊大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "Report Directory"
 msgstr "報告目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Report Interface"
 msgstr "報告介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:395
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -533,23 +536,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
 msgid "Save"
 msgstr "儲存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -561,13 +560,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:340
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -577,11 +576,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:369
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -601,23 +600,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "暫停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成攔截列表“adb_list.overall”的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -669,7 +668,7 @@ msgstr ""
 msgid "Time"
 msgstr "時間"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -683,11 +682,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:332
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
@@ -696,7 +695,7 @@ msgstr "觸發延遲"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:327
 msgid "Verbose Debug Logging"
 msgstr "囉嗦除錯紀錄"
 
@@ -711,11 +710,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+msgid "YouTube SafeSearch"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -723,15 +726,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:378
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 


### PR DESCRIPTION
New options under YouTube SafeSearch: restrictive, moderate or disabled. This allows for better YouTube filter control, as for some even moderate filtering is too intrusive, e.g. with music. This will allow to disable completely YouTube filtering and keeping SafeSearch enabled for the other search engines.

Signed-off-by: Alberto Martínez Álvarez amteza@gmail.com

Maintainer: Dirk Brenken <dev@brenken.org> / @dibdot 
Compile tested: (aarch64, RPi4, OpenWrt master)
Run tested: (aarch64, RPi4, OpenWrt master, tested all options on interface)