### PR TITLE
treewide: replace `which` with `command -v`

### DIFF
--- a/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
+++ b/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
@@ -179,23 +179,23 @@ local methods = {
 			local cache = {}
 
 			local function has_wget()
-				return (sys.call( [[which wget >/dev/null 2>&1]] ) == 0)
+				return (sys.call( [[command -v wget >/dev/null 2>&1]] ) == 0)
 			end
 
 			local function has_wgetssl()
 				if cache['has_wgetssl'] then return cache['has_wgetssl'] end
-				local res = (sys.call( [[which wget-ssl >/dev/null 2>&1]] ) == 0)
+				local res = (sys.call( [[command -v wget-ssl >/dev/null 2>&1]] ) == 0)
 				cache['has_wgetssl'] = res
 				return res
 			end
 
 			local function has_curlssl()
-				return (sys.call( [[$(which curl) -V 2>&1 | grep -qF "https"]] ) == 0)
+				return (sys.call( [[$(command -v curl) -V 2>&1 | grep -qF "https"]] ) == 0)
 			end
 
 			local function has_fetch()
 				if cache['has_fetch'] then return cache['has_fetch'] end
-				local res = (sys.call( [[which uclient-fetch >/dev/null 2>&1]] ) == 0)
+				local res = (sys.call( [[command -v uclient-fetch >/dev/null 2>&1]] ) == 0)
 				cache['has_fetch'] = res
 				return res
 			end
@@ -206,7 +206,7 @@ local methods = {
 
 			local function has_curl()
 				if cache['has_curl'] then return cache['has_curl'] end
-				local res = (sys.call( [[which curl >/dev/null 2>&1]] ) == 0)
+				local res = (sys.call( [[command -v curl >/dev/null 2>&1]] ) == 0)
 				cache['has_curl'] = res
 				return res
 			end
@@ -216,7 +216,7 @@ local methods = {
 			end
 
 			local function has_bbwget()
-				return (sys.call( [[$(which wget) -V 2>&1 | grep -iqF "busybox"]] ) == 0)
+				return (sys.call( [[$(command -v wget) -V 2>&1 | grep -iqF "busybox"]] ) == 0)
 			end
 
 			res['has_wget'] = has_wget() or false
@@ -229,17 +229,17 @@ local methods = {
 
 			local function has_bindhost()
 				if cache['has_bindhost'] then return cache['has_bindhost'] end
-				local res = (sys.call( [[which host >/dev/null 2>&1]] ) == 0)
+				local res = (sys.call( [[command -v host >/dev/null 2>&1]] ) == 0)
 				if res then
 					cache['has_bindhost'] = res
 					return true
 				end
-				res = (sys.call( [[which khost >/dev/null 2>&1]] ) == 0)
+				res = (sys.call( [[command -v khost >/dev/null 2>&1]] ) == 0)
 				if res then
 					cache['has_bindhost'] = res
 					return true
 				end
-				res = (sys.call( [[which drill >/dev/null 2>&1]] ) == 0)
+				res = (sys.call( [[command -v drill >/dev/null 2>&1]] ) == 0)
 				if res then
 					cache['has_bindhost'] = res
 					return true
@@ -251,11 +251,11 @@ local methods = {
 			res['has_bindhost'] = cache['has_bindhost'] or has_bindhost() or false
 
 			local function has_hostip()
-				return (sys.call( [[which hostip >/dev/null 2>&1]] ) == 0)
+				return (sys.call( [[command -v hostip >/dev/null 2>&1]] ) == 0)
 			end
 
 			local function has_nslookup()
-				return (sys.call( [[which nslookup >/dev/null 2>&1]] ) == 0)
+				return (sys.call( [[command -v nslookup >/dev/null 2>&1]] ) == 0)
 			end
 
 			res['has_dnsserver'] = cache['has_bindhost'] or has_nslookup() or has_hostip() or has_bindhost() or false

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua
@@ -664,8 +664,8 @@ elseif action == "logs" then
 elseif action == "console" then
 	m.submit = false
 	m.reset  = false
-	local cmd_docker = luci.util.exec("which docker"):match("^.+docker") or nil
-	local cmd_ttyd = luci.util.exec("which ttyd"):match("^.+ttyd") or nil
+	local cmd_docker = luci.util.exec("command -v docker"):match("^.+docker") or nil
+	local cmd_ttyd = luci.util.exec("command -v ttyd"):match("^.+ttyd") or nil
 
 	if cmd_docker and cmd_ttyd and container_info.State.Status == "running" then
 		local cmd = "/bin/sh"
@@ -697,8 +697,8 @@ elseif action == "console" then
 			Button.render(self, section, scope)
 		end
 		o.write = function(self, section)
-			local cmd_docker = luci.util.exec("which docker"):match("^.+docker") or nil
-			local cmd_ttyd = luci.util.exec("which ttyd"):match("^.+ttyd") or nil
+			local cmd_docker = luci.util.exec("command -v docker"):match("^.+docker") or nil
+			local cmd_ttyd = luci.util.exec("command -v ttyd"):match("^.+ttyd") or nil
 
 			if not cmd_docker or not cmd_ttyd or cmd_docker:match("^%s+$") or cmd_ttyd:match("^%s+$")then
 				return

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
@@ -41,18 +41,18 @@ track_ip.datatype = "host"
 track_method = mwan_interface:option(ListValue, "track_method", translate("Tracking method"))
 track_method.default = "ping"
 track_method:value("ping")
-if os.execute("which nping 1>/dev/null") == 0 then
+if os.execute("command -v nping 1>/dev/null") == 0 then
 	track_method:value("nping-tcp")
 	track_method:value("nping-udp")
 	track_method:value("nping-icmp")
 	track_method:value("nping-arp")
 end
 
-if os.execute("which arping 1>/dev/null") == 0 then
+if os.execute("command -v arping 1>/dev/null") == 0 then
 	track_method:value("arping")
 end
 
-if os.execute("which httping 1>/dev/null") == 0 then
+if os.execute("command -v httping 1>/dev/null") == 0 then
 	track_method:value("httping")
 end
 

--- a/build/i18n-init.sh
+++ b/build/i18n-init.sh
@@ -4,7 +4,7 @@ PATTERN=$1
 SCM=
 
 [ -d .svn ] && SCM="svn"
-git=$( which git 2>/dev/null )
+git=$( command -v git 2>/dev/null )
 [ "$git" ] && "$git" status >/dev/null && SCM="git"
 
 [ -z "$SCM" ] && {

--- a/libs/luci-lib-nixio/src/Makefile
+++ b/libs/luci-lib-nixio/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(OS),SunOS)
 endif
 
 ifneq (,$(findstring MINGW,$(OS))$(findstring mingw,$(OS))$(findstring Windows,$(OS)))
-	NIXIO_CROSS_CC:=$(shell which i586-mingw32msvc-cc)
+	NIXIO_CROSS_CC:=$(shell command -v i586-mingw32msvc-cc)
 ifneq (,$(NIXIO_CROSS_CC))
 	CC:=$(NIXIO_CROSS_CC)
 endif


### PR DESCRIPTION
Fix shellcheck SC2230
> which is non-standard. Use builtin 'command -v' instead.

Once applied to everything concerning OpenWrt we can disable the busybox
feature `which` and save 3.8kB.

Signed-off-by: Paul Spooren <mail@aparcar.org>