### PR TITLE
luci-proto-modemmanger: add missing proto options

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -117,11 +117,22 @@ return network.registerProtocol('modemmanager', {
 		o.value('ipv6', _('IPv6 only'));
 		o.default = 'ipv4v6';
 
+		s.taboption('general', form.Value, 'signalrate', _('Signal refresh rate'));
+
 		o = s.taboption('advanced', form.Value, 'mtu', _('Override MTU'));
 		o.placeholder = dev ? (dev.getMTU() || '1500') : '1500';
 		o.datatype    = 'max(9200)';
 		
 		s.taboption('general', form.Value, 'metric', _('Gateway metric'));
+		
+		s.taboption('advanced', form.Flag, 'debugmode', _('Enable Debugmode'));
 
+		o = s.taboption('advanced', form.ListValue, 'loglevel', _('Log output level'));
+		o.value('ERR', _('Error'))
+		o.value('WARN', _('Warning'));
+		o.value('INFO', _('Info'));
+		o.value('DEBUG', _('Debug'));
+		o.default = 'ERR';
+		
 	}
 });


### PR DESCRIPTION
Added options to luci proto to match Pull request #13009

https://github.com/openwrt/packages/pull/13009