### PR TITLE
luci-app-statistics: add users plugin support

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/users.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/users.js
@@ -1,0 +1,23 @@
+/* Licensed to the public under the Apache License 2.0. */
+
+'use strict';
+'require baseclass';
+
+return baseclass.extend({
+	title: _('Users'),
+
+	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
+		return {
+			title: "%H: Users (console logins)",
+			vlabel: "count",
+			data: {
+				types: [ "users" ],
+				options: {
+					users: {
+						title: "Users %di",
+					}
+				}
+			}
+		};
+	}
+});

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/users.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/users.js
@@ -1,0 +1,16 @@
+'use strict';
+'require baseclass';
+'require form';
+
+return baseclass.extend({
+	title: _('Users Plugin Configuration'),
+	description: _('The users plugin collects statistics about users logged in locally via shell. NOTE: Local shell (wtmp) tracking is NOT enabled in default builds. Additional setup is required to get non-zero counts.'),
+
+	addFormOptions: function(s) {
+		var o = s.option(form.Flag, 'enable', _('Enable this plugin'));
+	},
+
+	configSummary: function(section) {
+		return _('Monitoring shell users count');
+	}
+});


### PR DESCRIPTION
The users plugin is functional and useful, but requires usage of custom
built packages of busybox, dropbear, openssh, or other console/shell
access mechanisms.

Signed-off-by: Joel Johnson <mrjoel@lixil.net>