### PR TITLE
dispatcher: stop at first valid child

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -613,6 +613,12 @@ local function get_children(node)
 end
 
 local function find_subnode(root, prefix, recurse, descended)
+	-- First child can cause recursion, so to _stop_ and find a node, it needs to be "something else"
+	local valid = root.title ~= nil and root.action ~= nil and root.action.type ~= "firstchild"
+	if valid and prefix then
+		return prefix
+	end
+
 	local children = get_children(root)
 
 	if #children > 0 and (not descended or recurse) then
@@ -630,18 +636,6 @@ local function find_subnode(root, prefix, recurse, descended)
 			if res_path then
 				return res_path
 			end
-		end
-	end
-
-	if descended then
-		if not recurse or
-		   root.action.type == "cbi" or
-		   root.action.type == "form" or
-		   root.action.type == "view" or
-		   root.action.type == "template" or
-		   root.action.type == "arcombine"
-		then
-			return prefix
 		end
 	end
 end


### PR DESCRIPTION
Instead of recursing to the first valid leaf node, stop at the first
valid node at all.  Changes validity to be "having a title" and "not
being a type that recurses" rather than just allowing certain types
as well, based on discussion with jow.

This means that with some controller entries such as:
```
    entry({'home'}, call("desired_home"), _("Home"), 1)
    entry({'home', "wizard"}, firstchild(), _("Setup"), 2)
    entry({'home', 'wizard', 'initial_setup'}, call("action_wizard_home"), _("Initial Configuration"), 10)
    entry({'home', 'wizard', 'basic_view'}, view("unexepectedview"), _("Unexepected view"), 20)
```
The dispatcher will now route "cgi-bin/luci" to the
call("desired_home") rather than continuing to the "unexepectedview" as
the first leaf node of a suitable type.

Changing the list of types alone is insufficient as it would then
continue to the "call(action_wizard_home)" leaf still, instead of the
desired top level entry.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Tested and developed against 1907, but patch is against master.