### PR TITLE
luci-app-https-dns-proxy: add AliDNS DoH servers

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua
@@ -1,0 +1,6 @@
+return{
+name="Alidns",
+label=_("Alidns"),
+resolver_url="https://dns.alidns.com/dns-query",
+bootstrap_dns="223.5.5.5,223.6.6.6,2400:3200::1,2400:3200:baba::1"
+}


### PR DESCRIPTION
It's difficult to use Cloudflare or the DNS provided by Google in China, which means that users with https-dns-proxy enabled will have trouble accessing the site properly.

Alibaba Group now offers DoH services to regular users, so I added AliDNS servers to give users located in China the option to use them.

Signed-off-by: Yuan Tao ty@wevs.org