### PR TITLE
luci-app-xinetd: add new package

### DIFF
--- a/applications/luci-app-xinetd/Makefile
+++ b/applications/luci-app-xinetd/Makefile
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2020 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the Apache License Version 2.0.
+# See https://www.apache.org/licenses/LICENSE-2.0 for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=luci-app-xinetd
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Helge Mader <ma@dev.tdt.de>
+
+# LuCI specific settings
+LUCI_TITLE:=LuCI Support for xinetd
+LUCI_DEPENDS:=+xinetd
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js
+++ b/applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js
@@ -1,0 +1,192 @@
+'use strict';
+'require uci';
+'require ui';
+'require form';
+'require view';
+'require fs';
+'require tools.widgets as widgets';
+
+function validateEmpty(section, value) {
+	if (value) {
+		return true;
+	}
+	else {
+		return _('Expecting: non-empty value');
+	}
+}
+
+return view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('xinetd', _('Xinetd Settings'), _('Here you can configure Xinetd services'));
+
+		s = m.section(form.GridSection, 'service');
+		s.modaltitle = _('Service definitions to be used by Xinetd');
+		s.tabbed = true;
+		s.addremove = true;
+		s.addbtntitle = _('Add new service entry');
+
+		// The following dummy values are used to show the table overview without the hint texts
+		o = s.option(form.DummyValue, 'port', _('Port'));
+		o.modalonly = false;
+
+		o = s.option(form.DummyValue, 'socket_type', _('Socket type'));
+		o.modalonly = false;
+
+		o = s.option(form.DummyValue, 'protocol', _('Protocol'));
+		o.modalonly = false;
+
+		o = s.option(form.DummyValue, 'server', _('Server'));
+		o.modalonly = false;
+
+		o = s.option(form.DummyValue, 'disable', _('Enabled'));
+		o.cfgvalue = function(section) {
+			return (uci.get('xinetd', section, 'disable') == "no") ? _("yes") : _("no");
+		};
+		o.modalonly = false;
+
+		s.tab('basic', _('Basic Settings'));
+		s.tab('advanced', _('Advanced Settings'));
+
+		// Now here follow the "real" values to be set in the modal (with the hint texts)
+
+		// Basic settings
+		o = s.taboption('basic', form.Flag, 'disable', _('Enabled'), _('Enable or Disable this service'));
+		o.enabled  = 'no';
+		o.disabled = 'yes';
+		o.default  = o.enabled;
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('basic', form.ListValue, 'type', _('Type'), _('Type of service'));
+		o.default = 'UNLISTED';
+		// FIXME for now we will only support unlisted services, maybe later we could use the (very long) list from /etc/services if needed
+		// o.value('INTERNAL', _('INTERNAL'));
+		o.value('UNLISTED', _('UNLISTED'));
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('basic', form.Value, 'port', _('Port'), _('The port used for this service, valid range: 0 - 65535'));
+		o.datatype = 'port';
+		o.depends('type', 'UNLISTED');
+		o.rmempty = false;
+		o.modalonly = true;
+		o.validate = function(section_id, value) {
+			var sections = uci.sections('xinetd', 'service');
+
+			for (var i = 0; i < sections.length; i++) {
+				if (uci.get('xinetd', sections[i]['.name'], 'port') == value && section_id != sections[i]['.name'])
+					return _('Port already in use by service "%s"'.format(sections[i]['.name']));
+			}
+
+		return true;
+		};
+
+		o = s.taboption('basic', form.ListValue, 'wait', _('Threading behaviour'), _('Selection of the threading for this service'));
+		o.default = 'no';
+		o.value('yes', _('Single-Threaded Service'));
+		o.value('no', _('Multi-Threaded Service'));
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('basic', form.ListValue, 'socket_type', _('Socket type'), _('The type of the socket used for this service'));
+		o.default = 'stream';
+		o.value('stream', _('stream-based service'));
+		o.value('dgram', _('datagram-based service'));
+		o.value('raw', _('direct access to IP service'));
+		o.value('seqpacket', _('sequential datagram transmission service'));
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('basic', form.ListValue, 'protocol', _('Protocol'), _('The protocol to be used for this service'));
+		o.default = 'tcp';
+		o.value('tcp', _('TCP'));
+		o.value('udp', _('UDP'));
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('basic', widgets.UserSelect, 'user', _('User (UID)'), _('User ID for the server process for this service'));
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('basic', form.Value, 'server', _('Server'), _('Complete path to the executable server file'));
+		o.datatype = 'string';
+		o.rmempty = false;
+		o.modalonly = true;
+		o.validate = validateEmpty;
+		o.write = function(section, value) {
+			return fs.stat(value).then(function(res) {
+				if (res.type == "file") {
+					uci.set('xinetd', section, 'server', value);
+					return;
+				} else {
+					ui.addNotification(null, E('p', _('Service "%s": Invalid server file "%s"').format(section, value)), 'danger');
+				}
+			}).catch(function(err) {
+				ui.addNotification(null, E('p', _('Service "%s": No access to server file "%s" (%s)').format(section, value, err.message)), 'danger');
+				return;
+			});
+		};
+
+		o = s.taboption('basic', form.Value, 'server_args', _('Server arguments'), _('Additional arguments passed to the server. There is no validation of this input.'));
+		o.datatype = 'string';
+		o.modalonly = true;
+
+		// Advanced settings
+		o = s.taboption('advanced', form.DynamicList, 'only_from', _('Allowed hosts'), _('List of allowed hosts to access this service'));
+		o.datatype = 'host';
+		o.cast = 'string';
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.DynamicList, 'no_access', _('Forbidden hosts'), _('List of forbidden hosts to access this service'));
+		o.datatype = 'host';
+		o.cast = 'string';
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.DynamicList, 'access_times', _('Access times'), _('Time intervals within service is available (Format hh:mm-hh:mm)'));
+		o.datatype = 'string';
+		o.modalonly = true;
+		o.validate = function(section_id, value) {
+			if (value.length == 0 || /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/.test(value) == true)
+				return true;
+
+			return _('Expected \'hh:mm-hh:mm\'');
+
+		};
+
+		o = s.taboption('advanced', form.Value, 'cps', _('Connection limit'), _('Takes two arguments: [Number of connections per second] [Number of seconds to reenable service]'));
+		o.datatype = 'string';
+		o.placeholder = '50 10';
+		o.modalonly = true;
+		o.validate = function(section_id, value) {
+			if (value.length == 0 || /^([0-9]+\s+[0-9]+$)/.test(value) == true)
+				return true;
+
+			return _('Expected \'[Number] [Number]\'');
+
+		};
+
+		o = s.taboption('advanced', form.Value, 'instances', _('Number of instances'), _('Number of simultaneously running servers for this service. Argument is any number or the keyword \'UNLIMITED\''));
+		o.datatype = 'or("UNLIMITED", uinteger)';
+		o.value('UNLIMITED', 'UNLIMITED');
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.MultiValue, 'log_on_success', _('Log on success'), _('Informations that should be logged for this service in case of successful connection'));
+		o.value('PID', _('Server PID'));
+		o.value('HOST', _('Remote host address '));
+		o.value('USERID', _('User ID of the remote user'));
+		o.value('EXIT', _('Server exited along with the exit status'));
+		o.value('DURATION', _('Duration of a service session'));
+		o.value('TRAFFIC', _('Total bytes in and out for a redirected service'));
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.MultiValue, 'log_on_failure', _('Log on failure'), _('Informations that should be logged for this service in case of a failed connection'));
+		o.value('HOST', _('Remote host address '));
+		o.value('USERID', _('User ID of the remote user'));
+		o.value('ATTEMPT', _('Failed attempts'));
+		o.modalonly = true;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-xinetd/po/de/xinetd.po
+++ b/applications/luci-app-xinetd/po/de/xinetd.po
@@ -1,0 +1,282 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8\n"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:165
+msgid "Access times"
+msgstr "Zugriffszeiten"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:33
+msgid "Add new service entry"
+msgstr "Neuen Service-Eintrag hinzufügen"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:150
+msgid ""
+"Additional arguments passed to the server. There is no validation of this "
+"input."
+msgstr ""
+"Zusätzliche Aufruf-Argumente für den Server. Es findet keine Überprüfung "
+"statt"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:55
+msgid "Advanced Settings"
+msgstr "Erweiterte Einstellungen"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:155
+msgid "Allowed hosts"
+msgstr "Zulässige Hosts"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:54
+msgid "Basic Settings"
+msgstr "Grundlegende Einstellungen"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:131
+msgid "Complete path to the executable server file"
+msgstr "Kompletter Pfad zur ausführbaren Server-Datei"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:176
+msgid "Connection limit"
+msgstr "Verbindungslimit"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:198
+msgid "Duration of a service session"
+msgstr "Dauer einer Session"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:60
+msgid "Enable or Disable this service"
+msgstr "Diesen Service Aktivieren oder Deaktivieren"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:48
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:60
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:184
+msgid "Expected '[Number] [Number]'"
+msgstr "Erwartet '[Zahl] [Zahl]'"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:172
+msgid "Expected 'hh:mm-hh:mm'"
+msgstr "Erwartet 'hh:mm-hh:mm'"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:19
+msgid "Expecting: non-empty value"
+msgstr "Nicht leerer Wert erforderlich"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:205
+msgid "Failed attempts"
+msgstr "Fehlgeschlagene Versuche"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:160
+msgid "Forbidden hosts"
+msgstr "Verbotene Hosts"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:27
+msgid "Here you can configure Xinetd services"
+msgstr "Hier können Xinetd Dienste konfiguriert werden"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:202
+msgid ""
+"Informations that should be logged for this service in case of a failed "
+"connection"
+msgstr ""
+"Informationen die im Falle einer fehlgeschlagenen Verbindung protokolliert "
+"werden sollen"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:193
+msgid ""
+"Informations that should be logged for this service in case of successful "
+"connection"
+msgstr ""
+"Informationen die im Falle einer erfolgreichen Verbindung protokolliert "
+"werden sollen"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:155
+msgid "List of allowed hosts to access this service"
+msgstr "Liste zulässiger Hosts für diesen Service"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:160
+msgid "List of forbidden hosts to access this service"
+msgstr "Liste verbotener Hosts für diesen Service"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:202
+msgid "Log on failure"
+msgstr "Log im Fehlerfall"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:193
+msgid "Log on success"
+msgstr "Log bei Erfolg"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:94
+msgid "Multi-Threaded Service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:188
+msgid "Number of instances"
+msgstr "Anzahl Instanzen"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:188
+msgid ""
+"Number of simultaneously running servers for this service. Argument is any "
+"number or the keyword 'UNLIMITED'"
+msgstr ""
+"Anzahl gleichzeitig laufender Server für diesen Service. Das Argument ist "
+"eine Zahl oder das Schlüsselwort UNLIMITED"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:36
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:75
+msgid "Port"
+msgstr "Port"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:85
+msgid "Port already in use by service \"%s\""
+msgstr "Dieser Port wird bereits vom Service \"%s\" verwendet"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:42
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:107
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:195
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:203
+msgid "Remote host address"
+msgstr "Adresse des entfernten Hosts"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:91
+msgid "Selection of the threading for this service"
+msgstr "Threading für diesen Service"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:45
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:131
+msgid "Server"
+msgstr "Server"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:194
+msgid "Server PID"
+msgstr "Server PID"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:150
+msgid "Server arguments"
+msgstr "Server Argumente"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:197
+msgid "Server exited along with the exit status"
+msgstr "Server mit dem Exit-Code"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:142
+msgid "Service \"%s\": Invalid server file \"%s\""
+msgstr "Service \"%s\": Unzulässige Datei für Server \"%s\""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:145
+msgid "Service \"%s\": No access to server file \"%s\" (%s)"
+msgstr "Service \"%s\": Kein Zugriff auf Datei für Server \"%s\" (%s)"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:30
+msgid "Service definitions to be used by Xinetd"
+msgstr "Service Definitionen zur Verwendung mit Xinetd"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:93
+msgid "Single-Threaded Service"
+msgstr "Single-Threaded Service"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:39
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:98
+msgid "Socket type"
+msgstr "Socket Typ"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:109
+msgid "TCP"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:176
+msgid ""
+"Takes two arguments: [Number of connections per second] [Number of seconds "
+"to reenable service]"
+msgstr ""
+"Erwartet zwei Argumente: [Anzahl Verbindungen pro Sekunde] [Anzahl von "
+"Sekunden zur Reaktivierung des Service]"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:75
+msgid "The port used for this service, valid range: 0 - 65535"
+msgstr ""
+"Port, der für diesen Service verwendet werden soll. Wertebereich: 0 - 65535"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:107
+msgid "The protocol to be used for this service"
+msgstr "Das Protokoll das für diesen Service verwendet werden soll"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:98
+msgid "The type of the socket used for this service"
+msgstr "Typ des Sockets der für diesen Service verwendet werden soll"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:91
+msgid "Threading behaviour"
+msgstr "Threading Verhalten"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:165
+msgid "Time intervals within service is available (Format hh:mm-hh:mm)"
+msgstr "Zeitintervalle in denen der Service verfügbar ist (Format hh:mm-hh:mm)"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:199
+msgid "Total bytes in and out for a redirected service"
+msgstr "Anzahl Bytes (IN/OUT) für einen weitergeleiteten Service"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:67
+msgid "Type"
+msgstr "Typ"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:67
+msgid "Type of service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:110
+msgid "UDP"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:71
+msgid "UNLISTED"
+msgstr "UNLISTED"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:114
+msgid "User (UID)"
+msgstr "Benutzer (UID)"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:114
+msgid "User ID for the server process for this service"
+msgstr "Benutzer-ID des Server-Prozesses für diesen Server"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:196
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:204
+msgid "User ID of the remote user"
+msgstr "Benutzer-ID des Remote Users"
+
+#: applications/luci-app-xinetd/root/usr/share/luci/menu.d/luci-app-xinetd.json:3
+msgid "Xinetd"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:27
+msgid "Xinetd Settings"
+msgstr "Xinetd Einstellungen"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:101
+msgid "datagram-based service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:102
+msgid "direct access to IP service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:50
+msgid "no"
+msgstr "Nein"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:103
+msgid "sequential datagram transmission service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:100
+msgid "stream-based service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:50
+msgid "yes"
+msgstr "Ja"

