### PR TITLE
move nixio__bin2hex to header and make static

### DIFF
--- a/libs/luci-lib-nixio/src/address.c
+++ b/libs/luci-lib-nixio/src/address.c
@@ -153,7 +153,7 @@ int nixio__addr_write(nixio_addr *addr, struct sockaddr *saddr) {
 /**
  * netmask to prefix helper
  */
-int nixio__addr_prefix(struct sockaddr *saddr) {
+static int nixio__addr_prefix(struct sockaddr *saddr) {
 	int prefix = 0;
 	size_t len;
 	uint8_t *addr;

--- a/libs/luci-lib-nixio/src/binary.c
+++ b/libs/luci-lib-nixio/src/binary.c
@@ -19,10 +19,6 @@
 #include "nixio.h"
 #include <stdlib.h>
 
-const char nixio__bin2hex[16] = {
-'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-};
-
 static unsigned char nixio__b64encode_tbl[] =
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 

--- a/libs/luci-lib-nixio/src/nixio.h
+++ b/libs/luci-lib-nixio/src/nixio.h
@@ -107,7 +107,9 @@ int nixio__mode_write(int mode, char *modestr);
 
 int nixio__push_stat(lua_State *L, nixio_stat_t *buf);
 
-const char nixio__bin2hex[16];
+static const char nixio__bin2hex[16] = {
+'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+};
 
 /* Module functions */
 void nixio_open_file(lua_State *L);


### PR DESCRIPTION
This fixes compilation under GCC10.

There's no reason for this to be in a C file anyway.

Also fixed a -Wmissing-prototypes warning with nixio__addr_prefix.

Signed-off-by: Rosen Penev <rosenp@gmail.com>