### PR TITLE
luci-app-nlbwmon: move into menu entry into service section

### DIFF
--- a/applications/luci-app-nlbwmon/root/usr/share/luci/menu.d/luci-app-nlbwmon.json
+++ b/applications/luci-app-nlbwmon/root/usr/share/luci/menu.d/luci-app-nlbwmon.json
@@ -1,9 +1,10 @@
 {
-	"admin/nlbw": {
+	"admin/services/nlbw": {
 		"title": "Bandwidth Monitor",
 		"order": 80,
 		"action": {
-			"type": "firstchild"
+			"type": "alias",
+			"path": "admin/services/nlbw/display"
 		},
 		"depends": {
 			"acl": [ "luci-app-nlbwmon" ],
@@ -11,27 +12,27 @@
 		}
 	},
 
-	"admin/nlbw/display": {
+	"admin/services/nlbw/display": {
 		"title": "Display",
-		"order": 1,
+		"order": 10,
 		"action": {
 			"type": "view",
 			"path": "nlbw/display"
 		}
 	},
 
-	"admin/nlbw/config": {
+	"admin/services/nlbw/config": {
 		"title": "Configuration",
-		"order": 2,
+		"order": 20,
 		"action": {
 			"type": "view",
 			"path": "nlbw/config"
 		}
 	},
 
-	"admin/nlbw/backup": {
+	"admin/services/nlbw/backup": {
 		"title": "Backup",
-		"order": 3,
+		"order": 30,
 		"action": {
 			"type": "view",
 			"path": "nlbw/backup"


### PR DESCRIPTION
I'm referring to the discussion with @jow- where we once discussed whether we should rename the service section to app.
Unfortunately I cannot find the thread anymore.

To avoid extending the menu tree the application luci-app-nlbwmon should also be moved to the service section and not get an extra menu entry.