--- a/applications/luci-app-xinetd/po/en/xinetd.po
+++ b/applications/luci-app-xinetd/po/en/xinetd.po
@@ -1,0 +1,271 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8\n"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:165
+msgid "Access times"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:33
+msgid "Add new service entry"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:150
+msgid ""
+"Additional arguments passed to the server. There is no validation of this "
+"input."
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:55
+msgid "Advanced Settings"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:155
+msgid "Allowed hosts"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:54
+msgid "Basic Settings"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:131
+msgid "Complete path to the executable server file"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:176
+msgid "Connection limit"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:198
+msgid "Duration of a service session"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:60
+msgid "Enable or Disable this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:48
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:60
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:184
+msgid "Expected '[Number] [Number]'"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:172
+msgid "Expected 'hh:mm-hh:mm'"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:19
+msgid "Expecting: non-empty value"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:205
+msgid "Failed attempts"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:160
+msgid "Forbidden hosts"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:27
+msgid "Here you can configure Xinetd services"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:202
+msgid ""
+"Informations that should be logged for this service in case of a failed "
+"connection"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:193
+msgid ""
+"Informations that should be logged for this service in case of successful "
+"connection"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:155
+msgid "List of allowed hosts to access this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:160
+msgid "List of forbidden hosts to access this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:202
+msgid "Log on failure"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:193
+msgid "Log on success"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:94
+msgid "Multi-Threaded Service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:188
+msgid "Number of instances"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:188
+msgid ""
+"Number of simultaneously running servers for this service. Argument is any "
+"number or the keyword 'UNLIMITED'"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:36
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:75
+msgid "Port"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:85
+msgid "Port already in use by service \"%s\""
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:42
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:107
+msgid "Protocol"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:195
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:203
+msgid "Remote host address"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:91
+msgid "Selection of the threading for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:45
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:131
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:194
+msgid "Server PID"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:150
+msgid "Server arguments"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:197
+msgid "Server exited along with the exit status"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:142
+msgid "Service \"%s\": Invalid server file \"%s\""
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:145
+msgid "Service \"%s\": No access to server file \"%s\" (%s)"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:30
+msgid "Service definitions to be used by Xinetd"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:93
+msgid "Single-Threaded Service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:39
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:98
+msgid "Socket type"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:109
+msgid "TCP"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:176
+msgid ""
+"Takes two arguments: [Number of connections per second] [Number of seconds "
+"to reenable service]"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:75
+msgid "The port used for this service, valid range: 0 - 65535"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:107
+msgid "The protocol to be used for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:98
+msgid "The type of the socket used for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:91
+msgid "Threading behaviour"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:165
+msgid "Time intervals within service is available (Format hh:mm-hh:mm)"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:199
+msgid "Total bytes in and out for a redirected service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:67
+msgid "Type"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:67
+msgid "Type of service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:110
+msgid "UDP"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:71
+msgid "UNLISTED"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:114
+msgid "User (UID)"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:114
+msgid "User ID for the server process for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:196
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:204
+msgid "User ID of the remote user"
+msgstr ""
+
+#: applications/luci-app-xinetd/root/usr/share/luci/menu.d/luci-app-xinetd.json:3
+msgid "Xinetd"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:27
+msgid "Xinetd Settings"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:101
+msgid "datagram-based service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:102
+msgid "direct access to IP service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:50
+msgid "no"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:103
+msgid "sequential datagram transmission service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:100
+msgid "stream-based service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:50
+msgid "yes"
+msgstr ""

