### PR TITLE
luci-base: dispatcher: error404: flow message into template

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -394,7 +394,7 @@ function error404(message)
 
 	local function render()
 		local template = require "luci.template"
-		template.render("error404")
+		template.render("error404", {message=message})
 	end
 
 	if not util.copcall(render) then

--- a/modules/luci-base/luasrc/view/error404.htm
+++ b/modules/luci-base/luasrc/view/error404.htm
@@ -7,5 +7,6 @@
 <%+header%>
 <h2 name="content">404 <%:Not Found%></h2>
 <p><%:Sorry, the object you requested was not found.%></p>
+<p><%=message%></p>
 <tt><%:Unable to dispatch%>: <%=url(unpack(luci.dispatcher.context.request))%></tt>
 <%+footer%>


### PR DESCRIPTION
message was only being shown in the plain text case when the render
failed.

Signed-off-by: Karl Palsson <karlp@etactica.com>