### PR TITLE
rpcd-mod-luci: pull dhcp leases from all lease files

### DIFF
--- a/libs/rpcd-mod-luci/Makefile
+++ b/libs/rpcd-mod-luci/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-luci
-PKG_VERSION:=20191114
+PKG_VERSION:=20200729
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Fixes: https://github.com/openwrt/luci/issues/4303

rpcd mod currently only opens one lease file for each of dnsmasq/odhcpd. With this patch, it will open all the files that uci shows.

maintainer: @jow- 
compiled with: openwrt-sdk-19.07.3-ipq806x-generic_gcc-7.5.0_musl_eabi.Linux-x86_64 

Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>