### PR TITLE
luci-base: fix widgets CBIUserSelect appending list on load

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
@@ -580,6 +580,8 @@ var CBIUserSelect = form.ListValue.extend({
 
 	load: function(section_id) {
 		return getUsers().then(L.bind(function(users) {
+			delete this.keylist;
+			delete this.vallist;
 			for (var i = 0; i < users.length; i++) {
 				this.value(users[i]);
 			}


### PR DESCRIPTION
By using `widgets.UserSelect` the user list is appended to the dropdown again each time the page is loaded.
Although I'm not sure whether this PR is the correct solution to the problem I experienced it is working.

I came across this problem during the implementation of the LuCI xinetd module (https://github.com/openwrt/luci/pull/4178)
when @jow- gave me the hint to use the `widgets.UserSelect` instead of the local realization.