### PR TITLE
luci-app-mwan3: rulconfig variable name refactoring and dependency fixes

### DIFF
--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
@@ -33,17 +33,6 @@ o:value("info", translate("Info"))
 o:value("debug", translate("Debug"))
 o:depends("logging", "1")
 
-o = s:option(Value, "rtmon_interval",
-	translate("Update interval"),
-	translate("How often should rtmon update the interface routing table"))
-o.datatype = "integer"
-o.default = "5"
-o:value("1", translatef("%d second", 1))
-o:value("3", translatef("%d seconds", 3))
-o:value("5", translatef("%d seconds", 5))
-o:value("7", translatef("%d seconds", 7))
-o:value("10", translatef("%d seconds", 10))
-
 o = s:option(DynamicList, "rt_table_lookup",
 	translate("Routing table lookup"),
 	translate("Also scan this Routing table for connected networks"))

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
@@ -37,8 +37,6 @@ o = s:option(DynamicList, "rt_table_lookup",
 	translate("Routing table lookup"),
 	translate("Also scan this Routing table for connected networks"))
 o.datatype = "integer"
-o:value("1", translatef("Routing table %d", 1))
-o:value("2", translatef("Routing table %d", 2))
 o:value("220", translatef("Routing table %d", 220))
 
 return m

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
@@ -13,7 +13,7 @@ o = s:option(Value, "mmx_mask",
 	translate("Firewall mask"),
 	translate("Enter value in hex, starting with <code>0x</code>"))
 o.datatype = "hex(4)"
