### PR TITLE
protocols: add legacymap option for map

### DIFF
--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js
@@ -92,5 +92,7 @@ return network.registerProtocol('map', {
 		o = s.taboption('advanced', form.Value, 'mtu', _('Use MTU on tunnel interface'));
 		o.placeholder = '1280';
 		o.datatype    = 'max(9200)';
+
+		o = s.taboption('advanced', form.Flag, 'legacymap', _('Use legacy MAP'), _('Use legacy MAP interface identifier format (draft-ietf-softwire-map-00) instead of RFC7597'));
 	}
 });


### PR DESCRIPTION
legacymap causes map to use the legacy IPv6 Interface Identifier format
that was described in draft-ietf-softwire-map-00, but was eventually
changed in RFC7597. It is however still used by some major ISPs,
including in Japan.

Signed-off-by: Remi NGUYEN VAN <remi.nguyenvan+openwrt@gmail.com>