### PR TITLE
[18.06] luci-app-https-dns-proxy: fix bootstrap_dns for cloudflare security

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.security.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.security.lua
@@ -2,7 +2,7 @@ return {
 	name = "Cloudflare-Security",
 	label = _("Cloudflare (Security Protection)"),
 	resolver_url = "https://security.cloudflare-dns.com/dns-query",
-	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001",
+	bootstrap_dns = "1.1.1.2,1.0.0.2,2606:4700:4700::1112,2606:4700:4700::1002",
 	help_link = "https://one.one.one.one/family/",
 	help_link_text = "Cloudflare"
 }


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.net>