### PR TITLE
luci-theme-openwrt-2020: move definitions into custom.css file

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -1,18 +1,8 @@
-:root {
-	--main-bright-color: #00A3E1;
-	--main-dark-color: #002B49;
-	--secondary-bright-color: #FFFFFF;
-	--secondary-dark-color: #212322;
-	--danger-color: #CC1111;
-	--warning-color: #CC8800;
-	--regular-font: "GalanoGrotesqueW00-Regular";
-	--base-font-size: 16px;
-}
+/*
+ * Import custom.css file
+ */
 
-@font-face {
- 	font-family: "GalanoGrotesqueW00-Regular";
- 	src: url("GalanoGrotesqueW00-Regular.woff2") format("woff2");
-}
+@import url("custom.css") screen;
 
 /*
  * resets and base style

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/custom.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/custom.css
@@ -1,0 +1,15 @@
+:root {
+	--main-bright-color: #00A3E1;
+	--main-dark-color: #002B49;
+	--secondary-bright-color: #FFFFFF;
+	--secondary-dark-color: #212322;
+	--danger-color: #CC1111;
+	--warning-color: #CC8800;
+	--regular-font: "GalanoGrotesqueW00-Regular";
+	--base-font-size: 16px;
+}
+
+@font-face {
+	font-family: "GalanoGrotesqueW00-Regular";
+	src: url("GalanoGrotesqueW00-Regular.woff2") format("woff2");
+}


### PR DESCRIPTION
With this change the css variables can be adjusted independently. It is
not necessary to change the css file directly in cascade.css.
The changes are stored in a custom.css file.