### PR TITLE
Adding luci-mod-simple_configuration: combinations of two pages: stat…

### DIFF
--- a/modules/luci-mod-simple_configuration/Makefile
+++ b/modules/luci-mod-simple_configuration/Makefile
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2020 WANG Biyun <Biyun.Wang@etu.univ-grenoble-alpes.fr>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI Simple Configuration
+LUCI_DEPENDS:=+luci-base +libiwinfo-lua +rpcd-mod-iwinfo
+
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/modules/luci-mod-simple_configuration/htdocs/luci-static/resources/view/simple_configuration/port_forwards.js
+++ b/modules/luci-mod-simple_configuration/htdocs/luci-static/resources/view/simple_configuration/port_forwards.js
@@ -1,0 +1,81 @@
+'use strict';
+'require dom';
+'require view';
+'require rpc';
+'require form';
+'require uci';
+'require tools.firewall as fwtool';
+'require tools.widgets as widgets';
+
+return view.extend({
+    callHostHints: rpc.declare({
+        object: 'luci-rpc',
+        method: 'getHostHints',
+        expect: { '': {} }
+    }),
+
+    load: function() {
+        uci.load('firewall');
+        return this.callHostHints();
+    },
+
+    render: function(hosts) {
+        var m, s, o;
+        m = new form.Map('firewall', _('Port Forwards'),
+            _('Port forwarding allows remote computers on the Internet to connect to a specific computer or service within the private LAN.'));
+
+        s = m.section(form.TableSection, 'redirect', _('Port Forwards'));
+        s.addremove = true;
+        s.anonymous = true;
+
+        s.handleAdd = function(ev) {
+            var config_name = this.uciconfig || this.map.config,
+                section_id = uci.add(config_name, this.sectiontype);
+
+            uci.set(config_name, section_id, 'target', 'DNAT');
+            uci.set(config_name, section_id, 'src', 'wan');
+            uci.set(config_name, section_id, 'dest', 'lan');
+            this.addedSection = section_id;
+            this.renderMoreOptionsModal(section_id);
+        };
+
+        o = s.option(form.Value, 'name', _('Name'),
+            _('Name chosen for this server.'));
+        o.placeholder = _('Unnamed forward');
+
+        o = s.option(fwtool.CBIProtocolSelect, 'proto', _('Protocol'));
+        o.default = 'tcp udp';
+
+        o = s.option(form.Value, 'src_dport', _('External port'),
+            _('Match incoming traffic directed at the given destination port or port range on this host'));
+        o.rmempty = false;
+        o.datatype = 'neg(portrange)';
+        o.depends({ proto: 'tcp', '!contains': true });
+        o.depends({ proto: 'udp', '!contains': true });
+
+
+        o = s.option(form.Value, 'dest_ip', _('Internal IP address'),
+            _('Redirect matched incoming traffic to the specified internal host'));
+        o.rmempty = true;
+        o.datatype = 'list(neg(ipmask))';
+
+        var choices = fwtool.transformHostHints('ipv4', hosts);
+        for (var i = 0; i < choices[0].length; i++) {
+            o.value(choices[0][i], choices[1][choices[0][i]]);
+        }
+
+        o.transformChoices = function() {
+            return this.super('transformChoices', []) || {};
+        };
+
+        o = s.option(form.Value, 'dest_port', _('Internal port'),
+            _('Redirect matched incoming traffic to the given port on the internal host'));
+        o.rmempty = true;
+        o.placeholder = _('any');
+        o.datatype = 'portrange';
+        o.depends({ proto: 'tcp', '!contains': true });
+        o.depends({ proto: 'udp', '!contains': true });
+
+        return m.render();
+    }
+});

