### PR TITLE
luci-app-statistics: remove rrd path double escape

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
@@ -136,7 +136,7 @@ function Graph._generic( self, opts, plugin, plugin_instance, dtype, index )
 	function __def(source)
 
 		local inst = source.sname
-		local rrd  = source.rrd:gsub(":", "\\:")
+		local rrd  = source.rrd
 		local ds   = source.ds
 
 		if not ds or ds:len() == 0 then ds = "value" end


### PR DESCRIPTION
Fixes rendering errors when RRD file names contain IPv6 addresses and the colon (":") characters are double-escaped under OpenWrt 19.07.3.

Before this change, adding an IPv6 address to the `collectd-mod-ping` configuration results in broken "Ping" graph images in Luci when viewing `/cgi-bin/luci/admin/statistics/graph/ping`.

The following messages are written to the system log and can be viewed via `logread | grep "can't parse"`:
```shell
Thu Aug  6 00:35:56 2020 daemon.err uhttpd[1656]: ERROR: can't parse DEF '2ping_avg_raw=/tmp/rrd/OpenWrt/ping/ping-\\:\\:1.rrd:value:AVERAGE' -2
Thu Aug  6 00:35:56 2020 daemon.err uhttpd[1656]: ERROR: can't parse DEF '2ping_droprate_avg_raw=/tmp/rrd/OpenWrt/ping/ping_droprate-\\:\\:1.rrd:value:AVERAGE' -2
Thu Aug  6 00:35:56 2020 daemon.err uhttpd[1656]: ERROR: can't parse DEF '2ping_stddev_avg_raw=/tmp/rrd/OpenWrt/ping/ping_stddev-\\:\\:1.rrd:value:AVERAGE' -2
```

These messages appear to be the result of two conflicting changes which were intended to escape RRD file paths -- #2286 and #2657. This pull request reverts escaping added in #2286 in favor of escaping added in #2657 as the latter is within the `mkrrdpath` function and seems to be the more general and robust escaping approach.

This change has been tested using a VirtualBox image created from the official [19.07.3 x86/64 combined squashfs image](https://downloads.openwrt.org/releases/19.07.3/targets/x86/64/openwrt-19.07.3-x86-64-combined-squashfs.img.gz):
* Install required packages
  ```shell
  opkg update
  opkg install luci-app-statistics collectd-mod-ping
  ```
* Configure Collectd Ping plugin
  ```shell
  uci set luci_statistics.collectd_ping.enable='1'
  uci set luci_statistics.collectd_ping.AddressFamily='any'
  uci set luci_statistics.collectd_ping.Hosts='127.0.0.1 ::1'
  uci commit
  /etc/init.d/luci_statistics restart
  ```
* Verify RRD files have been created with colons in the filename
  ```shell
  find /tmp/rrd/OpenWrt/ping -type f | grep ::1
  ```
* Apply the changes in this pull request to `/usr/lib/lua/luci/statistics/rrdtool.lua`
* Reload the "Ping" graphs in Luci
* Verify the "Ping" graph shows statistics for `127.0.0.1` and `::1`

This change does not merge cleanly against `master` so it is being submitted against the `openwrt-19.07.3` branch instead.