### PR TITLE
luci-app-unbound: add rate_limit and dns_assist option support

### DIFF
--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
@@ -138,7 +138,7 @@ if (valman == "0") then
     dlk = s1:taboption("DHCP", ListValue, "dhcp_link",
         translate("DHCP Link"),
         translate("Link to supported programs to load DHCP into DNS"))
-    dlk:value("none", translate("No Link"))
+    dlk:value("none", translate("(none)"))
     dlk:value("dnsmasq", "dnsmasq")
     dlk:value("odhcpd", "odhcpd")
     dlk.rmempty = false
@@ -154,8 +154,6 @@ if (valman == "0") then
         translate("Domain suffix for this router and DHCP clients"))
     dom.placeholder = "lan"
     dom.optional = true
-    dom:depends("dhcp_link", "none")
-    dom:depends("dhcp_link", "odhcpd")
 
     dty = s1:taboption("DHCP", ListValue, "domain_type",
         translate("Local Domain Type"),
@@ -269,6 +267,12 @@ if (valman == "0") then
         translate("Prevent excessively short cache periods"))
     tlm.datatype = "and(uinteger,min(0),max(1200))"
     tlm.placeholder = "120"
+
+    rtt = s1:taboption("resource", Value, "rate_limit",
+        translate("Query Rate Limit"),
+        translate("Prevent client query overload; zero is off"))
+    rtt.datatype = "and(uinteger,min(0),max(5000))"
+    rtt.placeholder = "0"
 
     stt = s1:taboption("resource", Flag, "extended_stats",
         translate("Extended Statistics"),

--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/zone-details.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/zone-details.lua
@@ -48,6 +48,14 @@ else
         translate("Servers for this zone; see README.md for optional form"))
     srv.placeholder="192.0.2.53"
 
+    ast = s7:option(ListValue, "dns_assist", translate("DNS Plugin"),
+         translate("Check for local program to allow forward to localhost"))
+    ast:value("none", translate("(none)"))
+    ast:value("bind", "bind")
+    ast:value("dnsmasq", "dnsmasq")
+    ast:value("ipset-dns", "ipset-dns")
+    ast:value("nsd", "nsd")
+
     rlv = s7:option(Flag, "resolv_conf", translate("Use 'resolv.conf.auto'"),
         translate("Forward to upstream nameservers (ISP)"))
     rlv:depends("zone_type", "forward_zone")


### PR DESCRIPTION
maintainer: me
tested: Linksys WRT3200ACM
description:
resolves #4174 and picks up options from https://github.com/openwrt/packages/pull/12798