### PR TITLE
luci-app-statistics: add ability to configure collectd-mod-sqm

### DIFF
--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/sqm.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/sqm.lua
@@ -1,0 +1,24 @@
+-- /usr/lib/lua/luci/model/cbi/luci_statistics/sqm.lua
+-- Copyright 2011 Jo-Philipp Wich <jow@openwrt.org>
+-- Copyright 2020 Joseph Nahmias <joe@nahmias.net>
+-- based on /usr/lib/lua/luci/model/cbi/luci_statistics/iwinfo.lua
+-- Licensed to the public under the Apache License 2.0.
+
+local m, s, o
+
+m = Map("luci_statistics",
+	translate("SQM Plugin Configuration"),
+	translate("The sqm plugin collects statistics about smart queue management QoS."))
+
+s = m:section(NamedSection, "collectd_sqm", "luci_statistics")
+
+o = s:option(Flag, "enable", translate("Enable this plugin"))
+o.default = 0
+
+o = s:option(DynamicList, "Interfaces", translate("Monitor interfaces"))
+o.template = "cbi/network_ifacelist"
+o.widget   = "checkbox"
+o.nocreate = true
+o:depends("enable", 1)
+
+return m

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/sqm.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/sqm.lua
@@ -1,0 +1,10 @@
+-- /usr/lib/lua/luci/statistics/plugins/sqm.lua
+return {
+        legend = {
+                { },
+                { },
+                { "Interfaces" }
+        },
+        label = _("SQM"),
+        category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/sqm.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/sqm.lua
@@ -1,0 +1,44 @@
+-- /usr/lib/lua/luci/statistics/rrdtool/definitions/sqm.lua
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.statistics.rrdtool.definitions.sqm", package.seeall)
+
+function item()
+	return luci.i18n.translate("SQM")
+end
+
+function rrdargs( graph, plugin, plugin_instance, dtype )
+
+	return {
+		per_instance = true,
+		title = "%H: SQM qdisc on %pi",
+		rrdopts = { "--logarithmic" },
+		vlabel = " ",
+		alt_autoscale = true,
+		number_format = "%5.0lf",
+		data = {
+			types = { "qdisc_bytes", "qdisc_backlog", "qdisc_drops" },
+			options = {
+				qdisc_bytes = {
+					title = "kb/s:",
+					overlay = true,
+					noarea = false,
+					color = "0000ff",
+					transform_rpn = "125,/"
+				},
+				qdisc_backlog = {
+					title = "Backlog/B:",
+					overlay = true,
+					noarea = true,
+					color = "8000ff"
+				},
+				qdisc_drops = {
+					title = "Drops/s:",
+					overlay = true,
+					noarea = true,
+					color = "00ffff"
+				},
+			}
+		}
+	}
+end

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/sqmcake.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/sqmcake.lua
@@ -1,0 +1,80 @@
+-- /usr/lib/lua/luci/statistics/rrdtool/definitions/sqmcake.lua
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.statistics.rrdtool.definitions.sqmcake", package.seeall)
+
+function item()
+        return luci.i18n.translate("SQM-Cake")
+end
+
+function rrdargs( graph, plugin, plugin_instance, dtype )
+
+	local tindrops = {
+		per_instance = true,
+		title = "%H = CAKE %pi %di Drops/s & Backlog",
+		vlabel = "Bytes & Drops/s",
+		rrdopts = { "--logarithmic" },
+		number_format = "%5.0lf",
+		data = {
+			types = { "qdisct_backlog", "qdisct_drops" },
+			sources = { qdisct_drops = { "ack", "drops", "ecn" } },
+			options = {
+				qdisct_backlog = { title = "Backlog:", overlay = true, color = "0000ff" },
+				qdisct_drops__ack = { title = "Ack:", overlay = true, noarea = true, color = "ff00ff" },
+				qdisct_drops__drops = { title = "Drops:", overlay = true, noarea = true, color = "00ffff" },
+				qdisct_drops__ecn = { title = "Ecn:", overlay = true, noarea = true, color = "00ff00" }
+			}
+		}
+	}
+
+	local tinlatency = {
+		per_instance = true,
+		title = "%H = CAKE %pi %di Latency",
+		vlabel = "ms",
+		number_format = "%4.3lf",
+		data = {
+			types = { "qdisct_latencyus" },
+			sources = { qdisct_latencyus = { "tg", "pk", "av", "sp" } },
+			options = {
+				qdisct_latencyus__tg = { title = "Target:", overlay = true, noarea = true, color = "000000", transform_rpn = "1000,/" },
+				qdisct_latencyus__pk = { title = "Peak:", overlay = true, noarea = true, color = "ff0000", transform_rpn = "1000,/" },
+				qdisct_latencyus__av = { title = "Avg:", overlay = true, noarea = true, color = "00ff00", transform_rpn = "1000,/" },
+				qdisct_latencyus__sp = { title = "Sparse:", overlay = true, noarea = true, color = "0000ff", transform_rpn = "1000,/" }
+			}
+		}
+	};
+
+	local tinflows = {
+		per_instance = true,
+		title = "%H = CAKE %pi %di Flow Counts",
+		vlabel = "Flows",
+		number_format = "%4.0lf",
+		data = {
+			types = { "qdisct_flows" },
+			sources = { qdisct_flows = { "sp", "bu", "un" } },
+			options = {
+				qdisct_flows__sp = { title = "Sparse:", overlay = true, noarea = true, color = "00ff00" },
+				qdisct_flows__bu = { title = "Bulk:", overlay = true, noarea = true, color = "0000ff" },
+				qdisct_flows__un = { title = "Unresponsive:", overlay = true, noarea = true, color = "ff0000" }
+			}
+		}
+	};
+
+	local tinbytes = {
+		per_instance = true,
+		title = "%H = CAKE %pi %di Traffic",
+		vlabel = "Kb/s",
+		number_format = "%5.0lf",
+		rrdopts = { "--logarithmic" },
+		data = {
+			types = { "qdisct_bytes", "qdisct_thres" },
+			options = {
+				qdisct_bytes = { title = "Kb/s:", noarea = false, color = "0000ff", transform_rpn = "125,/" },
+				qdisct_thres = { title = "Thres:", overlay = true, noarea = true, color = "000000", transform_rpn = "125,/" }
+			}
+		}
+	};
+
+	return { tinbytes, tinlatency, tindrops, tinflows };
+
+end

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -4,6 +4,7 @@
 
 Luci statistics - collectd configuration generator
 (c) 2008 Freifunk Leipzig / Jo-Philipp Wich <jow@openwrt.org>
+(c) 2020 Joseph Nahmias <joe@nahmias.net>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,6 +43,8 @@ function section( plugin )
 
 		if type( plugins[plugin] ) == "function" then
 			params = plugins[plugin]( config )
+		elseif type( plugins[plugin] ) == nil then
+			return
 		else
 			params = config_generic( config, plugins[plugin][1], plugins[plugin][2], plugins[plugin][3], plugin == "collectd" )
 		end
@@ -98,10 +101,21 @@ function config_exec( c )
 	local str = ""
 
 	for s in pairs(sections) do
-		for key, type in pairs({ Exec="collectd_exec_input", NotificationExec="collectd_exec_notify" }) do
-			if sections[s][".type"] == type then
+		for plugin, key in pairs({ collectd_exec_input="Exec", collectd_exec_notify="NotificationExec", collectd_sqm="Exec" }) do
+			if sections[s][".type"] == plugin then
 
-				cmd = sections[s].cmdline
+				if plugin == "collectd_sqm" then
+					if sections[s]["enable"] == "1" then
+						-- TODO: auto-magically determine interfaces based on sqm config
+						--local sqm = uci:get_all( "sqm" )
+						local ifcs = table.concat(sections[s]["Interfaces"], " ")
+						if ifcs then
+							cmd = "/usr/libexec/collectd/sqm_collectd.sh " .. ifcs
+						end
+					end
+				else	-- exec_input or exec_notify
+					cmd = sections[s].cmdline
+				end
 
 				if cmd then
 					cmd   = cmd:gsub("^%s+", ""):gsub("%s+$", "")
@@ -292,6 +306,9 @@ for filename in nixio.fs.dir(plugin_dir) do
 	local name = filename:gsub("%.lua", "")
 	if (name == "exec") then
 		plugins[name] = config_exec
+	elseif (name == 'sqm') then
+		-- sqm uses the Exec plugin
+		plugins[name] = nil
 	elseif (name == "iptables") then
 		plugins[name] = config_iptables
 	elseif (name == "curl") then
@@ -303,6 +320,16 @@ for filename in nixio.fs.dir(plugin_dir) do
 	end
 end
 
+if sections.collectd_sqm.enable == "1" and sections.collectd_exec.enable == "0" then
+	-- blank out all disabled exec_input & exec_notify
+	for k,v in pairs(sections) do
+		if v[".type"] == "collectd_exec_input" or v[".type"] == "collectd_exec_notify" then
+			v.cmdline = nil
+		end
+	end
+	-- enable Exec plugin for SQM
+	sections.collectd_exec.enable = "1"
+end
 
 preprocess = {
 	RRATimespans = function(val)


### PR DESCRIPTION
This patch makes it possible to enable and configure the SQM input plugin
for collectd from the Luci front-end. It also handles the generation of
the appropriate config for the SQM plugin using the Exec plugin.

Signed-off-by: Joseph Nahmias <joe@nahmias.net>