--- a/applications/luci-app-xinetd/po/templates/xinetd.pot
+++ b/applications/luci-app-xinetd/po/templates/xinetd.pot
@@ -1,0 +1,271 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:165
+msgid "Access times"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:33
+msgid "Add new service entry"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:150
+msgid ""
+"Additional arguments passed to the server. There is no validation of this "
+"input."
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:55
+msgid "Advanced Settings"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:155
+msgid "Allowed hosts"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:54
+msgid "Basic Settings"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:131
+msgid "Complete path to the executable server file"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:176
+msgid "Connection limit"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:198
+msgid "Duration of a service session"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:60
+msgid "Enable or Disable this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:48
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:60
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:184
+msgid "Expected '[Number] [Number]'"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:172
+msgid "Expected 'hh:mm-hh:mm'"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:19
+msgid "Expecting: non-empty value"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:205
+msgid "Failed attempts"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:160
+msgid "Forbidden hosts"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:27
+msgid "Here you can configure Xinetd services"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:202
+msgid ""
+"Informations that should be logged for this service in case of a failed "
+"connection"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:193
+msgid ""
+"Informations that should be logged for this service in case of successful "
+"connection"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:155
+msgid "List of allowed hosts to access this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:160
+msgid "List of forbidden hosts to access this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:202
+msgid "Log on failure"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:193
+msgid "Log on success"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:94
+msgid "Multi-Threaded Service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:188
+msgid "Number of instances"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:188
+msgid ""
+"Number of simultaneously running servers for this service. Argument is any "
+"number or the keyword 'UNLIMITED'"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:36
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:75
+msgid "Port"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:85
+msgid "Port already in use by service \"%s\""
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:42
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:107
+msgid "Protocol"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:195
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:203
+msgid "Remote host address"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:91
+msgid "Selection of the threading for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:45
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:131
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:194
+msgid "Server PID"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:150
+msgid "Server arguments"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:197
+msgid "Server exited along with the exit status"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:142
+msgid "Service \"%s\": Invalid server file \"%s\""
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:145
+msgid "Service \"%s\": No access to server file \"%s\" (%s)"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:30
+msgid "Service definitions to be used by Xinetd"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:93
+msgid "Single-Threaded Service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:39
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:98
+msgid "Socket type"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:109
+msgid "TCP"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:176
+msgid ""
+"Takes two arguments: [Number of connections per second] [Number of seconds "
+"to reenable service]"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:75
+msgid "The port used for this service, valid range: 0 - 65535"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:107
+msgid "The protocol to be used for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:98
+msgid "The type of the socket used for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:91
+msgid "Threading behaviour"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:165
+msgid "Time intervals within service is available (Format hh:mm-hh:mm)"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:199
+msgid "Total bytes in and out for a redirected service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:67
+msgid "Type"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:67
+msgid "Type of service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:110
+msgid "UDP"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:71
+msgid "UNLISTED"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:114
+msgid "User (UID)"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:114
+msgid "User ID for the server process for this service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:196
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:204
+msgid "User ID of the remote user"
+msgstr ""
+
+#: applications/luci-app-xinetd/root/usr/share/luci/menu.d/luci-app-xinetd.json:3
+msgid "Xinetd"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:27
+msgid "Xinetd Settings"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:101
+msgid "datagram-based service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:102
+msgid "direct access to IP service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:50
+msgid "no"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:103
+msgid "sequential datagram transmission service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:100
+msgid "stream-based service"
+msgstr ""
+
+#: applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js:50
+msgid "yes"
+msgstr ""

