### PR TITLE
luci-app-adblock [19.07]: sync with adblock 4.0.6

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -266,7 +266,7 @@ return L.view.extend({
 		s.tab('general',  _('General Settings'));
 		s.tab('additional', _('Additional Settings'));
 		s.tab('adv_dns', _('Advanced DNS Settings'));
-		s.tab('adv_report', _('Advanced Report Settings'));
+		s.tab('adv_report', _('Advanced Report Settings'), _('Changes on this tab needs a full adblock service restart to take effect.<br /><p>&#xa0;</p>'));
 		s.tab('adv_email', _('Advanced E-Mail Settings'));
 		s.tab('sources', _('Blocklist Sources'), _('List of supported and fully pre-configured adblock sources, already active sources are pre-selected.<br /> \
 			<b><em>To avoid OOM errors, please do not select too many lists!</em></b><br /> \
@@ -299,7 +299,16 @@ return L.view.extend({
 		o = s.taboption('general', form.Flag, 'adb_safesearch', _('Enable SafeSearch'), _('Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and pixabay.'));
 		o.rmempty = false;
 
-		o = s.taboption('general', form.Flag, 'adb_safesearchmod', _('SafeSearch Moderate'), _('Enable moderate SafeSearch filters for youtube.'));
+		o = s.taboption('general', form.MultiValue, 'adb_safesearchlist', _('Limit SafeSearch'), _('Limit SafeSearch to certain providers.'));
+		o.depends('adb_safesearch', '1');
+		o.value('google');
+		o.value('bing');
+		o.value('yandex');
+		o.value('youtube');
+		o.value('pixabay');
+		o.rmempty = true;
+
+		o = s.taboption('general', form.Flag, 'adb_safesearchmod', _('Relax SafeSearch'), _('Enable moderate SafeSearch filters for youtube.'));
 		o.depends('adb_safesearch', '1');
 		o.rmempty = true;
 

--- a/applications/luci-app-adblock/po/bg/adblock.po
+++ b/applications/luci-app-adblock/po/bg/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -147,26 +153,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -180,7 +186,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +194,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +217,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,7 +267,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,11 +297,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +311,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +323,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -332,7 +338,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -344,7 +350,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -354,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -372,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -385,7 +399,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -406,7 +420,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -418,13 +432,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -434,7 +448,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -462,35 +476,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -517,23 +535,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -545,13 +559,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -561,11 +575,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -585,23 +599,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -653,7 +667,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -667,11 +681,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -680,7 +694,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -695,11 +709,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -707,14 +721,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ca/adblock.po
+++ b/applications/luci-app-adblock/po/ca/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Retard addicional en segons de l’activador abans que comenci el processament "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Domini blocat"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Fonts de la llista negra"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -155,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Recompte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Directori del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Reinicialització de fitxers del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Notificació per correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Adreça de destinatari de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr "Edita la llista blanca"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Purga la memòria cau del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Força el DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr "Darrera execució"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Llista d’utilitats de baixada admeses i plenament preconfigurades."
 
@@ -393,7 +407,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Servei de prioritat baixa"
 
@@ -414,7 +428,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -426,13 +440,13 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -442,7 +456,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,35 +484,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -525,23 +543,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Desa"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -553,13 +567,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -569,11 +583,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -593,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -661,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -675,11 +689,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -688,7 +702,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
@@ -703,11 +717,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -715,14 +729,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/cs/adblock.po
+++ b/applications/luci-app-adblock/po/cs/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatečné zpoždění v sekundách před začátkem zpracování blokování reklamy."
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Odpověd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "Blokované domény"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Zdroje seznamů blokování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -154,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Adresář DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Resetování souboru DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -187,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -195,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -218,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Oznámení e-mailem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Adresa příjemce e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -268,7 +274,7 @@ msgstr "Upravit whitelist"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -276,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -298,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,11 +318,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Vyprázdnit mezipaměť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -324,7 +330,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Vynutit lokální DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -339,7 +345,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -351,7 +357,15 @@ msgstr "Poslední spuštění"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -361,7 +375,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -379,7 +393,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Seznam podporovaných a plně předkonfigurovaných nástrojů pro stahování."
@@ -393,7 +407,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Služba s nízkou prioritou"
 
@@ -414,7 +428,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -426,13 +440,13 @@ msgstr "Dotaz"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adresa příjemce pro e-maily s upozorněním."
 
@@ -442,7 +456,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,35 +484,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Počet bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Velikost bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Adresář sestav"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Rozhraní sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -525,23 +543,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Uložit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -553,13 +567,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -569,11 +583,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -593,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Pozastavit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Cílový adresář pro vygenerovaný blokovací seznam 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -661,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr "Čas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -675,11 +689,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
@@ -688,7 +702,7 @@ msgstr "Prodleva spuštění"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
@@ -703,11 +717,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -715,14 +729,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/de/adblock.po
+++ b/applications/luci-app-adblock/po/de/adblock.po
@@ -43,7 +43,7 @@ msgstr "Füge diese (Sub-)Domain zur lokalen Blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Füge diese (Sub-)Domain zur lokalen Whiteklist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr "Zusätzliche Jail-Sperrliste"
 
@@ -51,7 +51,7 @@ msgstr "Zusätzliche Jail-Sperrliste"
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Zusätzliche Verzögerung (in Sekunden) bis zur Verarbeitung durch den "
@@ -73,15 +73,15 @@ msgstr "Fortgeschrittene Berichtseinstellungen"
 msgid "Answer"
 msgstr "Antwort"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "Basis-Temp-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +110,7 @@ msgstr "Blockierte Domain"
 msgid "Blocked Domains"
 msgstr "Gesperrte Domains"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "Sperrliste Backup"
 
@@ -126,7 +126,7 @@ msgstr "Sperrlisten abfragen..."
 msgid "Blocklist Sources"
 msgstr "Blockierlisten-Quellen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -143,6 +143,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Abbrechen"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -166,7 +172,7 @@ msgstr ""
 msgid "Count"
 msgstr "Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -175,19 +181,19 @@ msgstr ""
 "sofort ab dem Booten oder im Fall von Downloadfehlern zur Verfügung zu haben."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr "DNS-Backend"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "DNS-Datei zurücksetzen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -201,7 +207,7 @@ msgstr "DNS Anforderungen (blockiert)"
 msgid "DNS Requests (total)"
 msgstr "DNS-Abfragen (gesamt)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "DNS-Restart-Timeout"
 
@@ -209,15 +215,15 @@ msgstr "DNS-Restart-Timeout"
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "Deaktiviere DNS-Zulassen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "Deaktiviere DNS-Restarts"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -225,7 +231,7 @@ msgstr ""
 "Deaktiviere das Triggern von Neustarts des DNS-Backends durch Adblock per "
 "Autoload/inotify-Funktionsaufrufe."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
 
@@ -234,39 +240,39 @@ msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
 msgid "Domain"
 msgstr "Domäne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr "Downloadparameter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "Download-Warteschlange"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "Email-Benachrichtigszähler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "Email-Profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail-Empfängeradresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "Email-Absenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr "Email-Betreff"
 
@@ -284,7 +290,7 @@ msgstr "Whiteliste bearbeiten"
 msgid "Enable SafeSearch"
 msgstr "Aktiviere SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
 
@@ -292,7 +298,7 @@ msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
 msgid "Enable the adblock service."
 msgstr "Aktiviere den Adblock-Dienst."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Aktiviere ausführliche Debug-Logs im Fehlerfall."
 
@@ -314,11 +320,11 @@ msgstr "Erzwinge SafeSearch für Google, Bing, DuckDuckGo, Yandex und Pixabay."
 msgid "Existing job(s)"
 msgstr "Bestehende Job(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr "Externe DNS-Abfragedomain"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -330,11 +336,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filterkriterien wie z.B. Datum, Domain oder Client (optional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "DNS-Cache leeren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 
@@ -342,7 +348,7 @@ msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 msgid "Force Local DNS"
 msgstr "Lokales DNS erzwingen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -360,7 +366,7 @@ msgstr "Allgemeine Einstellungen"
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "Jail-Verzeichnis"
 
@@ -372,7 +378,15 @@ msgstr "Letzter Lauf"
 msgid "Latest DNS Requests"
 msgstr "Letzte DNS-Abfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Liste an verfügbaren Netzwerkschnittstellen die von tcpdump verwendet werden "
@@ -387,7 +401,7 @@ msgstr ""
 "triggern. Wähle \"unspecified\", um einen herkömmlichen Start-Timeout-"
 "Mechanismuss anstatt eines Netzwerk-Triggers zu verwenden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -416,7 +430,7 @@ msgstr ""
 "mehr RAM und zusätzlich eine Multicore-CPU, z.B entpsrechende x86- oder "
 "RaspberryPi-Geräte.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste der unterstützten und vollständig vorkonfigurierten Download-"
@@ -431,7 +445,7 @@ msgstr "Lokale DNS-Ports"
 msgid "Log View"
 msgstr "Log-Ansicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Dienst mit niedriger Priorität"
 
@@ -452,7 +466,7 @@ msgstr "Aktuell noch keine Adblock-Logs vorhanden!"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "\"msmtp\"-Profil, das für Adblock-Benachrichtigunsmails verwendet wird."
@@ -465,7 +479,7 @@ msgstr "Abfrage"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Frage aktive Sperrlisten und Backups über eine spezifische Domain ab."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -473,7 +487,7 @@ msgstr ""
 "Erhöhe den Benachrichtigunszähler um Emails zu erhalten, wenn die Gesamtzahl "
 "der Blocklisten kleiner gleich diesem Schwellwert ist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Empfängeradresse für Adblock-Benachrichtigungs-E-Mails."
 
@@ -485,7 +499,7 @@ msgstr ""
 "Leite alle DNS-Anfragen an die \"Lan\"-Zone auf den lokalen DNS-Resolver um, "
 "gilt sowohl für UDP und TCP-Protokolle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -516,35 +530,39 @@ msgstr "Aktualisiere Timer..."
 msgid "Refresh..."
 msgstr "Aktualisiere..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Berichte Datenblock-Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Berichte Datenblock-Größe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Verzeichnis für Berichte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Berichte-Schnittstelle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr "Berichte Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr "Berichte Datenblock-Nutzung durch tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Berichte von tcpdump verwendete Datenblockgröße in MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -574,17 +592,13 @@ msgstr "Run-Interfaces"
 msgid "Run Utils"
 msgstr "Run-Werkzeuge"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr "moderates SafeSearch"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Speichern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -592,7 +606,7 @@ msgstr ""
 "Sende relevante Adblock-Benachrichtigungen per Email. Hinweis: Hierzu muss "
 "das \"msmtp\"-Zusatzpaket installiert sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Absenderadresse für Adblock-Benachrichtigungsmails."
 
@@ -604,7 +618,7 @@ msgstr "(Er)Setze einen neuen Adblock-Job"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -612,7 +626,7 @@ msgstr ""
 "Größe der Download-Warteschlange für laufende Downloads (inkl. Platzbedarf "
 "für Sortieren, Zusammenführen)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr "Quellen (Größe, Fokus)"
 
@@ -624,11 +638,11 @@ msgstr ""
 "Leerzeichengetrennte Liste von DNS-relevanten Firewall-Ports, die zwingend "
 "lokal sein müssen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Leerzeichengetrennte Liste an Ports die von tcpdump genutzt werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Spezielle Konfigurationseinstellungen für das gewählte Download-Programm."
@@ -649,7 +663,7 @@ msgstr "Status / Version"
 msgid "Suspend"
 msgstr "Anhalten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -658,7 +672,7 @@ msgstr ""
 "\" gesetzt, hier sollte besser ein USB-Stick oder anderer lokaler Speicher "
 "verwendet werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -667,11 +681,11 @@ msgstr ""
 "hier sollte besser ein USB-Stick oder anderer lokaler Speicher verwendet "
 "werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Zielverzeichnis für die erzeugte Sperrliste 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Zielverzeichnis für die erzeugte Jail-Sperrliste \"adb_list.jail\"."
 
@@ -733,7 +747,7 @@ msgstr ""
 msgid "Time"
 msgstr "Zeit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Timeout für erfolgreichen DNS-Backend-Startvorgang."
 
@@ -749,11 +763,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top-10 Statistiken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr "Betreff für Adblock-Benachrichtigungsmails."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Verzögerung Trigger-Bedingung"
 
@@ -762,7 +776,7 @@ msgstr "Verzögerung Trigger-Bedingung"
 msgid "Unable to save changes: %s"
 msgstr "Konnte Änderungen nicht speichern: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
@@ -779,11 +793,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Whiteliste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -791,14 +805,17 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "Max. Größe des Result-Sets"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "moderates SafeSearch"

--- a/applications/luci-app-adblock/po/el/adblock.po
+++ b/applications/luci-app-adblock/po/el/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Λίστα Μπλοκαρισμένων πηγών"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -153,26 +159,26 @@ msgstr ""
 msgid "Count"
 msgstr "Μέτρηση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "κατάλογος DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Επαναφορά αρχείου DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -186,7 +192,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +200,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +223,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,7 +273,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -275,7 +281,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -297,11 +303,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +317,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +329,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -338,7 +344,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -350,7 +356,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -360,7 +374,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -378,7 +392,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -391,7 +405,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -412,7 +426,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -424,13 +438,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -440,7 +454,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -468,35 +482,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -523,23 +541,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -551,13 +565,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -567,11 +581,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -591,23 +605,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -659,7 +673,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -673,11 +687,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -686,7 +700,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -701,11 +715,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -713,14 +727,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/en/adblock.po
+++ b/applications/luci-app-adblock/po/en/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -153,26 +159,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -186,7 +192,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +200,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +223,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,7 +273,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -275,7 +281,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -297,11 +303,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +317,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +329,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -338,7 +344,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -350,7 +356,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -360,7 +374,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -378,7 +392,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -391,7 +405,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -412,7 +426,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -424,13 +438,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -440,7 +454,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -468,35 +482,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -523,23 +541,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -551,13 +565,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -567,11 +581,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -591,23 +605,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -659,7 +673,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -673,11 +687,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -686,7 +700,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -701,11 +715,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -713,14 +727,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -46,7 +46,7 @@ msgstr "Agregue este (sub) dominio a su lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Agregue este (sub) dominio a su lista blanca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr "Lista de bloqueo adicional de la cárcel"
 
@@ -54,7 +54,7 @@ msgstr "Lista de bloqueo adicional de la cárcel"
 msgid "Additional Settings"
 msgstr "Configuración adicional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
@@ -76,15 +76,15 @@ msgstr "Configuración avanzada de informes"
 msgid "Answer"
 msgstr "Responder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "Directorio de temperatura base"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -113,7 +113,7 @@ msgstr "Dominio bloqueado"
 msgid "Blocked Domains"
 msgstr "Dominios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "Copia de seguridad de lista de bloqueo"
 
@@ -129,7 +129,7 @@ msgstr "Consulta de lista de bloqueo..."
 msgid "Blocklist Sources"
 msgstr "Fuentes de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -147,6 +147,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -170,7 +176,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -179,19 +185,19 @@ msgstr ""
 "caso de errores de descarga o durante el inicio."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr "Backend de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Directorio DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Restablecimiento de archivos DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -205,7 +211,7 @@ msgstr "Solicitudes DNS (bloqueadas)"
 msgid "DNS Requests (total)"
 msgstr "Solicitudes DNS (total)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "Tiempo de espera de reinicio de DNS"
 
@@ -213,15 +219,15 @@ msgstr "Tiempo de espera de reinicio de DNS"
 msgid "Date"
 msgstr "Fecha"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "Desactivar Permitir DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "Desactivar Reinicios de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,7 +235,7 @@ msgstr ""
 "Desactivar los reinicios activados por adblock para back-end dns con "
 "funciones de carga automática/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
 
@@ -238,39 +244,39 @@ msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr "Descargar parámetros"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "Descargar Cola"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Notificación del E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "Conteo de notificaciones por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "Perfil de E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario del E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente del E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr "Tema de E-Mail"
 
@@ -288,7 +294,7 @@ msgstr "Editar lista blanca"
 msgid "Enable SafeSearch"
 msgstr "Activar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activar filtros moderados de SafeSearch para YouTube."
 
@@ -296,7 +302,7 @@ msgstr "Activar filtros moderados de SafeSearch para YouTube."
 msgid "Enable the adblock service."
 msgstr "Activa el servicio Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activar el registro detallado de depuración en caso de errores de "
@@ -322,11 +328,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Trabajo(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr "Dominio de búsqueda de DNS externo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -339,11 +345,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterios de filtro como fecha, dominio o cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Vaciar caché de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 
@@ -351,7 +357,7 @@ msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 msgid "Force Local DNS"
 msgstr "Forzar DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -370,7 +376,7 @@ msgstr "Configuración general"
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "Directorio de la cárcel"
 
@@ -382,7 +388,15 @@ msgstr "Último inicio"
 msgid "Latest DNS Requests"
 msgstr "Últimas solicitudes de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de dispositivos de red disponibles utilizados por tcpdump."
 
@@ -395,7 +409,7 @@ msgstr ""
 "Elija 'No especificado' para usar un tiempo de espera de inicio clásico en "
 "lugar de un disparador de red."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -424,7 +438,7 @@ msgstr ""
 "MByte,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) necesita más RAM y soporte "
 "multinúcleo, p. ej. x86 o dispositivos Raspberry.<br /><p></p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
@@ -438,7 +452,7 @@ msgstr "Puertos DNS locales"
 msgid "Log View"
 msgstr "Vista de registro"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Servicio con prioridad baja"
 
@@ -459,7 +473,7 @@ msgstr "¡Aún no hay registros relacionados con adblock!"
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil utilizado por 'msmtp' para notificaciones de E-Mails adblock."
 
@@ -473,7 +487,7 @@ msgstr ""
 "Consulta listas de bloqueo activas y copias de seguridad para un dominio "
 "específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -481,7 +495,7 @@ msgstr ""
 "Aumente el recuento de notificaciones para obtener correos electrónicos si "
 "el recuento general de la lista de bloqueo es menor o igual al límite dado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Dirección del receptor para la notificación de bloqueos electrónicos."
 
@@ -493,7 +507,7 @@ msgstr ""
 "Redireccionar todas las consultas DNS desde la zona 'lan' al solucionador "
 "DNS local, se aplica al protocolo UDP y TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -524,35 +538,39 @@ msgstr "Actualizar temporizador..."
 msgid "Refresh..."
 msgstr "Actualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Informe de recuento de fragmentos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Tamaño del fragmento de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Directorio de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Interfaz de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr "Informar puertos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr "Informe el recuento de fragmentos utilizado por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informe el tamaño del fragmento utilizado por tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -582,17 +600,13 @@ msgstr "Ejecutar interfaces"
 msgid "Run Utils"
 msgstr "Ejecutar utilidades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr "SafeSearch Moderado"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -600,7 +614,7 @@ msgstr ""
 "Enviar correos electrónicos de notificación relacionados con adblock. Tenga "
 "en cuenta: esto necesita una instalación adicional del paquete 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Dirección del remitente para los correos electrónicos de notificación de "
@@ -614,7 +628,7 @@ msgstr "Establecer/Reemplazar un nuevo trabajo de adblock"
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -622,7 +636,7 @@ msgstr ""
 "Tamaño de la cola de descarga para el procesamiento de descarga (incluida la "
 "clasificación, fusión, etc.) en paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr "Fuentes (tamaño, enfoque)"
 
@@ -634,11 +648,11 @@ msgstr ""
 "Lista separada por espacios de puertos de firewall relacionados con DNS que "
 "deben forzarse localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de puertos separados por espacios utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opciones de configuración especiales para la utilidad de descarga "
@@ -660,7 +674,7 @@ msgstr "Estado / Versión"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -669,7 +683,7 @@ msgstr ""
 "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
 "otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -678,12 +692,12 @@ msgstr ""
 "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
 "otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo generada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo de cárcel generada 'adb_list."
@@ -749,7 +763,7 @@ msgstr ""
 msgid "Time"
 msgstr "Hora"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tiempo de espera para esperar un reinicio de backend de DNS exitoso."
 
@@ -765,11 +779,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 estadísticas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr "Tema para los correos electrónicos de notificación de adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
@@ -778,7 +792,7 @@ msgstr "Retraso de disparo"
 msgid "Unable to save changes: %s"
 msgstr "No se pueden guardar los cambios: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
@@ -795,11 +809,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista blanca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -807,14 +821,17 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "máx. tamaño del conjunto de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr "llamado (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr "crudo (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "SafeSearch Moderado"

--- a/applications/luci-app-adblock/po/fr/adblock.po
+++ b/applications/luci-app-adblock/po/fr/adblock.po
@@ -43,7 +43,7 @@ msgstr "Ajout sous-domaine au réseau local blacklisté."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Ajout sous-domaine au réseau local whitelisté."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr "Additionnel Bannis Blocklisté"
 
@@ -51,7 +51,7 @@ msgstr "Additionnel Bannis Blocklisté"
 msgid "Additional Settings"
 msgstr "Paramètres additionnels"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Délai de déclenchement supplémentaire en secondes avant que le bloqueur de "
@@ -73,15 +73,15 @@ msgstr "Paramètres de rapport avancés"
 msgid "Answer"
 msgstr "Répondre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "Répertoire Temporaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +110,7 @@ msgstr "Domaines bloqués"
 msgid "Blocked Domains"
 msgstr "Domaines bloqués"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "Sauvegarde de la liste de blocage"
 
@@ -126,7 +126,7 @@ msgstr "Demande Blocklist..."
 msgid "Blocklist Sources"
 msgstr "Sources des listes de blocage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -144,6 +144,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Annuler"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -168,7 +174,7 @@ msgstr ""
 msgid "Count"
 msgstr "Compteur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -177,19 +183,19 @@ msgstr ""
 "utilisées en cas d'erreurs de téléchargement ou lors du démarrage."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr "Backend du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Répertoire du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Réinitialiser le fichier de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -203,7 +209,7 @@ msgstr "Requêtes DNS (bloquées)"
 msgid "DNS Requests (total)"
 msgstr "Requêtes DNS (totales)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "Délai de redémarrage DNS"
 
@@ -211,15 +217,15 @@ msgstr "Délai de redémarrage DNS"
 msgid "Date"
 msgstr "Date"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "Désactiver l'autorisation DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "Désactiver les redémarrages DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,7 +233,7 @@ msgstr ""
 "Désactiver les redémarrages déclenchés par adblock pour les backends dns "
 "avec des fonctions d'auto-chargement/notification."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
 
@@ -236,39 +242,39 @@ msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
 msgid "Domain"
 msgstr "Domaine"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr "Paramètres Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "Queue de Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Notifications par e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "Nombre de notifications par courrier électronique"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "Profile Email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Adresse e-mail du destinataire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "Adresse électronique de l'expéditeur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr "Objet du courrier électronique"
 
@@ -286,7 +292,7 @@ msgstr "Modifier la liste blanche"
 msgid "Enable SafeSearch"
 msgstr "Activé Safesearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activez les filtres SafeSearch modérés pour youtube."
 
@@ -294,7 +300,7 @@ msgstr "Activez les filtres SafeSearch modérés pour youtube."
 msgid "Enable the adblock service."
 msgstr "Activé le service adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activez la journalisation verbale de débogage en cas d'erreurs de traitement."
@@ -319,11 +325,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Travaux en cours"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr "Domaine de recherche DNS externe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +342,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Critère filtre comme la date, domaine, client (option)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Vider le cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Videz également le cache DNS avant le traitement des adblocs."
 
@@ -348,7 +354,7 @@ msgstr "Videz également le cache DNS avant le traitement des adblocs."
 msgid "Force Local DNS"
 msgstr "Forcer le DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -367,7 +373,7 @@ msgstr "Paramètres généraux"
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "Répertoire des bannis"
 
@@ -379,7 +385,15 @@ msgstr "Dernière exécution"
 msgid "Latest DNS Requests"
 msgstr "Dernière Requêtes DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste des périphériques réseau disponibles utilisés par tcpdump."
 
@@ -392,7 +406,7 @@ msgstr ""
 "l'adblock. Choisissez \"non spécifié\" pour utiliser un délai de démarrage "
 "classique au lieu d'un déclencheur réseau."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -423,7 +437,7 @@ msgstr ""
 "besoin de plus de RAM et de support Multicore, par exemple des appareils x86 "
 "ou Raspberry.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste des utilitaires de téléchargement pris en charge et entièrement pré-"
@@ -438,7 +452,7 @@ msgstr "Ports DNS locaux"
 msgid "Log View"
 msgstr "Vue du journal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Service en priorité basse"
 
@@ -459,7 +473,7 @@ msgstr "Pas encore de journaux liés à l'adblock !"
 msgid "Overview"
 msgstr "Aperçu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilisé par \"msmtp\" pour les e-mails de notification adblock."
 
@@ -473,7 +487,7 @@ msgstr ""
 "Recherchez des listes de blocage actives et des sauvegardes pour un domaine "
 "spécifique."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -482,7 +496,7 @@ msgstr ""
 "électroniques si le nombre total de blocages est inférieur ou égal à la "
 "limite donnée."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Adresse du destinataire pour les e-mails de notification du bloqueur de "
@@ -496,7 +510,7 @@ msgstr ""
 "Rediriger toutes les requêtes DNS de la zone \"lan\" vers le résolveur DNS "
 "local, s'applique aux protocoles UDP et TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -528,35 +542,39 @@ msgstr "Rafraîchir l'horloge..."
 msgid "Refresh..."
 msgstr "Rafraichi..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Rapporter le nombre de morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Rapporter la taille des morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Rapporter le Répertoire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Rapporter l'Interface"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr "Rapport des Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr "Signalez le nombre de morceaux utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Indiquez la taille des morceaux utilisés par tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -586,17 +604,13 @@ msgstr "Interfaces de travail"
 msgid "Run Utils"
 msgstr "Outils de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr "SafeSearch Modéré"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Enregistrer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -604,7 +618,7 @@ msgstr ""
 "Envoyer des e-mails de notification relatifs à l'adblock. Veuillez noter que "
 "l'installation du paquet \"msmtp\" supplémentaire est nécessaire."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Adresse de l'expéditeur des courriers électroniques de notification de "
@@ -618,7 +632,7 @@ msgstr "Définir/remplacer un nouveau travail d'adblock"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -626,7 +640,7 @@ msgstr ""
 "Taille de la file d'attente pour le traitement des téléchargements (y "
 "compris le tri, la fusion, etc.) en parallèle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr "Sources (Taille, Focus)"
 
@@ -638,11 +652,11 @@ msgstr ""
 "Liste séparée par espace des ports de pare-feu liés au DNS qui doivent être "
 "forcés localement."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Liste des ports utilisés par tcpdump, séparés par des espaces."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Options de configuration spéciales pour l'utilitaire de téléchargement "
@@ -664,7 +678,7 @@ msgstr "Statut / Version"
 msgid "Suspend"
 msgstr "Mettre en pause"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -672,7 +686,7 @@ msgstr ""
 "Répertoire cible pour les fichiers de rapports liés au DNS. La valeur par "
 "défaut est '/tmp', veuillez utiliser plutot une clé usb ou un disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -681,12 +695,12 @@ msgstr ""
 "défaut est '/tmp', veuillez utiliser de préférence une clé usb ou un autre "
 "disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Répertoire cible pour la liste de blocage générée \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Répertoire cible pour la liste de blocage générée \"adb_list.jail\"."
 
@@ -752,7 +766,7 @@ msgstr ""
 msgid "Time"
 msgstr "Heure"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Délai d'attente pour un redémarrage réussi du backend du DNS."
 
@@ -768,11 +782,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 Statistiques"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr "Objet pour les notifications par e-mails d'adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
@@ -781,7 +795,7 @@ msgstr "Délai de déclenchement"
 msgid "Unable to save changes: %s"
 msgstr "Sauvegarde Impossible : %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
@@ -798,11 +812,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Liste Blanche..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -810,14 +824,17 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "taille max. des résultats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "SafeSearch Modéré"

--- a/applications/luci-app-adblock/po/he/adblock.po
+++ b/applications/luci-app-adblock/po/he/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -147,26 +153,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -180,7 +186,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +194,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +217,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,7 +267,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,11 +297,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +311,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +323,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -332,7 +338,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -344,7 +350,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -354,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -372,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -385,7 +399,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -406,7 +420,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -418,13 +432,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -434,7 +448,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -462,35 +476,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -517,23 +535,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -545,13 +559,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -561,11 +575,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -585,23 +599,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -653,7 +667,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -667,11 +681,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -680,7 +694,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -695,11 +709,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -707,14 +721,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hi/adblock.po
+++ b/applications/luci-app-adblock/po/hi/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -147,26 +153,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -180,7 +186,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +194,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +217,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,7 +267,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,11 +297,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +311,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +323,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -332,7 +338,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -344,7 +350,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -354,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -372,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -385,7 +399,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -406,7 +420,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -418,13 +432,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -434,7 +448,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -462,35 +476,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -517,23 +535,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -545,13 +559,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -561,11 +575,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -585,23 +599,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -653,7 +667,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -667,11 +681,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -680,7 +694,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -695,11 +709,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -707,14 +721,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hu/adblock.po
+++ b/applications/luci-app-adblock/po/hu/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "További aktiválókésleltetés másodpercben, mielőtt a reklámblokkolás "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Válasz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Blokkolt tartomány"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Blokkolási lista forrásai"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -136,6 +136,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Mégse"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -155,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Darabszám"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS könyvtár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "DNS fájlvisszaállítás"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Tartomány"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "E-mail értesítés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "E-mail fogadócím"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr "Fehérlista szerkesztése"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "DNS gyorsítótár kiürítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Helyi DNS kényszerítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr "Általános beállítások"
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr "Utolsó futás"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "A támogatott és teljesen előre beállított letöltési segédprogramok listája."
@@ -394,7 +408,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Alacsony prioritású szolgáltatás"
 
@@ -415,7 +429,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -427,13 +441,13 @@ msgstr "Lekérdezés"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Fogadó címe a reklámblokkoló értesítési e-mailekhez."
 
@@ -443,7 +457,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -471,35 +485,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Darabok számának jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Darabok méretének jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Könyvtár jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Csatoló jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -526,23 +544,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Mentés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -554,13 +568,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -570,11 +584,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -594,23 +608,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Célkönyvtár az előállított „adb_list.overall” blokkolási listához."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -664,7 +678,7 @@ msgstr ""
 msgid "Time"
 msgstr "Idő"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -678,11 +692,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
@@ -691,7 +705,7 @@ msgstr "Aktiváló késleltetése"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
@@ -706,11 +720,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -718,14 +732,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -46,7 +46,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Tempo addizionale in secondi di attesa prima che adblock si avvii."
 
@@ -74,15 +74,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Risposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Directory del Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -107,7 +107,7 @@ msgstr "Dominio bloccato"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -123,7 +123,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Fonti lista di Blocco"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -136,6 +136,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -156,26 +162,26 @@ msgstr ""
 msgid "Count"
 msgstr "Numero"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Directory DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Reset File DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -189,7 +195,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -197,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -220,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Notifica E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail destinatario"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,7 +276,7 @@ msgstr "Modifica Lista Bianca"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -278,7 +284,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -300,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -314,11 +320,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Pulisci Cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -326,7 +332,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Forza DNS Locale"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -341,7 +347,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -353,7 +359,15 @@ msgstr "Ultimo Avvio"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -363,7 +377,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -381,7 +395,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Elenco delle utility di download supportate e completamente preconfigurate."
@@ -395,7 +409,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Serviio a bassa priorità"
 
@@ -416,7 +430,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riassunto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -428,13 +442,13 @@ msgstr "Interrogazione"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Indirizzo del destinatario per e-mail di notifica di blocco degli annunci."
@@ -445,7 +459,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -473,35 +487,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Directory dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -528,23 +546,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Salva"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -556,13 +570,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -572,11 +586,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -596,23 +610,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Sospendi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Directory per la lista di blocco generata 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +679,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +693,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Ritardo Innesco"
 
@@ -692,7 +706,7 @@ msgstr "Ritardo Innesco"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Registro di Debug Dettagliato"
 
@@ -707,11 +721,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -719,14 +733,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Adblock の処理が開始されるまでの、追加の遅延時間（秒）です。"
 
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "ブロックされたドメイン"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "ブロックリスト提供元"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -154,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr "カウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "DNS ファイル リセット"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -187,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -195,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr "日付"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -218,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr "ドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "ダウンロード ユーティリティ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -268,7 +274,7 @@ msgstr "ホワイトリストの編集"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -276,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -298,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,11 +318,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "DNS キャッシュのクリア"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -324,7 +330,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "ローカル DNS の強制"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -339,7 +345,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -351,7 +357,15 @@ msgstr "最終実行"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -361,7 +375,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -379,7 +393,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "サポートされ、かつ設定済のダウンロード ユーティリティの一覧です。"
 
@@ -392,7 +406,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "低優先度サービス"
 
@@ -413,7 +427,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -425,13 +439,13 @@ msgstr "検索"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知メールの受信アドレスです。"
 
@@ -441,7 +455,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -469,35 +483,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "レポート チャンクカウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "レポート チャンクサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "レポート インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -524,23 +542,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -552,13 +566,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -568,11 +582,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -592,23 +606,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成されたブロックリスト 'adb_list.overall' の保存先ディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -660,7 +674,7 @@ msgstr ""
 msgid "Time"
 msgstr "時刻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -674,11 +688,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
@@ -687,7 +701,7 @@ msgstr "トリガ遅延"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
@@ -702,11 +716,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -714,14 +728,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ko/adblock.po
+++ b/applications/luci-app-adblock/po/ko/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +65,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -127,6 +127,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -147,26 +153,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -180,7 +186,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -188,21 +194,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -211,39 +217,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,7 +267,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,11 +297,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -305,11 +311,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -317,7 +323,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -332,7 +338,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -344,7 +350,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -354,7 +368,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -372,7 +386,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -385,7 +399,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -406,7 +420,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -418,13 +432,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -434,7 +448,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -462,35 +476,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -517,23 +535,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -545,13 +559,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -561,11 +575,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -585,23 +599,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -653,7 +667,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -667,11 +681,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -680,7 +694,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -695,11 +709,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -707,14 +721,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/mr/adblock.po
+++ b/applications/luci-app-adblock/po/mr/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -153,26 +159,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -186,7 +192,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +200,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +223,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,7 +273,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -275,7 +281,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -297,11 +303,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +317,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +329,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -338,7 +344,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -350,7 +356,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -360,7 +374,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -378,7 +392,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -391,7 +405,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -412,7 +426,7 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -424,13 +438,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -440,7 +454,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -468,35 +482,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -523,23 +541,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -551,13 +565,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -567,11 +581,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -591,23 +605,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -659,7 +673,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -673,11 +687,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -686,7 +700,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -701,11 +715,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -713,14 +727,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ms/adblock.po
+++ b/applications/luci-app-adblock/po/ms/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Terdapat kelewatan picu dalam saat sebelum proses adblock bermula."
 
@@ -71,15 +71,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Jawapan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,7 +104,7 @@ msgstr "Kawasan Liputan Yang telah disekat"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Punca Senarai Sekatan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -133,6 +133,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -153,26 +159,26 @@ msgstr ""
 msgid "Count"
 msgstr "Kiraan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Direktori DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Reset fail DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -186,7 +192,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -194,21 +200,21 @@ msgstr ""
 msgid "Date"
 msgstr "Tarikh"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -217,39 +223,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,7 +273,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -275,7 +281,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -297,11 +303,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -311,11 +317,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -323,7 +329,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -338,7 +344,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -350,7 +356,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -360,7 +374,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -378,7 +392,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -391,7 +405,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -412,7 +426,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -424,13 +438,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -440,7 +454,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -468,35 +482,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -523,23 +541,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -551,13 +565,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -567,11 +581,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -591,23 +605,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -659,7 +673,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -673,11 +687,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -686,7 +700,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -701,11 +715,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -713,14 +727,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/nb_NO/adblock.po
+++ b/applications/luci-app-adblock/po/nb_NO/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligere utløserforsinkelse i sekunder før behandling av "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Blokkert domene"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Blokklistekilder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -155,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Antall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS-mappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "DNS-filtilbakestilling"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dato"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "E-postmerknad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagersadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr "Rediger hvitliste"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Tøm DNS-hurtiglageret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Tving lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr "Sist kjørt"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -393,7 +407,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -414,7 +428,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -426,13 +440,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -442,7 +456,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,35 +484,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -525,23 +543,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -553,13 +567,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -569,11 +583,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -593,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -661,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -675,11 +689,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -688,7 +702,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -703,11 +717,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -715,14 +729,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/pl/adblock.po
+++ b/applications/luci-app-adblock/po/pl/adblock.po
@@ -44,7 +44,7 @@ msgstr "Dodaj tę (sub-)domenę do Twojej lokalnej czarnej listy."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Dodaj tę (pod-)domenę do Twojej lokalnej białej listy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr "Dodatkowa lista zablokowanych"
 
@@ -52,7 +52,7 @@ msgstr "Dodatkowa lista zablokowanych"
 msgid "Additional Settings"
 msgstr "Dodatkowe ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalacza w sekundach przed rozpoczęciem przetwarzania "
@@ -74,15 +74,15 @@ msgstr "Zaawansowane ustawienia raportów"
 msgid "Answer"
 msgstr "Odpowiedź"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "Podstawowy katalog tymczasowy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,7 +111,7 @@ msgstr "Zablokowana domena"
 msgid "Blocked Domains"
 msgstr "Zablokowane domeny"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "Kopia zapasowa listy zablokowanych"
 
@@ -127,7 +127,7 @@ msgstr "Zapytanie..."
 msgid "Blocklist Sources"
 msgstr "Źródła list"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,6 +145,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Anuluj"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -168,7 +174,7 @@ msgstr ""
 msgid "Count"
 msgstr "Licznik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -177,19 +183,19 @@ msgstr ""
 "używane w przypadku błędów pobierania lub podczas uruchamiania."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr "Zaplecze DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Katalog DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Resetuj plik DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -203,7 +209,7 @@ msgstr "Żądania DNS (zablokowane)"
 msgid "DNS Requests (total)"
 msgstr "Żądania DNS (ogółem)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "Limit czasu restartu DNS"
 
@@ -211,15 +217,15 @@ msgstr "Limit czasu restartu DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "Wyłącz pozwolenie na DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "Wyłącz restart DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,7 +233,7 @@ msgstr ""
 "Wyłącz wyzwalane restarty adblocka dla zaplecza DNS z funkcjami Autoload/"
 "Inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
 
@@ -236,39 +242,39 @@ msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
 msgid "Domain"
 msgstr "Domena"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "Kolejka pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Powiadomienie email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "Licznik powiadomień email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "Profil email"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Adres email odbiorcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "Adres email nadawcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr "Temat email"
 
@@ -286,7 +292,7 @@ msgstr "Edycja białej listy"
 msgid "Enable SafeSearch"
 msgstr "Włącz funkcję SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
 
@@ -294,7 +300,7 @@ msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
 msgid "Enable the adblock service."
 msgstr "Włącz usługę adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Włącz pełne rejestrowanie debugowania w przypadku błędów przetwarzania."
@@ -319,11 +325,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Istniejące zadania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr "Zewnętrzna domena wyszukiwania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +342,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Kryteria filtrowania takie jak data, domena lub klient (opcjonalnie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Opróżnij pamięć podręczną DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 
@@ -348,7 +354,7 @@ msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 msgid "Force Local DNS"
 msgstr "Wymuś lokalny DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -366,7 +372,7 @@ msgstr "Ustawienia główne"
 msgid "Information"
 msgstr "Informacja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "Katalog więzienia"
 
@@ -378,7 +384,15 @@ msgstr "Ostatnie uruchomienie"
 msgid "Latest DNS Requests"
 msgstr "Ostatnie zapytania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dostępnych urządzeń sieciowych używanych przez tcpdump."
 
@@ -391,7 +405,7 @@ msgstr ""
 "'nieokreślone', aby użyć klasycznego limitu czasu uruchamiania zamiast "
 "wyzwalacza sieciowego."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -421,7 +435,7 @@ msgstr ""
 "wielordzeniowej, np. urządzenia x86 lub urządzenia typu raspberry.<br /> "
 "<p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista obsługiwanych i wstępnie skonfigurowanych narzędzi do pobierania."
@@ -435,7 +449,7 @@ msgstr "Lokalne porty DNS"
 msgid "Log View"
 msgstr "Widok dziennika"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Usługa niskopriorytetowa"
 
@@ -456,7 +470,7 @@ msgstr "Brak dzienników związanych z adblockiem!"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil używany przez 'msmtp' do powiadamiania o blokadzie email."
 
@@ -470,7 +484,7 @@ msgstr ""
 "Wysyłaj zapytania do aktywnych list blokowania i kopii zapasowych dla "
 "określonej domeny."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -478,7 +492,7 @@ msgstr ""
 "Zwiększ liczbę powiadomień, aby otrzymywać wiadomości email jeśli ogólna "
 "liczba blokowanych list jest mniejsza lub równa podanemu limitowi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adres odbiorcy dla powiadomień email adblocka."
 
@@ -490,7 +504,7 @@ msgstr ""
 "Przekieruj wszystkie zapytania DNS ze strefy LAN do lokalnego programu "
 "obsługi DNS, dotyczy protokołu UDP i TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -520,35 +534,39 @@ msgstr "Odśwież zegar..."
 msgid "Refresh..."
 msgstr "Odświeżanie..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Zgłoś liczbę fragmentów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Zgłoś wielkość porcji"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Katalog raportów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Interfejs raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr "Porty raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr "Raportuj liczbę fragmentów używaną przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Raportuj wielkość fragmentów używaną przez tcpdump w MB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -577,17 +595,13 @@ msgstr "Uruchomione interfejsy"
 msgid "Run Utils"
 msgstr "Uruchomione narzędzia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr "Moderuj filtr SafeSearch"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Zapisz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -595,7 +609,7 @@ msgstr ""
 "Wysyłaj powiadomienia email związane z adblock. Uwaga: wymaga to dodatkowej "
 "instalacji pakietu 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adres nadawcy dla powiadomień emailowych adblocka."
 
@@ -607,7 +621,7 @@ msgstr "Ustaw/Zmień nowe zadanie Adblock"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -615,7 +629,7 @@ msgstr ""
 "Rozmiar kolejki pobierania do przetwarzania plików (w tym sortowanie, "
 "łączenie itp.) równolegle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr "Źródła (wielkość, skupienie)"
 
@@ -627,11 +641,11 @@ msgstr ""
 "Rozdzielona spacjami lista portów zapory związanych z DNS, które należy "
 "wymusić lokalnie."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Rozdzielona spacjami lista portów używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr "Specjalne opcje konfiguracji dla wybranego narzędzia do pobierania."
 
@@ -651,7 +665,7 @@ msgstr "Status/Wersja"
 msgid "Suspend"
 msgstr "Zawieś"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -659,7 +673,7 @@ msgstr ""
 "Katalog docelowy dla plików raportowania. Domyślnie jest to '/ tmp', "
 "najlepiej użyj pamięci USB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -667,12 +681,12 @@ msgstr ""
 "Katalog docelowy dla kopii zapasowych listy zablokowanych. Domyślnie jest to "
 "'/tmp', użyj najlepiej pamięci USB lub innego dysku lokalnego."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy blokowania 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy zablokowanych 'adb_list.jail'."
@@ -736,7 +750,7 @@ msgstr ""
 msgid "Time"
 msgstr "Czas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Limit czasu oczekiwania na pomyślne ponowne uruchomienie zaplecza DNS."
 
@@ -752,11 +766,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr "Temat dla powiadomień email adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
@@ -765,7 +779,7 @@ msgstr "Opóźnienie wyzwalacza"
 msgid "Unable to save changes: %s"
 msgstr "Nie można zapisać zmian: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
@@ -782,11 +796,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Biała lista ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -794,14 +808,17 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "maks. rozmiar zestawu wyników"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "Moderuj filtr SafeSearch"

--- a/applications/luci-app-adblock/po/pt/adblock.po
+++ b/applications/luci-app-adblock/po/pt/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso adicional do trigger em segundos antes do processamento do Adblock "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Domínio Bloqueado"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Origem da Blocklist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -136,6 +136,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -155,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Repor o ficheiro DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Ferramenta para descarregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Endereço do destinatário de e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr "Editar lista de permissões"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Limpar o cache de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Forçar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr "Configurações Gerais"
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de ferramentas de descarregamento suportadas e completamente pré-"
@@ -395,7 +409,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -416,7 +430,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -428,13 +442,13 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Endereço do destinatário para e-mails de notificação do adblock."
 
@@ -444,7 +458,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -472,35 +486,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Relatar Contagem de Porções"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Tamanho de Porções de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Interface de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -527,23 +545,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -555,13 +569,13 @@ msgstr ""
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -571,11 +585,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,24 +609,24 @@ msgstr ""
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Diretório de destino para a lista de blocos 'adb_list.overall' gerada ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -666,7 +680,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -680,11 +694,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
@@ -693,7 +707,7 @@ msgstr "Atraso do Gatilho"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Registro de Depuração Detalhado"
 
@@ -708,11 +722,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -720,14 +734,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/pt_BR/adblock.po
+++ b/applications/luci-app-adblock/po/pt_BR/adblock.po
@@ -46,7 +46,7 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Adicional"
 
@@ -54,7 +54,7 @@ msgstr "Lista de Bloqueio Adicional"
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso de gatilho adicional em segundos antes do processamento do adblock "
@@ -76,15 +76,15 @@ msgstr "Configurações Avançadas do Relatório"
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -114,7 +114,7 @@ msgstr "Domínios Bloqueados"
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -130,7 +130,7 @@ msgstr "Pesquisando a Lista de Bloqueio..."
 msgid "Blocklist Sources"
 msgstr "Fontes de listas de bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -148,6 +148,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -171,7 +177,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -180,19 +186,19 @@ msgstr ""
 "usados em caso de erros de download ou durante a inicialização."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Zerar Arquivo de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -206,7 +212,7 @@ msgstr "Solicitações do DNS (bloqueadas)"
 msgid "DNS Requests (total)"
 msgstr "Solicitações do DNS (total)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -214,15 +220,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Dia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -230,7 +236,7 @@ msgstr ""
 "Desative o bloqueador de anúncios que causar a reinicialização das funções "
 "autoload/inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
 
@@ -239,39 +245,39 @@ msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "Fila de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "Perfil de E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -289,7 +295,7 @@ msgstr "Editar a Lista Branca"
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
 
@@ -297,7 +303,7 @@ msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço de bloqueio de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
@@ -323,11 +329,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -340,11 +346,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Limpar a Cache do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 
@@ -352,7 +358,7 @@ msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 msgid "Force Local DNS"
 msgstr "Usar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -371,7 +377,7 @@ msgstr "Configurações Gerais"
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
@@ -383,7 +389,15 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Lista de dispositivos da rede disponíveis que foram usados pelo tcpdump."
@@ -397,7 +411,7 @@ msgstr ""
 "Escolha 'não especificado' para usar um tempo de inicialização clássico em "
 "vez de um gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -428,7 +442,7 @@ msgstr ""
 "mais suporte a RAM e Multicore, por exemplo. x86 ou dispositivos raspberry."
 "<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
@@ -441,7 +455,7 @@ msgstr "Portas DNS Locais"
 msgid "Log View"
 msgstr "Exibir o Registro Log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -462,7 +476,7 @@ msgstr "Ainda não há registros relacionados ao bloqueio de anúncio!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Perfil dos E-Mails de notificação do bloqueio de anúncio utilizado por "
@@ -478,7 +492,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -486,7 +500,7 @@ msgstr ""
 "Aumente a contagem de notificações para receber E-Mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Endereço de E-Mail do destinatário para recebimento das notificações do "
@@ -500,7 +514,7 @@ msgstr ""
 "Redirecione todas as consultas de DNS da zona 'lan' para o resolvedor de DNS "
 "local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -532,35 +546,39 @@ msgstr "Atualizando o Temporizador..."
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Contagem de Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Tamanho dos Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Interface do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -590,17 +608,13 @@ msgstr "Executar Interfaces"
 msgid "Run Utils"
 msgstr "Executar Utilitários"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr "SafeSearch Moderado"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Salvar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -608,7 +622,7 @@ msgstr ""
 "Envie E-Mails de notificação relacionados ao bloqueio de anúncios. Note que: "
 "é necessário a instalação adicional do pacote 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Endereço E-Mail do remetente para as notificações do bloqueador de anúncios."
@@ -621,7 +635,7 @@ msgstr "Definir/Substituir um novo trabalho de bloqueio de anúncios"
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -629,7 +643,7 @@ msgstr ""
 "Tamanho da fila de download para o processamento de download (incl. "
 "classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
@@ -641,11 +655,11 @@ msgstr ""
 "Lista separada por espaço das portas de firewall relacionadas ao DNS que "
 "devem ser impostas localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de download selecionado."
@@ -666,7 +680,7 @@ msgstr "Condição Geral / Versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -675,7 +689,7 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
 "outro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -684,11 +698,11 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou outro "
 "disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Caminho do diretório para a lista nega gerada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
@@ -753,7 +767,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -769,13 +783,13 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos E-Mais que serão usados nas notificações do bloqueador "
 "de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
@@ -784,7 +798,7 @@ msgstr "Gatilho de Atraso"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
@@ -801,11 +815,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -813,14 +827,17 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "SafeSearch Moderate"
+#~ msgstr "SafeSearch Moderado"

--- a/applications/luci-app-adblock/po/ro/adblock.po
+++ b/applications/luci-app-adblock/po/ro/adblock.po
@@ -44,7 +44,7 @@ msgstr "Adăugați acest (sub) domeniu în lista locală de interzise."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adăugați acest (sub) domeniu la lista locală de admise."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Setări Suplimentare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Întârziere adițională înainte ca procesarea adblock-ului să înceapă (în "
@@ -74,15 +74,15 @@ msgstr "Setări Avansate Raport"
 msgid "Answer"
 msgstr "Răspuns"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "Director Temporar de Bază"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,7 +111,7 @@ msgstr "Domeniu blocat"
 msgid "Blocked Domains"
 msgstr "Domenii Blocate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "Copie de Rezervă Pentru Lista de Blocate"
 
@@ -127,7 +127,7 @@ msgstr "Interogare Lista de Blocare..."
 msgid "Blocklist Sources"
 msgstr "Surse de blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,6 +145,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Renunțare"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -168,7 +174,7 @@ msgstr ""
 msgid "Count"
 msgstr "Număr"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -177,19 +183,19 @@ msgstr ""
 "utilizate în cazul erorilor de descărcare sau în timpul pornirii."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Director DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -203,7 +209,7 @@ msgstr "Cereri DNS (blocate)"
 msgid "DNS Requests (total)"
 msgstr "Cereri DNS (total)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "Timp Repornire DNS"
 
@@ -211,15 +217,15 @@ msgstr "Timp Repornire DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "Dezactivare Permite DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "Dezactivare Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,7 +233,7 @@ msgstr ""
 "Dezactivează repornirile declanșate de adblock pentru backend-urile dns cu "
 "funcții de autoîncărcare /notificare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
 
@@ -236,39 +242,39 @@ msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
 msgid "Domain"
 msgstr "Domeniu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr "Descărcare Parametri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "Coadă de Descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Notificare e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "Număr de Notificări pe E-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "Profil E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "Adresa E-Mail Expeditor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr "Subiect E-Mail"
 
@@ -286,7 +292,7 @@ msgstr "Editare listă albă"
 msgid "Enable SafeSearch"
 msgstr "Activare Căutare Sigură"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activare filtre moderate SafeSearch pentru YouTube."
 
@@ -294,7 +300,7 @@ msgstr "Activare filtre moderate SafeSearch pentru YouTube."
 msgid "Enable the adblock service."
 msgstr "Activare serviciu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activare înregistrare detaliată de depanare în cazul unor erori de procesare."
@@ -319,11 +325,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Activitate(ăți) existentă(e)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr "Domeniul de căutare DNS extern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +342,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterii de filtrare precum dată, domeniu sau client (opțional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Eliberează cache-ul DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 
@@ -348,7 +354,7 @@ msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 msgid "Force Local DNS"
 msgstr "Forţează DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -367,7 +373,7 @@ msgstr "Setări generale"
 msgid "Information"
 msgstr "Informare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "Director Închisoare"
 
@@ -379,7 +385,15 @@ msgstr "Ultima rulare"
 msgid "Latest DNS Requests"
 msgstr "Ultimele Cereri DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dispozitivelor de rețea utilizate de tcpdump."
 
@@ -392,7 +406,7 @@ msgstr ""
 "Alegeți „nespecificat” pentru a utiliza un interval de timp de pornire "
 "clasic în loc de declanșarea rețelei."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -421,7 +435,7 @@ msgstr ""
 "&#xa0;<b>XXL</b> (200k-) au nevoie de dispozitive cu mai mult RAM și suport "
 "Multicore, ex. x86 sau raspberry.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -434,7 +448,7 @@ msgstr "Porturi DNS Locale"
 msgid "Log View"
 msgstr "Vizualizare Jurnal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -455,7 +469,7 @@ msgstr "Nu există încă jurnale adblock!"
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilizat de „msmtp” pentru e-mailurile de notificare adblock."
 
@@ -469,7 +483,7 @@ msgstr ""
 "Interogare listă de blocări active și copii de rezervă pentru un anumit "
 "domeniu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -477,7 +491,7 @@ msgstr ""
 "Creșteți numărul de notificări pentru a primi e-mailuri dacă numărul total "
 "de blocări este mai mic sau egal cu limita dată."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -489,7 +503,7 @@ msgstr ""
 "Redirecționare toate interogările DNS din zona „lan” către procesatorul DNS "
 "local, se aplică protocolului UDP și TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -520,35 +534,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -575,23 +593,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Salvează"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -603,13 +617,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -619,11 +633,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -643,23 +657,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Suspendă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -711,7 +725,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -725,11 +739,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
@@ -738,7 +752,7 @@ msgstr "Intârzierea declanșării"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -753,11 +767,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -765,14 +779,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -49,7 +49,7 @@ msgstr "Добавить (под-)домен в ваш локальный чер
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Добавить (под-)домен в ваш локальный белый список."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr "Дополнительный тюремный блоклист"
 
@@ -57,7 +57,7 @@ msgstr "Дополнительный тюремный блоклист"
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Дополнительная задержка в секундах до начала работы Adblock."
 
@@ -77,15 +77,15 @@ msgstr "Расширенные настройки отчетов"
 msgid "Answer"
 msgstr "Ответ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "Базовый временный каталог"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -114,7 +114,7 @@ msgstr "Заблокированные домены"
 msgid "Blocked Domains"
 msgstr "Заблокированные домены"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "Бэкап черного списка"
 
@@ -131,7 +131,7 @@ msgstr "Запросы к черному списку..."
 msgid "Blocklist Sources"
 msgstr "Источники черных списков"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 #, fuzzy
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
@@ -150,6 +150,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Отменить"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -174,7 +180,7 @@ msgstr ""
 msgid "Count"
 msgstr "Количество"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -183,19 +189,19 @@ msgstr ""
 "загрузкой или во время запуска."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr "DNS-серверная часть"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "Папка DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Сброс файла DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -209,7 +215,7 @@ msgstr "DNS запросы (заблокированы)"
 msgid "DNS Requests (total)"
 msgstr "DNS запросов (всего)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "Таймаут перезапуска DNS"
 
@@ -217,21 +223,21 @@ msgstr "Таймаут перезапуска DNS"
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "Отключить DNS ответы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "Отключить перезагрузки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -240,39 +246,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "Очередь загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Утилита для скачивания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Уведомление электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "Счётчик e-mail уведомлений"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "Почтовый адрес отправителя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +296,7 @@ msgstr "Редактировать Белый список"
 msgid "Enable SafeSearch"
 msgstr "Включить Безопасный Поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Включите умеренные фильтры Безопастного Поиска для youtube."
 
@@ -298,7 +304,7 @@ msgstr "Включите умеренные фильтры Безопастно�
 msgid "Enable the adblock service."
 msgstr "Включить сервис AdBlock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -320,11 +326,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -334,11 +340,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Критерии фильтрации, такие как дата, домен или клиент (необязательно)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Очистка кэша DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Очистите кэш DNS до обработки adblock."
 
@@ -346,7 +352,7 @@ msgstr "Очистите кэш DNS до обработки adblock."
 msgid "Force Local DNS"
 msgstr "Локальный DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -361,7 +367,7 @@ msgstr "Основные настройки"
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "Директория Jail"
 
@@ -373,7 +379,15 @@ msgstr "Последний запуск"
 msgid "Latest DNS Requests"
 msgstr "Последние DNS запросы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr "Список доступных сетевых устройств используемых tcpdump."
 
@@ -383,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -401,7 +415,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Список поддерживаемых и полностью предварительно настроенных утилит для "
@@ -416,7 +430,7 @@ msgstr "Локальные порты DNS"
 msgid "Log View"
 msgstr "Просмотр журнала"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Низкий приоритет службы"
 
@@ -437,7 +451,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -449,13 +463,13 @@ msgstr "Запрос"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Адрес получателя для уведомлений по электронной почте."
 
@@ -465,7 +479,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -493,35 +507,39 @@ msgstr "Обновить таймер..."
 msgid "Refresh..."
 msgstr "Обновить..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "Количество фрагментов отчета"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "Размер фрагментов отчета"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "Папка для отчетов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "Отчет интерфейса"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr "Порты отчетов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -548,23 +566,19 @@ msgstr "Интерфейсы запуска"
 msgid "Run Utils"
 msgstr "Запуск Утилиты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Сохранить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr "E-Mails адрес отправителя для уведомления adblock ."
 
@@ -576,13 +590,13 @@ msgstr ""
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -592,11 +606,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Разделенный пробелами список портов используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -616,23 +630,23 @@ msgstr "Статус / Версия"
 msgid "Suspend"
 msgstr "Приостановить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Папка для созданного списка блокировки 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -686,7 +700,7 @@ msgstr ""
 msgid "Time"
 msgstr "Время"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Тайм-аут ожидания успешного перезапуска серверной части DNS."
 
@@ -700,11 +714,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Топ-10 статистики"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
@@ -713,7 +727,7 @@ msgstr "Задержка запуска"
 msgid "Unable to save changes: %s"
 msgstr "Невозможно сохранить изменения: %ы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
@@ -730,11 +744,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Белый список..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -742,14 +756,14 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"

--- a/applications/luci-app-adblock/po/sk/adblock.po
+++ b/applications/luci-app-adblock/po/sk/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatočné oneskorenie v sekundách pred začiatkom spracovania blokovania "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Odpoveď"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Blokovaná doména"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Zdroje zoznamov blokovaní"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -136,6 +136,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Zrušiť"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -155,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS adresár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Inicializácia DNS súboru"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "Upozornenie e-mailom"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "Adresa príjemcu e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr "Upraviť bielu listinu"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Vyprázdniť medzipamäť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr "Všeobecné nastavenia"
 msgid "Information"
 msgstr "Informácie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -393,7 +407,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -414,7 +428,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -426,13 +440,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -442,7 +456,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,35 +484,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -525,23 +543,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Uložiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -553,13 +567,13 @@ msgstr ""
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -569,11 +583,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -593,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -661,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -675,11 +689,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -688,7 +702,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -703,11 +717,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -715,14 +729,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligare trigger fördröjning i sekunder innan Adblock-bearbetningen "
@@ -73,15 +73,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,7 +106,7 @@ msgstr "Blockerad domän"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Källor för blockeringslistor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -155,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Räkna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS-mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "DNS-filåterställning"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagaradress"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr "Redigera vitlista"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "Töm DNS-cache"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Tvinga lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr "Kördes senast"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
 
@@ -393,7 +407,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "Lågprioriterad tjänst"
 
@@ -414,7 +428,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Översikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -426,13 +440,13 @@ msgstr "Fråga"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -442,7 +456,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,35 +484,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -525,23 +543,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Spara"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -553,13 +567,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -569,11 +583,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -593,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Stäng av"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -661,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -675,11 +689,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -688,7 +702,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -703,11 +717,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -715,14 +729,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -42,7 +42,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -62,15 +62,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -124,6 +124,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -144,26 +150,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -177,7 +183,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -185,21 +191,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -208,39 +214,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -258,7 +264,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -266,7 +272,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -288,11 +294,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -302,11 +308,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -314,7 +320,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -329,7 +335,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -341,7 +347,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -351,7 +365,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -369,7 +383,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -382,7 +396,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -403,7 +417,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -415,13 +429,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -431,7 +445,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -459,35 +473,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -514,23 +532,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -542,13 +556,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -558,11 +572,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -582,23 +596,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -650,7 +664,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -664,11 +678,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -677,7 +691,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -692,11 +706,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -704,14 +718,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/tr/adblock.po
+++ b/applications/luci-app-adblock/po/tr/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 #, fuzzy
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Reklam engelleme işlemi başlamadan önceki ilave tetik gecikmesi."
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Cevap"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Yedek Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "Engellenmiş Alan Adı"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Engelleme Listesi Kaynakları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -155,26 +161,26 @@ msgstr ""
 msgid "Count"
 msgstr "Sayım"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -393,7 +407,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -414,7 +428,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -426,13 +440,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -442,7 +456,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,35 +484,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -525,23 +543,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -553,13 +567,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -569,11 +583,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -593,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -661,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -675,11 +689,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -688,7 +702,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -703,11 +717,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -715,14 +729,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/uk/adblock.po
+++ b/applications/luci-app-adblock/po/uk/adblock.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -135,6 +135,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "Скасувати"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -154,26 +160,26 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -187,7 +193,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -195,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -218,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -268,7 +274,7 @@ msgstr "Редагувати білий список"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -276,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -298,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,11 +318,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -324,7 +330,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -339,7 +345,7 @@ msgstr "Загальні параметри"
 msgid "Information"
 msgstr "Інформація"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -351,7 +357,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -361,7 +375,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -379,7 +393,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -392,7 +406,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -413,7 +427,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -425,13 +439,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -441,7 +455,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -469,35 +483,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -524,23 +542,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "Зберегти"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -552,13 +566,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -568,11 +582,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -592,23 +606,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -660,7 +674,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -674,11 +688,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr ""
 
@@ -687,7 +701,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -702,11 +716,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -714,14 +728,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/vi/adblock.po
+++ b/applications/luci-app-adblock/po/vi/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Kích hoạt độ trễ trong vài giây trước khi bắt đầu tiến trình chặn quảng cáo."
@@ -72,15 +72,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Phản hồi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,7 +105,7 @@ msgstr "Tên miền bị chặn"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Bộ lọc"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,6 +134,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:161
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
@@ -154,27 +160,27 @@ msgstr ""
 msgid "Count"
 msgstr "Bộ đếm"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 #, fuzzy
 msgid "DNS Directory"
 msgstr "Thư mục DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "Đặt lại tệp DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -188,7 +194,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ngày"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,7 +275,7 @@ msgstr ""
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -299,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +319,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +331,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -340,7 +346,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -352,7 +358,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -362,7 +376,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -380,7 +394,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -393,7 +407,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr ""
 
@@ -414,7 +428,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -426,13 +440,13 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -442,7 +456,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,35 +484,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -525,23 +543,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -553,13 +567,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -569,11 +583,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -593,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -661,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr "Thời gian"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -675,11 +689,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
@@ -688,7 +702,7 @@ msgstr "Kích hoạt độ trễ"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 #, fuzzy
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
@@ -704,11 +718,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -716,14 +730,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/zh_Hans/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hans/adblock.po
@@ -50,7 +50,7 @@ msgstr "添加此域名到本地黑名单"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "添加此域名到本地白名单"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr "额外的封锁禁闭名单"
 
@@ -58,7 +58,7 @@ msgstr "额外的封锁禁闭名单"
 msgid "Additional Settings"
 msgstr "附加设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "事件触发启动前的延时（秒）。"
 
@@ -78,15 +78,15 @@ msgstr "高级报告设置"
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "备份目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr "基础临时目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,7 +111,7 @@ msgstr "已拦截的域名"
 msgid "Blocked Domains"
 msgstr "拦截域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr "黑名单列表的备份"
 
@@ -127,7 +127,7 @@ msgstr "黑名单查询..."
 msgid "Blocklist Sources"
 msgstr "拦截列表来源"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -143,6 +143,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "取消"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -165,26 +171,26 @@ msgstr ""
 msgid "Count"
 msgstr "计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "创建压缩的阻止列表备份，将在下载错误或启动期间使用它们。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr "DNS后端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS 目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "DNS 文件重置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -198,7 +204,7 @@ msgstr "DNS请求（已阻止）"
 msgid "DNS Requests (total)"
 msgstr "DNS请求（总计）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr "DNS重新启动超时"
 
@@ -206,21 +212,21 @@ msgstr "DNS重新启动超时"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr "禁止 DNS 允许"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr "禁用DNS重新启动"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "禁用具有自动加载/ inotify功能的dns后端的adblock触发的重启。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "禁止选择性DNS白名单(RPZ通过)."
 
@@ -229,39 +235,39 @@ msgstr "禁止选择性DNS白名单(RPZ通过)."
 msgid "Domain"
 msgstr "域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr "下载队列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "E-Mail 通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr "电子邮件通知计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr "电子邮件资料"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail 收件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -279,7 +285,7 @@ msgstr "编辑白名单"
 msgid "Enable SafeSearch"
 msgstr "启用安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "为YouTube启用适度的安全搜索过滤器."
 
@@ -287,7 +293,7 @@ msgstr "为YouTube启用适度的安全搜索过滤器."
 msgid "Enable the adblock service."
 msgstr "启用广告屏蔽服务."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出现任何处理错误的情况下启用详细调试日志记录."
 
@@ -309,11 +315,11 @@ msgstr "强制执行Google，Bing，Duckduckgo，Yandex，youtube和Google的Saf
 msgid "Existing job(s)"
 msgstr "现有的工作(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr "外部DNS查找域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -325,11 +331,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "过滤条件，例如日期，域或客户（可选）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 缓存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "还要在处理adblock之前刷新DNS缓存。"
 
@@ -337,7 +343,7 @@ msgstr "还要在处理adblock之前刷新DNS缓存。"
 msgid "Force Local DNS"
 msgstr "强制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -354,7 +360,7 @@ msgstr "常规设置"
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr "黑名单目录"
 
@@ -366,7 +372,15 @@ msgstr "最后运行"
 msgid "Latest DNS Requests"
 msgstr "最新的DNS请求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump使用的可用网络设备列表."
 
@@ -378,7 +392,7 @@ msgstr ""
 "触发adblock启动的可用网络接口列表.选择“未指定”以使用传统的启动超时而不是网络"
 "触发器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -404,7 +418,7 @@ msgstr ""
 "＃xa0; <b> XXL </ b>（200k-）需要更多的RAM和多核支持，例如x86或树莓派设备。"
 "<br /> <p>＆＃xa0; </ p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支持和完全预配置的下载工具列表。"
 
@@ -417,7 +431,7 @@ msgstr "本地DNS端口"
 msgid "Log View"
 msgstr "日志视图"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "低优先级服务"
 
@@ -438,7 +452,7 @@ msgstr "尚无与adblock相关的日志！"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp' 用于adblock通知电子邮件的配置文件。"
 
@@ -450,14 +464,14 @@ msgstr "查询"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查询特定域的活动阻止列表和备份."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 "如果总体阻止列表总数小于或等于给定的限制，请提高通知数量，以获取电子邮件."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知 E-Mail 的收件人地址。"
 
@@ -468,7 +482,7 @@ msgid ""
 msgstr ""
 "将所有 DNS 查询从“lan”区域重定向到本地解析器，包括 udp、tcp 协议的端口 ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -498,35 +512,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "报告区块计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "报告区块大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "报告接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -553,23 +571,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -581,13 +595,13 @@ msgstr ""
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -597,11 +611,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -621,23 +635,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -689,7 +703,7 @@ msgstr ""
 msgid "Time"
 msgstr "时间"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -703,11 +717,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "触发延迟"
 
@@ -716,7 +730,7 @@ msgstr "触发延迟"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
@@ -731,11 +745,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -743,14 +757,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/zh_Hant/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hant/adblock.po
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "廣告塊處理開始前數秒內的額外觸發延遲。"
 
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Answer"
 msgstr "回覆"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +110,7 @@ msgstr "封锁网域"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,7 +126,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "拉黑檔案清單"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,6 +140,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
 msgid "Cancel"
 msgstr "取消"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+msgid ""
+"Changes on this tab needs a full adblock service restart to take effect.<br /"
+"><p>&#xa0;</p>"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Client"
@@ -159,26 +165,26 @@ msgstr ""
 msgid "Count"
 msgstr "次數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:217
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "DNS Directory"
 msgstr "DNS 目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "DNS File Reset"
 msgstr "DNS檔案重置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:26
 msgid "DNS Report"
@@ -192,7 +198,7 @@ msgstr ""
 msgid "DNS Requests (total)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -200,21 +206,21 @@ msgstr ""
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:412
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:409
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -223,39 +229,39 @@ msgstr ""
 msgid "Domain"
 msgstr "網域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "Download Utility"
 msgstr "下載實用程式"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid "E-Mail Notification"
 msgstr "電子郵件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,7 +279,7 @@ msgstr "編輯白名單"
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -281,7 +287,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -303,11 +309,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -317,11 +323,11 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 快取"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -329,7 +335,7 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "強制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:306
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:315
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +350,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,7 +362,15 @@ msgstr "最後執行"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
+msgid "Limit SafeSearch to certain providers."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -366,7 +380,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -384,7 +398,7 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:357
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:366
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支援和完全預配置的下載工具列表。"
 
@@ -397,7 +411,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid "Low Priority Service"
 msgstr "低優先權服務"
 
@@ -418,7 +432,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:454
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -430,13 +444,13 @@ msgstr "查詢"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:323
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
@@ -446,7 +460,7 @@ msgid ""
 "to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -474,35 +488,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:311
+msgid "Relax SafeSearch"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report Chunk Count"
 msgstr "報告區塊計數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report Chunk Size"
 msgstr "報告區塊大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "Report Directory"
 msgstr "報告目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
 msgid "Report Interface"
 msgstr "報告介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:438
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -529,23 +547,19 @@ msgstr ""
 msgid "Run Utils"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
-msgid "SafeSearch Moderate"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:38
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:73
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:81
 msgid "Save"
 msgstr "儲存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:319
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -557,13 +571,13 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:344
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:475
 msgid "Sources (Size, Focus)"
 msgstr ""
 
@@ -573,11 +587,11 @@ msgid ""
 "locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,23 +611,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "暫停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成攔截列表“adb_list.overall”的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -665,7 +679,7 @@ msgstr ""
 msgid "Time"
 msgstr "時間"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -679,11 +693,11 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
@@ -692,7 +706,7 @@ msgstr "觸發延遲"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:331
 msgid "Verbose Debug Logging"
 msgstr "囉嗦除錯紀錄"
 
@@ -707,11 +721,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:381
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -719,14 +733,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "unbound (/var/lib/unbound)"
 msgstr ""


### PR DESCRIPTION
* made SafeSearch provider configurable, you can limit
  SafeSearch to certain providers
* add an explanation paragraph to report settings
  tab (regarding restart requirement)
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>