--- a/modules/luci-mod-simple_configuration/htdocs/luci-static/resources/view/simple_configuration/static_ip.js
+++ b/modules/luci-mod-simple_configuration/htdocs/luci-static/resources/view/simple_configuration/static_ip.js
@@ -1,0 +1,123 @@
+'use strict';
+'require dom';
+'require view';
+'require rpc';
+'require form';
+'require uci';
+
+function validateHostname(sid, s) {
+    if (s == null || s == '')
+        return true;
+    if (s.length > 256)
+        return _('Expecting: %s').format(_('valid hostname'));
+
+    var labels = s.replace(/^\.+|\.$/g, '').split(/\./);
+
+    for (var i = 0; i < labels.length; i++)
+        if (!labels[i].match(/^[a-z0-9_](?:[a-z0-9-]{0,61}[a-z0-9])?$/i))
+            return _('Expecting: %s').format(_('valid hostname'));
+
+    return true;
+}
+
+return view.extend({
+    callHostHints: rpc.declare({
+        object: 'luci-rpc',
+        method: 'getHostHints',
+        expect: { '': {} }
+    }),
+
+    load: function() {
+        return this.callHostHints();
+    },
+
+    render: function(hosts) {
+        var m, s, o;
+
+        m = new form.Map('dhcp', _('Static IP'));
+
+        s = m.section(form.TableSection, 'leases', _('Static Leases'), _('Static leases are used to assign fixed IP addresses and symbolic hostnames to DHCP clients. They are alo required for non-dynamic interface configurations where only hosts with a corresponding lease are served.'));
+        s.addremove = true;
+        s.anonymous = true;
+
+
+        o = s.option(form.Value, 'name', _('Hostname'));
+        o.validate = validateHostname;
+        o.rmempty  = true;
+        o.write = function(section, value) {
+            uci.set('dhcp', section, 'name', value);
+            uci.set('dhcp', section, 'dns', '1');
+        };
+        o.remove = function(section) {
+            uci.unset('dhcp', section, 'name');
+            uci.unset('dhcp', section, 'dns');
+        };
+
+        o = s.option(form.Value, 'mac', _('<abbr title="Media Access Control">MAC</abbr>-Address'));
+        o.datatype = 'list(unique(macaddr))';
+        o.rmempty  = true;
+        o.cfgvalue = function(section) {
+            var macs = uci.get('dhcp', section, 'mac'),
+                result = [];
+
+            if (!Array.isArray(macs))
+                macs = (macs != null && macs != '') ? macs.split(/\ss+/) : [];
+
+            for (var i = 0, mac; (mac = macs[i]) != null; i++) {
+                if (/^([0-9a-fA-F]{1,2}):([0-9a-fA-F]{1,2}):([0-9a-fA-F]{1,2}):([0-9a-fA-F]{1,2}):([0-9a-fA-F]{1,2}):([0-9a-fA-F]{1,2})$/.test(mac)) {
+                    result.push('%02X:%02X:%02X:%02X:%02X:%02X'.format(
+                        parseInt(RegExp.$1, 16), parseInt(RegExp.$2, 16),
+                        parseInt(RegExp.$3, 16), parseInt(RegExp.$4, 16),
+                        parseInt(RegExp.$5, 16), parseInt(RegExp.$6, 16)));
+                }
+            }
+            return result.length ? result.join(' ') : null;
+        };
+        o.renderWidget = function(section_id, option_index, cfgvalue) {
+            var node = form.Value.prototype.renderWidget.apply(this, [section_id, option_index, cfgvalue]),
+                ipopt = this.section.children.filter(function(o) { return o.option == 'ip' })[0];
+
+            node.addEventListener('cbi-dropdown-change', L.bind(function(ipopt, section_id, ev) {
+                var mac = ev.detail.value.value;
+                if (mac == null || mac == '' || !hosts[mac] || !hosts[mac].ipv4)
+                    return;
+
+                var ip = ipopt.formvalue(section_id);
+                if (ip != null && ip != '')
+                    return;
+
+                var node = ipopt.map.findElement('id', ipopt.cbid(section_id));
+                if (node)
+                    dom.callClassMethod(node, 'setValue', hosts[mac].ipv4);
+            }, this, ipopt, section_id));
+
+            return node;
+        };
+        Object.keys(hosts).forEach(function(mac) {
+            var hint = hosts[mac].name || hosts[mac].ipv4;
+            o.value(mac, hint ? '%s (%s)'.format(mac, hint) : mac);
+        });
+
+        o = s.option(form.Value, 'ip', _('<abbr title="Internet Protocol Version 4">IPv4</abbr>-Address'));
+        o.datatype = 'or(ip4addr,"ignore")';
+        o.validate = function(section, value) {
+            var mac = this.map.lookupOption('mac', section),
+                name = this.map.lookupOption('name', section),
+                m = mac ? mac[0].formvalue(section) : null,
+                n = name ? name[0].formvalue(section) : null;
+
+            if ((m == null || m == '') && (n == null || n == ''))
+                return _('One of hostname or mac address must be specified!');
+
+            return true;
+        };
+        Object.keys(hosts).forEach(function(mac) {
+            if (hosts[mac].ipv4) {
+                var hint = hosts[mac].name;
+                o.value(hosts[mac].ipv4, hint ? '%s (%s)'.format(hosts[mac].ipv4, hint) : hosts[mac].ipv4);
+            }
+        });
+
+        return m.render();
+    }
+});