-o.default = "0xff00"
+o.default = "0x3F00"
 
 o = s:option(Flag, "logging",
 	translate("Logging"),

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/globalsconfig.lua
@@ -3,61 +3,53 @@
 
 local net = require "luci.model.network".init()
 
-local s, m, mask, rtmon, rtlookup, logging, loglevel
+local s, m, o
 
 m = Map("mwan3", translate("MWAN - Globals"))
 
 s = m:section(NamedSection, "globals", "globals", nil)
 
-mask = s:option(
-	Value,
-	"mmx_mask",
+o = s:option(Value, "mmx_mask",
 	translate("Firewall mask"),
 	translate("Enter value in hex, starting with <code>0x</code>"))
-mask.datatype = "hex(4)"
-mask.default = "0xff00"
+o.datatype = "hex(4)"
+o.default = "0xff00"
 
-logging = s:option(Flag,
-	"logging",
+o = s:option(Flag, "logging",
 	translate("Logging"),
 	translate("Enables global firewall logging"))
 
-loglevel = s:option(
-	ListValue,
-	"loglevel",
+o = s:option(ListValue, "loglevel",
 	translate("Loglevel"),
 	translate("Firewall loglevel"))
-loglevel.default = "notice"
-loglevel:value("emerg", translate("Emergency"))
-loglevel:value("alert", translate("Alert"))
-loglevel:value("crit", translate("Critical"))
-loglevel:value("error", translate("Error"))
-loglevel:value("warning", translate("Warning"))
-loglevel:value("notice", translate("Notice"))
-loglevel:value("info", translate("Info"))
-loglevel:value("debug", translate("Debug"))
-loglevel:depends("logging", "1")
+o.default = "notice"
+o:value("emerg", translate("Emergency"))
+o:value("alert", translate("Alert"))
+o:value("crit", translate("Critical"))
+o:value("error", translate("Error"))
+o:value("warning", translate("Warning"))
+o:value("notice", translate("Notice"))
+o:value("info", translate("Info"))
+o:value("debug", translate("Debug"))
+o:depends("logging", "1")
 
-rtmon = s:option(
-	Value,
-	"rtmon_interval",
+o = s:option(Value, "rtmon_interval",
 	translate("Update interval"),
 	translate("How often should rtmon update the interface routing table"))
-rtmon.datatype = "integer"
-rtmon.default = "5"
-rtmon:value("1", translatef("%d second", 1))
-rtmon:value("3", translatef("%d seconds", 3))
-rtmon:value("5", translatef("%d seconds", 5))
-rtmon:value("7", translatef("%d seconds", 7))
-rtmon:value("10", translatef("%d seconds", 10))
+o.datatype = "integer"
+o.default = "5"
+o:value("1", translatef("%d second", 1))
+o:value("3", translatef("%d seconds", 3))
+o:value("5", translatef("%d seconds", 5))
+o:value("7", translatef("%d seconds", 7))
+o:value("10", translatef("%d seconds", 10))
 
-rtlookup = s:option(DynamicList,
-	"rt_table_lookup",
+o = s:option(DynamicList, "rt_table_lookup",
 	translate("Routing table lookup"),
 	translate("Also scan this Routing table for connected networks"))
-rtlookup.datatype = "integer"
-rtlookup:value("1", translatef("Routing table %d", 1))
-rtlookup:value("2", translatef("Routing table %d", 2))
-rtlookup:value("220", translatef("Routing table %d", 220))
+o.datatype = "integer"
+o:value("1", translatef("Routing table %d", 1))
+o:value("2", translatef("Routing table %d", 2))
+o:value("220", translatef("Routing table %d", 220))
 
 return m

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua
@@ -140,8 +140,7 @@ m = Map("mwan3", translate("MWAN - Interfaces"),
 	interfaceWarnings(configCheck()))
 
 mwan_interface = m:section(TypedSection, "interface", nil,
-	translate("MWAN supports up to 252 physical and/or logical interfaces<br />" ..
-	"MWAN requires that all interfaces have a unique metric configured in /etc/config/network<br />" ..
+	translate("mwan3 requires that all interfaces have a unique metric configured in /etc/config/network<br />" ..
 	"Names must match the interface name found in /etc/config/network<br />" ..
 	"Names may contain characters A-Z, a-z, 0-9, _ and no spaces<br />" ..
 	"Interfaces may not share the same name as configured members, policies or rules"))

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
@@ -30,6 +30,8 @@ o.datatype = ipaddr
 
 o = s:option(Value, "src_port", translate("Source port"),
 	translate("May be entered as a single or multiple port(s) (eg \"22\" or \"80,443\") or as a portrange (eg \"1024:2048\") without quotes"))
+o:depends("proto", "tcp")
+o:depends("proto", "udp")
 
 o = s:option(Value, "dest_ip", translate("Destination address"),
 	translate("Supports CIDR notation (eg \"192.168.100.0/24\") without quotes"))
@@ -37,6 +39,8 @@ o.datatype = ipaddr
 
 o = s:option(Value, "dest_port", translate("Destination port"),
 	translate("May be entered as a single or multiple port(s) (eg \"22\" or \"80,443\") or as a portrange (eg \"1024:2048\") without quotes"))
+o:depends("proto", "tcp")
+o:depends("proto", "udp")
 
 o = s:option(Value, "proto", translate("Protocol"),
 	translate("View the content of /etc/protocols for protocol description"))

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
@@ -18,6 +18,12 @@ s = m:section(NamedSection, arg[1], "rule", "")
 s.addremove = false
 s.dynamic = false
 
+o = s:option(ListValue, "family", translate("Internet Protocol"))
+o.default = ""
+o:value("", translate("IPv4 and IPv6"))
+o:value("ipv4", translate("only IPv4"))
+o:value("ipv6", translate("only IPv6"))
+
 o = s:option(Value, "src_ip", translate("Source address"),
 	translate("Supports CIDR notation (eg \"192.168.100.0/24\") without quotes"))
 o.datatype = ipaddr

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
@@ -5,8 +5,7 @@
 local dsp = require "luci.dispatcher"
 local util   = require("luci.util")
 
-local m, mwan_rule, src_ip, src_port, dest_ip, dest_port, proto, sticky
-local timeout, ipset, logging, policy
+local m, s, o
 
 arg[1] = arg[1] or ""
 
@@ -15,62 +14,62 @@ local ipsets = util.split(util.trim(util.exec("ipset -n -L 2>/dev/null | grep -v
 m = Map("mwan3", translatef("MWAN Rule Configuration - %s", arg[1]))
 m.redirect = dsp.build_url("admin", "network", "mwan", "rule")
 
-mwan_rule = m:section(NamedSection, arg[1], "rule", "")
-mwan_rule.addremove = false
-mwan_rule.dynamic = false
+s = m:section(NamedSection, arg[1], "rule", "")
+s.addremove = false
+s.dynamic = false
 
-src_ip = mwan_rule:option(Value, "src_ip", translate("Source address"),
+o = s:option(Value, "src_ip", translate("Source address"),
 	translate("Supports CIDR notation (eg \"192.168.100.0/24\") without quotes"))
-src_ip.datatype = ipaddr
+o.datatype = ipaddr
 
-src_port = mwan_rule:option(Value, "src_port", translate("Source port"),
+o = s:option(Value, "src_port", translate("Source port"),
 	translate("May be entered as a single or multiple port(s) (eg \"22\" or \"80,443\") or as a portrange (eg \"1024:2048\") without quotes"))
 
-dest_ip = mwan_rule:option(Value, "dest_ip", translate("Destination address"),
+o = s:option(Value, "dest_ip", translate("Destination address"),
 	translate("Supports CIDR notation (eg \"192.168.100.0/24\") without quotes"))
-dest_ip.datatype = ipaddr
+o.datatype = ipaddr
 
-dest_port = mwan_rule:option(Value, "dest_port", translate("Destination port"),
+o = s:option(Value, "dest_port", translate("Destination port"),
 	translate("May be entered as a single or multiple port(s) (eg \"22\" or \"80,443\") or as a portrange (eg \"1024:2048\") without quotes"))
 
-proto = mwan_rule:option(Value, "proto", translate("Protocol"),
+o = s:option(Value, "proto", translate("Protocol"),
 	translate("View the content of /etc/protocols for protocol description"))
-proto.default = "all"
-proto.rmempty = false
-proto:value("all")
-proto:value("tcp")
-proto:value("udp")
-proto:value("icmp")
-proto:value("esp")
+o.default = "all"
+o.rmempty = false
+o:value("all")
+o:value("tcp")
+o:value("udp")
+o:value("icmp")
+o:value("esp")
 
-sticky = mwan_rule:option(ListValue, "sticky", translate("Sticky"),
+o = s:option(ListValue, "sticky", translate("Sticky"),
 	translate("Traffic from the same source IP address that previously matched this rule within the sticky timeout period will use the same WAN interface"))
-sticky.default = "0"
-sticky:value("1", translate("Yes"))
-sticky:value("0", translate("No"))
+o.default = "0"
+o:value("1", translate("Yes"))
+o:value("0", translate("No"))
 
-timeout = mwan_rule:option(Value, "timeout", translate("Sticky timeout"),
+o = s:option(Value, "timeout", translate("Sticky timeout"),
 	translate("Seconds. Acceptable values: 1-1000000. Defaults to 600 if not set"))
-timeout.datatype = "range(1, 1000000)"
+o.datatype = "range(1, 1000000)"
 
-ipset = mwan_rule:option(Value, "ipset", translate("IPset"),
+o = s:option(Value, "ipset", translate("IPset"),
 	translate("Name of IPset rule. Requires IPset rule in /etc/dnsmasq.conf (eg \"ipset=/youtube.com/youtube\")"))
-ipset:value("", translate("-- Please choose --"))
+o:value("", translate("-- Please choose --"))
 for _, z in ipairs(ipsets) do
-	ipset:value(z)
+	o:value(z)
 end
 
-logging = mwan_rule:option(Flag, "logging", translate("Logging"),
+o = s:option(Flag, "logging", translate("Logging"),
 	translate("Enables firewall rule logging (global mwan3 logging must also be enabled)"))
 
-policy = mwan_rule:option(Value, "use_policy", translate("Policy assigned"))
+o = s:option(Value, "use_policy", translate("Policy assigned"))
 m.uci:foreach("mwan3", "policy",
 	function(s)
-		policy:value(s['.name'], s['.name'])
+		o:value(s['.name'], s['.name'])
 	end
 )
-policy:value("unreachable", translate("unreachable (reject)"))
-policy:value("blackhole", translate("blackhole (drop)"))
-policy:value("default", translate("default (use main routing table)"))
+o:value("unreachable", translate("unreachable (reject)"))
+o:value("blackhole", translate("blackhole (drop)"))
+o:value("default", translate("default (use main routing table)"))
 
 return m


### PR DESCRIPTION
- Use standard LuCI variable name for map, section and option as m, s and o
- Add missing family selection on rulconfig (any | IPv4 | IPv6) if any is selected the rule is applied to IPv4 and IPv6
- Add dependency to port option. This is only valid if proto is tcp or udp