### PR TITLE
luci-base: Fixed delayed portstatus loading on R7800

### DIFF
--- a/modules/luci-base/root/usr/libexec/rpcd/luci
+++ b/modules/luci-base/root/usr/libexec/rpcd/luci
@@ -368,7 +368,7 @@ local methods = {
 						break
 					end
 
-					local pnum = line:match("^Port (%d+):")
+					local pnum = line:match("^Port (%d+):$")
 					if pnum then
 						port = {
 							port = tonumber(pnum),


### PR DESCRIPTION
This PR fixes a bug, visible on LuCI Switch Settings on a Netgear R7800:
When navigating to Network -> Switch everything but the Port Status loads immediately.

This is caused by `getSwconfigPortState` returning more port states than exist, which is caused by a too lax [RegEx](https://github.com/openwrt/luci/blob/6d59a6400ed055d71e0b335679d291c22bbdbd40/modules/luci-base/root/usr/libexec/rpcd/luci#L370).
On a R7800 `swconfig dev switch0 show` (called by `getSwconfigPortState`) returns additional port information (ARP table) as global attributes:
```
root@OpenWrt:~# swconfig dev switch0 show
Global attributes:
	enable_vlan: 1
	[…]	
	arl_table: address resolution table
Port 0: MAC b0:7f:b9:xx:xx:xx
Port 3: MAC b8:27:xx:xx:xx:xx
Port 4: MAC 64:4b:xx:xx:xx:xx
Port 5: MAC 5c:e2:xx:xx:xx:xx
Port 5: MAC 5c:e2:xx:xx:xx:xx
Port 6: MAC f8:2d:xx:xx:xx:xx
Port 6: MAC b0:7f:xx:xx:xx:xx

	igmp_snooping: 0
	igmp_v3: 0
Port 0:
	[…]
        link: port:0 link:up speed:1000baseT full-duplex
Port 1:
	[…]
```
The RegEx mistakenly also matches the ARP table information and therefore returns broken port information (see output below or XHR response in browser). Notice how the ARP information is listed as ports (Port 0, Port 3, Port 4, ...) and after that the actual ports (Port 0, Port 1, ...).
```
root@OpenWrt:~# ubus call luci getSwconfigPortState '{ "switch": "switch0" }'
{
	"result": [
		{
			"duplex": false,
			"port": 0,
			"auto": false,
			"link": false,
			"speed": 0,
			"txflow": false,
			"rxflow": false
		},
		{
			"duplex": false,
			"port": 3,
			"auto": false,
			"link": false,
			"speed": 0,
			"txflow": false,
			"rxflow": false
		},
		{
			"duplex": false,
			"port": 4,
			"auto": false,
			"link": false,
			"speed": 0,
			"txflow": false,
			"rxflow": false
		},
                [...]
		{
			"duplex": true,
			"port": 0,
			"auto": false,
			"link": true,
			"speed": 1000,
			"txflow": false,
			"rxflow": false
		},
		{
			"duplex": false,
			"port": 1,
			"auto": false,
			"link": false,
			"speed": 0,
			"txflow": false,
			"rxflow": false
		},
                [...]
	]
}
```

This is fixed with this PR by ending the RegEx pattern after the colon, so that it´s not longer matching the ARP table, but only the actual port information.

Tested-by: Ansuel Smith <ansuelsmth@gmail.com>
Signed-off-by: Nicolas Thumann <me@n-thumann.de>