### PR TITLE
luci-app-shadowsocks-libev: local_{ipv4,ipv6}_address for ss_server

### DIFF
--- a/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/shadowsocks-libev.js
+++ b/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/shadowsocks-libev.js
@@ -21,6 +21,7 @@ var names_options_client = [
 ];
 
 var names_options_common = [
+	'local_address',
 	'verbose',
 	'ipv6_first',
 	'fast_open',
@@ -100,13 +101,25 @@ return baseclass.extend({
 			}
 		});
 	},
-	values_ipaddr: function(o, netDevs) {
+	values_ip4addr: function(o, netDevs) {
 		netDevs.forEach(function(v) {
 			v.getIPAddrs().forEach(function(a) {
 				var host = a.split('/')[0];
 				o.value(host, '%s (%s)'.format(host, v.getShortName()));
 			});
 		});
+	},
+	values_ip6addr: function(o, netDevs) {
+		netDevs.forEach(function(v) {
+			v.getIP6Addrs().forEach(function(a) {
+				var host = a.split('/')[0];
+				o.value(host, '%s (%s)'.format(host, v.getShortName()));
+			});
+		});
+	},
+	values_ipaddr: function(o, netDevs) {
+		this.values_ip4addr(o, netDevs)
+		this.values_ip6addr(o, netDevs)
 	},
 	options_client: function(s, tab, netDevs) {
 		var o = s.taboption(tab, form.ListValue, 'server', _('Remote server'));
@@ -191,7 +204,7 @@ return baseclass.extend({
 		if (stype === 'ss_server') {
 			this.cfgvalue_overview_(sdata, lines, names_options_server);
 			this.cfgvalue_overview_(sdata, lines, names_options_common);
-			this.cfgvalue_overview_(sdata, lines, ['bind_address']);
+			this.cfgvalue_overview_(sdata, lines, ['local_ipv4_address', 'local_ipv6_address']);
 		} else if (stype === 'ss_local' || stype === 'ss_redir' || stype === 'ss_tunnel') {
 			this.cfgvalue_overview_(sdata, lines, names_options_client);
 			if (stype === 'ss_tunnel') {

--- a/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js
+++ b/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js
@@ -84,12 +84,21 @@ return view.extend({
 
 					if (stype === 'ss_server') {
 						ss.options_server(s, { tab: 'general' });
-						o = s.taboption('general', form.Value, 'bind_address',
-							_('Bind address'),
-							_('The address ss-server will initiate connection from'));
+						o = s.taboption('advanced', form.Value, 'local_address',
+							_('Local address'),
+							_('The address ss-server will initiate connections from'));
 						o.datatype = 'ipaddr';
-						o.placeholder = '0.0.0.0';
 						ss.values_ipaddr(o, res[1]);
+						o = s.taboption('advanced', form.Value, 'local_ipv4_address',
+							_('Local IPv4 address'),
+							_('The IPv4 address ss-server will initiate IPv4 connections from'));
+						o.datatype = 'ip4addr';
+						ss.values_ip4addr(o, res[1]);
+						o = s.taboption('advanced', form.Value, 'local_ipv6_address',
+							_('Local IPv6 address'),
+							_('The IPv6 address ss-server will initiate IPv6 connections from'));
+						o.datatype = 'ip6addr';
+						ss.values_ip6addr(o, res[1]);
 					} else {
 						ss.options_client(s, 'general', res[1]);
 						if (stype === 'ss_tunnel') {


### PR DESCRIPTION
Following changes are related and included in the same commit

 - Deprecate bind_address by not displaying and handling it in the UI
 - Allow ipv6 address for the old local_address option

Depends on openwrt/packages#12945