### PR TITLE
luci-app-mwan3: use ucitrack is now done with mwan3 procd

### DIFF
--- a/applications/luci-app-mwan3/root/etc/uci-defaults/60_luci-mwan3
+++ b/applications/luci-app-mwan3/root/etc/uci-defaults/60_luci-mwan3
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-# replace existing mwan ucitrack entry
+# remove existing mwan ucitrack entry is now done with procd
 uci -q batch <<-EOF >/dev/null
 	del ucitrack.@mwan3[-1]
-	add ucitrack mwan3
-	set ucitrack.@mwan3[-1].exec="/etc/init.d/mwan3 reload"
 	commit ucitrack
 EOF
 


### PR DESCRIPTION
Remove uci track handling. This is now done with procd in mwan3.
https://github.com/openwrt/packages/pull/12533