--- a/applications/luci-app-xinetd/root/usr/share/luci/menu.d/luci-app-xinetd.json
+++ b/applications/luci-app-xinetd/root/usr/share/luci/menu.d/luci-app-xinetd.json
@@ -1,0 +1,14 @@
+{
+	"admin/services/xinetd": {
+		"title": "Xinetd",
+		"order": 90,
+		"action": {
+			"type": "view",
+			"path": "xinetd/xinetd"
+		},
+		"depends": {
+			"acl": [ "luci-app-xinetd" ],
+			"uci": { "xinetd": true }
+		}
+	}
+}

--- a/applications/luci-app-xinetd/root/usr/share/rpcd/acl.d/luci-app-xinetd.json
+++ b/applications/luci-app-xinetd/root/usr/share/rpcd/acl.d/luci-app-xinetd.json
@@ -1,0 +1,14 @@
+{
+	"luci-app-xinetd": {
+		"description": "Grant access to luci-app-xinetd",
+		"read": {
+			"file": {
+				"/etc/passwd": [ "read" ]
+			},
+			"uci": [ "xinetd" ]
+		},
+		"write": {
+			"uci": [ "xinetd" ]
+		}
+	}
+}


### PR DESCRIPTION
This is a luci application to configure xinetd services.
Only the (probably) most used parameters are implemented for now.

This package depends on PR in another repo (https://github.com/openwrt/packages/pull/12389)