### PR TITLE
[18.06] luci-app-simple-adblock: racially-neutral names

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=48
+PKG_RELEASE:=49
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
@@ -143,14 +143,14 @@ errorTable["errorFailDNSReload"] = translate("failed to restart/reload DNS resol
 errorTable["errorSharedMemory"] = translate("failed to access shared memory")
 errorTable["errorSorting"] = translate("failed to sort data file")
 errorTable["errorOptimization"] = translate("failed to optimize data file")
-errorTable["errorWhitelistProcessing"] = translate("failed to process whitelist")
+errorTable["errorAllowListProcessing"] = translate("failed to process allow-list")
 errorTable["errorDataFileFormatting"] = translate("failed to format data file")
 errorTable["errorMovingDataFile"] = translatef("failed to move temporary data file to '%s'", outputFile)
 errorTable["errorCreatingCompressedCache"] = translate("failed to create compressed cache")
 errorTable["errorRemovingTempFiles"] = translate("failed to remove temporary files")
 errorTable["errorRestoreCompressedCache"] = translate("failed to unpack compressed cache")
 errorTable["errorRestoreCache"] = translatef("failed to move '%s' to '%s'", outputCache, outputFile)
-errorTable["errorOhSnap"] = translate("failed to create blocklist or restart DNS resolver")
+errorTable["errorOhSnap"] = translate("failed to create block-list or restart DNS resolver")
 errorTable["errorStopping"] = translatef("failed to stop %s", packageName)
 errorTable["errorDNSReload"] = translate("failed to reload/restart DNS resolver")
 errorTable["errorDownloadingList"] = translate("failed to download")
@@ -320,29 +320,29 @@ o11:value("1", translate("Enable Debugging"))
 o11.default = "0"
 
 
-s2 = m:section(NamedSection, "config", "simple-adblock", translate("Whitelist and Blocklist Management"))
--- Whitelisted Domains
-d1 = s2:option(DynamicList, "whitelist_domain", translate("Whitelisted Domains"), translate("Individual domains to be whitelisted."))
+s2 = m:section(NamedSection, "config", "simple-adblock", translate("Allowed and Blocked Lists Management"))
+-- Allowed Domains
+d1 = s2:option(DynamicList, "allowed_domain", translate("Allowed Domains"), translate("Individual domains to be allowed."))
 d1.addremove = false
 d1.optional = false
 
--- Blacklisted Domains
-d3 = s2:option(DynamicList, "blacklist_domain", translate("Blacklisted Domains"), translate("Individual domains to be blacklisted."))
-d3.addremove = false
-d3.optional = false
-
--- Whitelisted Domains URLs
-d2 = s2:option(DynamicList, "whitelist_domains_url", translate("Whitelisted Domain URLs"), translate("URLs to lists of domains to be whitelisted."))
+-- Allowed Domains URLs
+d2 = s2:option(DynamicList, "allowed_domains_url", translate("Allowed Domain URLs"), translate("URLs to lists of domains to be allowed."))
 d2.addremove = false
 d2.optional = false
 
--- Blacklisted Domains URLs
-d4 = s2:option(DynamicList, "blacklist_domains_url", translate("Blacklisted Domain URLs"), translate("URLs to lists of domains to be blacklisted."))
+-- Blocked Domains
+d3 = s2:option(DynamicList, "blocked_domain", translate("Blocked Domains"), translate("Individual domains to be blocked."))
+d3.addremove = false
+d3.optional = false
+
+-- Blocked Domains URLs
+d4 = s2:option(DynamicList, "blocked_domains_url", translate("Blocked Domain URLs"), translate("URLs to lists of domains to be blocked."))
 d4.addremove = false
 d4.optional = false
 
--- Blacklisted Hosts URLs
-d5 = s2:option(DynamicList, "blacklist_hosts_url", translate("Blacklisted Hosts URLs"), translate("URLs to lists of hosts to be blacklisted."))
+-- Blocked Hosts URLs
+d5 = s2:option(DynamicList, "blocked_hosts_url", translate("Blocked Hosts URLs"), translate("URLs to lists of hosts to be blocked."))
 d5.addremove = false
 d5.optional = false
 

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -29,6 +29,18 @@ msgstr ""
 msgid "Advanced Configuration"
 msgstr ""
 
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
+msgid "Allowed Domain URLs"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
+msgid "Allowed Domains"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:323
+msgid "Allowed and Blocked Lists Management"
+msgstr ""
+
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
@@ -39,15 +51,15 @@ msgid "Basic Configuration"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
-msgid "Blacklisted Domain URLs"
+msgid "Blocked Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
-msgid "Blacklisted Domains"
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
+msgid "Blocked Domains"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
-msgid "Blacklisted Hosts URLs"
+msgid "Blocked Hosts URLs"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
@@ -167,6 +179,10 @@ msgstr ""
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
+#: applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json:3
+msgid "Grant UCI and file access for luci-app-simple-adblock"
+msgstr ""
+
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
 msgid "IPv6 Support"
 msgstr ""
@@ -177,12 +193,12 @@ msgid ""
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
-msgid "Individual domains to be blacklisted."
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
+msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
-msgid "Individual domains to be whitelisted."
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
+msgid "Individual domains to be blocked."
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
@@ -309,16 +325,16 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
-msgid "URLs to lists of domains to be blacklisted."
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
+msgid "URLs to lists of domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
-msgid "URLs to lists of domains to be whitelisted."
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
+msgid "URLs to lists of domains to be blocked."
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
-msgid "URLs to lists of hosts to be blacklisted."
+msgid "URLs to lists of hosts to be blocked."
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
@@ -337,18 +353,6 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:323
-msgid "Whitelist and Blocklist Management"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
-msgid "Whitelisted Domain URLs"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
-msgid "Whitelisted Domains"
-msgstr ""
-
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:143
 msgid "failed to access shared memory"
 msgstr ""
@@ -358,7 +362,7 @@ msgid "failed to create '%s' file"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:153
-msgid "failed to create blocklist or restart DNS resolver"
+msgid "failed to create block-list or restart DNS resolver"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:149
@@ -390,7 +394,7 @@ msgid "failed to parse"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:146
-msgid "failed to process whitelist"
+msgid "failed to process allow-list"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:155


### PR DESCRIPTION
Sync with https://github.com/openwrt/packages/pull/12508.

Signed-off-by: Stan Grishin <stangri@melmac.net>