### PR TITLE
luci-app-frpc: correct prop name 'subdomain'

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -50,7 +50,7 @@ var bindInfoConf = [
 
 var domainConf = [
 	[form.Value, 'custom_domains', _('Custom domains')],
-	[form.Value, 'sub_domain', _('Subdomain')],
+	[form.Value, 'subdomain', _('Subdomain')],
 ];
 
 var httpProxyConf = [


### PR DESCRIPTION
https://github.com/fatedier/frp/tree/2406ecdfea62567a576bdb71e38adbafa3b4814a#custom-subdomain-names