### PR TITLE
luci-compat: add btn class to all button inputs

### DIFF
--- a/modules/luci-compat/luasrc/view/cbi/button.htm
+++ b/modules/luci-compat/luasrc/view/cbi/button.htm
@@ -1,6 +1,6 @@
 <%+cbi/valueheader%>
 	<% if self:cfgvalue(section) ~= false then %>
-		<input class="cbi-button cbi-button-<%=self.inputstyle or "button" %>" type="submit"<%= attr("name", cbid) .. attr("id", cbid) .. attr("value", self.inputtitle or self.title)%> />
+		<input class="btn cbi-button cbi-button-<%=self.inputstyle or "button" %>" type="submit"<%= attr("name", cbid) .. attr("id", cbid) .. attr("value", self.inputtitle or self.title)%> />
 	<% else %>
 		-
 	<% end %>

--- a/modules/luci-compat/luasrc/view/cbi/delegator.htm
+++ b/modules/luci-compat/luasrc/view/cbi/delegator.htm
@@ -6,18 +6,18 @@
 <% end %>
 <% if not self.disallow_pageactions then %>
 <% if self.allow_finish and not self:get_next(self.current) then %>
-	<input class="cbi-button cbi-button-finish" type="submit" value="<%:Finish%>" />
+	<input class="btn cbi-button cbi-button-finish" type="submit" value="<%:Finish%>" />
 <% elseif self:get_next(self.current) then %>
-		<input class="cbi-button cbi-button-next" type="submit" value="<%:Next »%>" />
+		<input class="btn cbi-button cbi-button-next" type="submit" value="<%:Next »%>" />
 <% end %>
 <% if self.allow_cancel then %>
-		<input class="cbi-button cbi-button-cancel" type="submit" name="cbi.cancel" value="<%:Cancel%>" />
+		<input class="btn cbi-button cbi-button-cancel" type="submit" name="cbi.cancel" value="<%:Cancel%>" />
 <% end %>
 <% if self.allow_reset then %>
-		<input class="cbi-button cbi-button-reset" type="reset" value="<%:Reset%>" />
+		<input class="btn cbi-button cbi-button-reset" type="reset" value="<%:Reset%>" />
 <% end %>
 <% if self.allow_back and self:get_prev(self.current) then %>
-		<input class="cbi-button cbi-button-back" type="submit" name="cbi.delg.back" value="<%:« Back%>" />
+		<input class="btn cbi-button cbi-button-back" type="submit" name="cbi.delg.back" value="<%:« Back%>" />
 <% end %>
 <% end %>
 		<script type="text/javascript">cbi_d_update();</script>

--- a/modules/luci-compat/luasrc/view/cbi/error.htm
+++ b/modules/luci-compat/luasrc/view/cbi/error.htm
@@ -14,6 +14,6 @@
 	</p>
 
 	<div class="cbi-page-actions">
-		<input class="cbi-button cbi-button-apply" type="submit" name="cbi.save" value="<%:Save%>" />
+		<input class="btn cbi-button cbi-button-apply" type="submit" name="cbi.save" value="<%:Save%>" />
 	</div>
 </div>

