### PR TITLE
luci-proto-modemmanager: add modem specific error messages

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -37,9 +37,15 @@ function getModemList() {
 }
 
 network.registerPatternVirtual(/^mobiledata-.+$/);
-network.registerErrorCode('CALL_FAILED', _('Call failed'));
-network.registerErrorCode('NO_CID',      _('Unable to obtain client ID'));
-network.registerErrorCode('PLMN_FAILED', _('Setting PLMN failed'));
+network.registerErrorCode('MM_CONNECT_FAILED', _('Connection attempt failed.'));
+network.registerErrorCode('MM_DISCONNECT_IN_PROGRESS', _('Modem disconnection in progress. Please wait.'));
+network.registerErrorCode('MM_CONNECT_IN_PROGRESS', _('Modem connection in progress. Please wait. This process will timeout after 2 minutes.'));
+network.registerErrorCode('MM_TEARDOWN_IN_PROGRESS', _('Modem bearer teardown in progress.'));
+network.registerErrorCode('MM_MODEM_DISABLED', _('Modem is disabled.'));
+network.registerErrorCode('DEVICE_NOT_MANAGED', _('Device not managed by ModemManager.'));
+network.registerErrorCode('INVALID_BEARER_LIST', _('Invalid bearer list. Possibly too many bearers created.  This protocol supports one and only one bearer.'));
+network.registerErrorCode('UNKNOWN_METHOD', _('Unknown and unsupported connection method.'));
+network.registerErrorCode('DISCONNECT_FAILED', _('Disconnection attempt failed.'));
 
 return network.registerProtocol('modemmanager', {
 	getI18n: function() {


### PR DESCRIPTION
Add ModemManager specific error messages to indicate the status of the modem during operation.

Requires https://github.com/openwrt/packages/pull/12775
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>