--- a/modules/luci-mod-simple_configuration/luasrc/view/simple_configuration/port_forwards.htm
+++ b/modules/luci-mod-simple_configuration/luasrc/view/simple_configuration/port_forwards.htm
@@ -1,0 +1,50 @@
+<%#
+ Copyright 2019-2020 ZHANG Zhao <Zhao.Zhang2@etu.univ-grenoble-alpes.fr>
+ Licensed to the public under the Apache License 2.0.
+-%>
+
+<% css = [[
+
+.cbi-dropdown:not(.btn):not(.cbi-button) > ul > li {
+	flex-grow: initial;
+}
+
+.cbi-section-table-row > div:first-child {
+	min-width: 172px;
+}
+
+.cbi-section-table-row > div:nth-child(2) > div > div {
+	min-width: initial!important;
+}
+
+.cbi-section-table-row > div:nth-child(3) > div > div {
+	min-width: initial!important;
+}
+
+.cbi-section-node .cbi-value .cbi-value-field > .cbi-dropdown > ul{
+	justify-content: space-evenly;
+}
+
+.cbi-section-node .cbi-value .cbi-value-field > .cbi-dropdown > ul > li[display]:not([display="0"]) {
+	padding-left: 20px;
+}
+
+.cbi-section-node .cbi-value .cbi-dropdown-open > .cbi-dropdown > ul > li {
+	padding-left:0!important;
+}
+
+]] -%>
+
+<%+header%>
+
+<div id="view">
+	<div class="spinning"><%:Loading view…%></div>
+</div>
+
+<script type="text/javascript">
+	L.require('ui').then(function(ui) {
+		ui.instantiateView('simple_configuration/port_forwards');
+	});
+</script>
+
+<%+footer%>

