### PR TITLE
luci-app-dawn: various minor improvements

### DIFF
--- a/applications/luci-app-dawn/luasrc/controller/dawn.lua
+++ b/applications/luci-app-dawn/luasrc/controller/dawn.lua
@@ -6,6 +6,6 @@ function index()
     e.acl_depends = { "luci-app-dawn" }
 
     entry({ "admin", "dawn", "configure_daemon" }, cbi("dawn/dawn_config"), "Configure DAWN", 1)
-    entry({ "admin", "dawn", "view_network" }, cbi("dawn/dawn_network"), "View Network Overview", 2)
-    entry({ "admin", "dawn", "view_hearing_map" }, cbi("dawn/dawn_hearing_map"), "View Hearing Map", 3)
+    entry({ "admin", "dawn", "view_network" }, cbi("dawn/dawn_network"), "Network Overview", 2)
+    entry({ "admin", "dawn", "view_hearing_map" }, cbi("dawn/dawn_hearing_map"), "Hearing Map", 3)
 end

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
@@ -15,9 +15,9 @@ function s.render(self, sid)
         for name, macs in pairs(stat) do
         %>
         <div class="cbi-section-node">
-	        <h3>SSID: <%= name %></h3>
+        <h3>SSID: <%= name %></h3>
             <div class="table" id="dawn_hearing_map">
-		        <div class="tr table-titles">
+                <div class="tr table-titles">
                     <div class="th">Client MAC</div>
                     <div class="th">AP MAC</div>
                     <div class="th">Frequency</div>
@@ -55,8 +55,8 @@ function s.render(self, sid)
                             <div class="td"><%= "%d" %data2.num_sta %></div>
                             <div class="td"><%= "%d" %data2.score %></div>
                         </div>
-			    <%
-			            count_loop = count_loop + 1
+                <%
+                        count_loop = count_loop + 1
                     end
                 end
                 %>
@@ -65,7 +65,6 @@ function s.render(self, sid)
         <%
         end
         %>
-    </div>
     ]])
 end
 

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
@@ -10,13 +10,14 @@ function s.render(self, sid)
         local utl = require "luci.util"
         local status = require "luci.tools.ieee80211"
         local stat = utl.ubus("dawn", "get_hearing_map", { })
+        local n_ssid = 0
         local name, macs
 
         for name, macs in pairs(stat) do
         %>
         <div class="cbi-section-node">
         <h3>SSID: <%= name %></h3>
-            <div class="table" id="dawn_hearing_map">
+            <div class="table" id="dawn_hearing_map_<%= n_ssid %>">
                 <div class="tr table-titles">
                     <div class="th">Client MAC</div>
                     <div class="th">AP MAC</div>
@@ -63,6 +64,7 @@ function s.render(self, sid)
             </div>
         </div>
         <%
+        n_ssid = n_ssid + 1
         end
         %>
     ]])

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
@@ -14,13 +14,15 @@ function s.render(self, sid)
 		local sys = require "luci.sys"
 		local hosts = sys.net.host_hints()
 		local stat = utl.ubus("dawn", "get_network", { })
+		local n_ssid = 0
 		local name, macs
+
 		for name, macs in pairs(stat) do
 		%>
 
 			<div class="cbi-section-node">
 			<h3>SSID: <%= name %></h3>
-			<div class="table" id=network_overview_main">
+			<div class="table" id="network_overview_main_<%= n_ssid %>">
 				<div class="tr table-titles">
 					<div class="th">AP</div>
 					<div class="th">Clients</div>
@@ -88,6 +90,7 @@ function s.render(self, sid)
 			</div>
 			</div>
 		<%
+		n_ssid = n_ssid + 1
 		end
 		%>
 	]])

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
@@ -73,7 +73,7 @@ function s.render(self, sid)
 									<div class="td"><%= clientmac %></div>
 									<div class="td"><%= (clientvals.ht == true) and "available" or "not available" %></div>
 									<div class="td"><%= (clientvals.vht == true) and "available" or "not available" %></div>
-									<div class="td"><%= "%d" %clientvals.signal %></div>
+									<div class="td"><%= (clientvals.signal ~= nil) and ("%d" %clientvals.signal) or "?" %></div>
 								</div>
 								<%
 								end

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
@@ -9,7 +9,7 @@ function s.render(self, sid)
 	local utl = require "luci.util"
 	tpl.render_string([[
 		<%
-	    local status = require "luci.tools.ieee80211"
+		local status = require "luci.tools.ieee80211"
 		local utl = require "luci.util"
 		local sys = require "luci.sys"
 		local hosts = sys.net.host_hints()
@@ -19,7 +19,7 @@ function s.render(self, sid)
 		%>
 
 			<div class="cbi-section-node">
-	        <h3>SSID: <%= name %></h3>
+			<h3>SSID: <%= name %></h3>
 			<div class="table" id=network_overview_main">
 				<div class="tr table-titles">
 					<div class="th">AP</div>


### PR DESCRIPTION
The patches in this pull request contain a few small improvement to the DAWN app:
* Consistetnly use tabs or spaces in a source file,
* Remove an unbalanced `</div>` that caused the page footer to be rendered in an unexpected way (full screen width),
* Shorten the menu entry titles for consistency with other menus.
* Prevent the network overview from showing "%d" if clientvals.signal does not exist

I've separated out the changes into multiple patches for now, because they all have a different reason to be applied. They can be merged into one patch with a longer description if that would be preferred.