### PR TITLE
luci-app-statistics: use CPU name over Processor

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/cpu.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/cpu.js
@@ -5,7 +5,7 @@
 'require uci';
 
 return baseclass.extend({
-	title: _('Processor'),
+	title: _('CPU'),
 
 	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
 		var p = [];

--- a/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/cpu.json
+++ b/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/cpu.json
@@ -1,5 +1,5 @@
 {
-	"title": "Processor",
+	"title": "CPU",
 	"category": "general",
 	"legend": [
 		[],


### PR DESCRIPTION
This is an RFC PR, if the general idea is acceptable then I'll followup and make the `po` changes for the renamed msgid.

The collectd plugin, tab/list ordering, and storage all use the original
cpu name. This makes the title match the expected plugin name and make
more sense finding it in both the Graphs and Setup pages.