--- a/modules/luci-mod-simple_configuration/root/usr/share/luci/menu.d/luci-base.json
+++ b/modules/luci-mod-simple_configuration/root/usr/share/luci/menu.d/luci-base.json
@@ -1,0 +1,162 @@
+{
+	"admin": {
+		"title": "Administration",
+		"order": 10,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		},
+		"auth": {
+			"methods": [ "cookie:sysauth" ],
+			"login": true
+		}
+	},
+
+	"admin/status": {
+		"title": "Status",
+		"order": 10,
+		"action": {
+			"type": "firstchild",
+			"preferred": "overview",
+			"recurse": true
+		}
+	},
+
+	"admin/system": {
+		"title": "System",
+		"order": 20,
+		"action": {
+			"type": "firstchild",
+			"preferred": "system",
+			"recurse": true
+		}
+	},
+
+	"admin/vpn": {
+		"title": "VPN",
+		"order": 30,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		}
+	},
+
+	"admin/services": {
+		"title": "Services",
+		"order": 40,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		}
+	},
+
+	"admin/simple_configuration": {
+		"title": "Simple Configuration",
+		"order": 2,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		}
+	},
+
+
+	"admin/network": {
+		"title": "Network",
+		"order": 50,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		}
+	},
+
+	"admin/translations/*": {
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.index",
+			"function": "action_translations"
+		},
+		"auth": {}
+	},
+
+	"admin/ubus/*": {
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.index",
+			"function": "action_ubus"
+		},
+		"auth": {}
+	},
+
+	"admin/logout": {
+		"title": "Logout",
+		"order": 999,
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.index",
+			"function": "action_logout"
+		},
+		"depends": {
+			"acl": [ "luci-base" ]
+		}
+	},
+
+	"admin/uci": {
+		"action": {
+			"type": "firstchild"
+		}
+	},
+
+	"admin/uci/revert": {
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.uci",
+			"function": "action_revert",
+			"post": true
+		}
+	},
+
+	"admin/uci/apply_rollback": {
+		"cors": true,
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.uci",
+			"function": "action_apply_rollback",
+			"post": true
+		},
+		"auth": {
+			"methods": [ "cookie:sysauth" ]
+		}
+	},
+
+	"admin/uci/apply_unchecked": {
+		"cors": true,
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.uci",
+			"function": "action_apply_unchecked",
+			"post": true
+		},
+		"auth": {
+			"methods": [ "cookie:sysauth" ]
+		}
+	},
+
+	"admin/uci/confirm": {
+		"cors": true,
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.uci",
+			"function": "action_confirm"
+		},
+		"auth": {}
+	},
+
+	"admin/menu": {
+		"action": {
+			"type": "call",
+			"module": "luci.controller.admin.index",
+			"function": "action_menu"
+		},
+		"auth": {}
+	}
+}

--- a/modules/luci-mod-simple_configuration/root/usr/share/luci/menu.d/luci-mod-simple_configuration.json
+++ b/modules/luci-mod-simple_configuration/root/usr/share/luci/menu.d/luci-mod-simple_configuration.json
@@ -1,0 +1,26 @@
+{
+  "admin/simple_configuration/static_ip": {
+    "title": "Static IP",
+    "order": 150,
+    "action": {
+      "type": "view",
+      "path": "simple_configuration/static_ip"
+    },
+    "depends": {
+      "acl": [ "luci-mod-simple_configuration" ],
+      "uci": { "dhcp": true }
+    }
+  },
+  "admin/simple_configuration/port_forwards": {
+    "title": "Port Forwards",
+    "order": 180,
+    "action": {
+      "type": "template",
+      "path": "simple_configuration/port_forwards"
+    },
+    "depends": {
+      "acl": [ "luci-mod-simple_configuration" ],
+      "uci": { "firewall": true }
+    }
+  }
+}

--- a/modules/luci-mod-simple_configuration/root/usr/share/rpcd/acl.d/luci-mod-simple_configuration.json
+++ b/modules/luci-mod-simple_configuration/root/usr/share/rpcd/acl.d/luci-mod-simple_configuration.json
@@ -1,0 +1,12 @@
+{
+    "luci-mod-simple_configuration": {
+      "description": "Access to DHCP and firewall configuration",
+      "read": {
+        "luci-rpc": ["getDUIDHints"],
+        "uci": [ "dhcp", "firewall", "network", "wireless" ]
+      },
+      "write": {
+        "uci": [ "luci", "system", "dhcp", "firewall"]
+      }
+    }
+}


### PR DESCRIPTION
Adding luci-mod-simple_configuration: combinations of two pages: static leases and port forwards.

Our objectif is to create a lite version of luci interface for users non experts, we have chosen some functionalities most popular, these modules are parts of what we want to create, we explicate what we have done in the wiki of luci.
This is the lien of documentation: https://openwrt.org/docs/guide-user/luci/port_forwards
https://openwrt.org/docs/guide-user/luci/static_ip

Signed-off-by: WANG biyun <biyun.wang@etu.univ-grenoble-alpes.fr>