--- a/modules/luci-compat/luasrc/view/cbi/ipaddr.htm
+++ b/modules/luci-compat/luasrc/view/cbi/ipaddr.htm
@@ -23,5 +23,5 @@
 		ifattr(self.combobox_manual, "data-manual", self.combobox_manual) ..
 		ifattr(#self.keylist > 0, "data-choices", { self.keylist, self.vallist })
 	%> /><!--
-	--><button class="cbi-button cbi-button-neutral" title="<%:Switch to CIDR list notation%>" aria-label="<%:Switch to CIDR list notation%>" onclick="switchToCIDRList(event)">…</button>
+	--><button class="btn cbi-button cbi-button-neutral" title="<%:Switch to CIDR list notation%>" aria-label="<%:Switch to CIDR list notation%>" onclick="switchToCIDRList(event)">…</button>
 <%+cbi/valuefooter%>

--- a/modules/luci-compat/luasrc/view/cbi/nsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/nsection.htm
@@ -8,7 +8,7 @@
 		<%- end %>
 		<% if self.addremove then -%>
 			<div class="cbi-section-remove right">
-				<input type="submit" class="cbi-button" name="cbi.rns.<%=self.config%>.<%=section%>" value="<%:Delete%>" />
+				<input type="submit" class="btn cbi-button" name="cbi.rns.<%=self.config%>.<%=section%>" value="<%:Delete%>" />
 			</div>
 		<%- end %>
 		<div class="cbi-section-node<% if self.tabs then %> cbi-section-node-tabbed<% end %>" id="cbi-<%=self.config%>-<%=section%>">
@@ -22,7 +22,7 @@
 			<legend><%=self.title%></legend>
 		<%- end %>
 		<div class="cbi-section-descr"><%=self.description%></div>
-		<input type="submit" class="cbi-button cbi-button-add" name="cbi.cns.<%=self.config%>.<%=self.section%>" value="<%:Add%>" />
+		<input type="submit" class="btn cbi-button cbi-button-add" name="cbi.cns.<%=self.config%>.<%=self.section%>" value="<%:Add%>" />
 	</div>
 	<%- end %>
 <% end %>

--- a/modules/luci-compat/luasrc/view/cbi/simpleform.htm
+++ b/modules/luci-compat/luasrc/view/cbi/simpleform.htm
@@ -45,26 +45,26 @@
 			%><div class="cbi-page-actions"><%
 
 			if display_back then
-				%><input class="cbi-button cbi-button-link" type="button" value="<%:Back to Overview%>" onclick="location.href='<%=pcdata(redirect)%>'" /> <%
+				%><input class="btn cbi-button cbi-button-link" type="button" value="<%:Back to Overview%>" onclick="location.href='<%=pcdata(redirect)%>'" /> <%
 			end
 
 			if display_cancel then
 				local label = pcdata(self.cancel or translate("Cancel"))
-				%><input class="cbi-button cbi-button-link" type="button" value="<%=label%>" onclick="cbi_submit(this, 'cbi.cancel')" /> <%
+				%><input class="btn cbi-button cbi-button-link" type="button" value="<%=label%>" onclick="cbi_submit(this, 'cbi.cancel')" /> <%
 			end
 
 			if display_skip then
-				%><input class="cbi-button cbi-button-neutral" type="button" value="<%:Skip%>" onclick="cbi_submit(this, 'cbi.skip')" /> <%
+				%><input class="btn cbi-button cbi-button-neutral" type="button" value="<%:Skip%>" onclick="cbi_submit(this, 'cbi.skip')" /> <%
 			end
 
 			if display_submit then
 				local label = pcdata(self.submit or translate("Submit"))
-				%><input class="cbi-button cbi-button-save" type="submit" value="<%=label%>" /> <%
+				%><input class="btn cbi-button cbi-button-save" type="submit" value="<%=label%>" /> <%
 			end
 
 			if display_reset then
 				local label = pcdata(self.reset or translate("Reset"))
-				%><input class="cbi-button cbi-button-reset" type="reset" value="<%=label%>" /> <%
+				%><input class="btn cbi-button cbi-button-reset" type="reset" value="<%=label%>" /> <%
 			end
 
 			%></div><%

--- a/modules/luci-compat/luasrc/view/cbi/tblsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tblsection.htm
@@ -148,10 +148,10 @@ end
 				<div class="td cbi-section-table-cell nowrap cbi-section-actions">
 					<div>
 						<%- if self.sortable then -%>
-							<input class="cbi-button cbi-button-up" type="button" value="<%:Up%>" onclick="return cbi_row_swap(this, true, 'cbi.sts.<%=self.config%>.<%=self.sectiontype%>')" title="<%:Move up%>" />
-							<input class="cbi-button cbi-button-down" type="button" value="<%:Down%>" onclick="return cbi_row_swap(this, false, 'cbi.sts.<%=self.config%>.<%=self.sectiontype%>')" title="<%:Move down%>" />
+							<input class="btn cbi-button cbi-button-up" type="button" value="<%:Up%>" onclick="return cbi_row_swap(this, true, 'cbi.sts.<%=self.config%>.<%=self.sectiontype%>')" title="<%:Move up%>" />
+							<input class="btn cbi-button cbi-button-down" type="button" value="<%:Down%>" onclick="return cbi_row_swap(this, false, 'cbi.sts.<%=self.config%>.<%=self.sectiontype%>')" title="<%:Move down%>" />
 						<% end; if self.extedit then -%>
-							<input class="cbi-button cbi-button-edit" type="button" value="<%:Edit%>"
+							<input class="btn cbi-button cbi-button-edit" type="button" value="<%:Edit%>"
 							<%- if type(self.extedit) == "string" then
 							%> onclick="location.href='<%=self.extedit:format(section)%>'"
 							<%- elseif type(self.extedit) == "function" then
@@ -159,7 +159,7 @@ end
 							<%- end
 							%> alt="<%:Edit%>" title="<%:Edit%>" />
 						<% end; if self.addremove then %>
-							<input class="cbi-button cbi-button-remove" type="submit" value="<%:Delete%>"  onclick="this.form.cbi_state='del-section'; return true" name="cbi.rts.<%=self.config%>.<%=k%>" alt="<%:Delete%>" title="<%:Delete%>" />
+							<input class="btn cbi-button cbi-button-remove" type="submit" value="<%:Delete%>"  onclick="this.form.cbi_state='del-section'; return true" name="cbi.rts.<%=self.config%>.<%=k%>" alt="<%:Delete%>" title="<%:Delete%>" />
 						<%- end -%>
 					</div>
 				</div>
@@ -186,7 +186,7 @@ end
 		<% if self.template_addremove then include(self.template_addremove) else -%>
 		<div class="cbi-section-create cbi-tblsection-create">
 			<% if self.anonymous then %>
-				<input class="cbi-button cbi-button-add" type="submit" value="<%:Add%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" title="<%:Add%>" />
+				<input class="btn cbi-button cbi-button-add" type="submit" value="<%:Add%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" title="<%:Add%>" />
 			<% else %>
 				<% if self.invalid_cts then -%>
 					<div class="cbi-section-error"><%:Invalid%></div>
@@ -194,7 +194,7 @@ end
 				<div>
 					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" data-type="uciname" data-optional="true" />
 				</div>
-				<input class="cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
+				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
 			<% end %>
 		</div>
 		<%- end %>

--- a/modules/luci-compat/luasrc/view/cbi/tsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tsection.htm
@@ -13,7 +13,7 @@
 	<% local isempty = true for i, k in ipairs(self:cfgsections()) do -%>
 		<% if self.addremove then -%>
 			<div class="cbi-section-remove right">
-				<input type="submit" name="cbi.rts.<%=self.config%>.<%=k%>" onclick="this.form.cbi_state='del-section'; return true" value="<%:Delete%>" class="cbi-button" />
+				<input type="submit" name="cbi.rts.<%=self.config%>.<%=k%>" onclick="this.form.cbi_state='del-section'; return true" value="<%:Delete%>" class="btn cbi-button" />
 			</div>
 		<%- end %>
 
@@ -36,7 +36,7 @@
 		<% if self.template_addremove then include(self.template_addremove) else -%>
 		<div class="cbi-section-create">
 			<% if self.anonymous then -%>
-				<input type="submit" class="cbi-button cbi-button-add" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" value="<%:Add%>" />
+				<input type="submit" class="btn cbi-button cbi-button-add" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" value="<%:Add%>" />
 			<%- else -%>
 				<% if self.invalid_cts then -%>
 					<div class="cbi-section-error"><%:Invalid%></div>
@@ -44,7 +44,7 @@
 				<div>
 					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." data-type="uciname" data-optional="true" />
 				</div>
-				<input class="cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
+				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
 			<%- end %>
 		</div>
 		<%- end %>

--- a/modules/luci-compat/luasrc/view/cbi/ucisection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/ucisection.htm
@@ -51,6 +51,6 @@
 				<%- end %>
 			</select>
 		<%- end -%>
-		<input type="submit" class="cbi-button cbi-button-fieldadd" value="<%:Add%>" />
+		<input type="submit" class="btn cbi-button cbi-button-fieldadd" value="<%:Add%>" />
 	</div>
 <% end %>


### PR DESCRIPTION
This fixes the view of the buttons, that are still written in lua and therefore use luci-compat.
The buttons do not look nice when using the new luci-theme-openwrt-2020 theme.
Therefore I have added the btn css class to every button input in this pullrequest

Before the change:
![Screenshot_2020-07-20 st-dev-07 - Schnittstellen - LuCI](https://user-images.githubusercontent.com/553091/87949357-358c7200-caa6-11ea-8459-7f1cedb978d7.png)
After the change:
![Screenshot_2020-07-20 st-dev-07 - Richtlinien - LuCI](https://user-images.githubusercontent.com/553091/87949665-9caa2680-caa6-11ea-9f47-ea2ab1a9d4a7.png)
