### PR TITLE
luci-app-statistics: remove rrd path triple escape

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool.js
@@ -376,7 +376,7 @@ return baseclass.extend({
 
 		function __def(source) {
 			var inst = source.sname,
-			    rrd  = source.rrd.replace(/[\\:]/g, '\\$&'),
+			    rrd  = source.rrd,
 			    ds   = source.ds || 'value';
 
 			_args.push(


### PR DESCRIPTION
Fixes rendering errors when RRD file names contain IPv6 addresses and the colon (":") characters are triple escaped.

Adapts the Lua-specific fix in #4340 to Javascript as suggested by @hnyman.

This is the change was tested using a VirtualBox image created from the [`r14184-eadb1a9437` snapshot x86/64 squashfs combined image](https://downloads.openwrt.org/snapshots/targets/x86/64/openwrt-x86-64-generic-squashfs-combined.img.gz):
* Install required packages
  ```shell
  opkg update
  opkg install luci-app-statistics collectd-mod-ping uhttpd luci-theme-bootstrap
  ```
* Configure Collectd Ping plugin
  ```shell
  uci set luci_statistics.collectd_ping.enable='1'
  uci set luci_statistics.collectd_ping.AddressFamily='any'
  uci set luci_statistics.collectd_ping.Hosts='127.0.0.1 ::1'
  uci commit
  /etc/init.d/luci_statistics restart
  ```
* Verify RRD files have been created with colons in the filename
  ```shell
  find /tmp/rrd/OpenWrt/ping -type f | grep ::1
  ```
* Apply the changes in this pull request to `/www/luci-static/resources/statistics/rrdtool.js`
* Disable browser cache using browser's developer tools
* Reload the "Ping" graphs in Luci
* Verify the "Ping" graph shows statistics for `127.0.0.1` and `::1`

Before applying this fix, `logread` did not show any error messages suggesting this fix was needed and the `POST` to `/cgi-bin/cgi-exec?...` returned an empty `200 OK` response rather than an error. The only clue that there was excessive escaping was in the form data's `command` parameter value where the path appeared to be triple escaped:
```
/usr/bin/rrdtool graph - -a PNG -s NOW-1hour -e NOW-60 -w 840 -h 100 -t OpenWrt:\ ICMP\ Round\ Trip\ Time -v ms DEF:1ping_avg_raw=/tmp/rrd/OpenWrt/ping/ping-127.0.0.1.rrd:value:AVERAGE CDEF:1ping_avg=1ping_avg_raw,0,+ CDEF:1ping_nnl=1ping_avg,UN,0,1ping_avg,IF DEF:2ping_avg_raw=/tmp/rrd/OpenWrt/ping/ping-\\\\\\:\\\\\\:1.rrd:value:AVERAGE CDEF:2ping_avg=2ping_avg_raw,0,+ CDEF:2ping_nnl=2ping_avg,UN,0,2ping_avg,IF CDEF:2ping_stk=2ping_nnl CDEF:2ping_plot=2ping_avg CDEF:1ping_stk=1ping_nnl CDEF:1ping_plot=1ping_avg LINE2:1ping_plot#0158e8:127.0.0.1 GPRINT:1ping_avg:AVERAGE:\	Avg\\:\ %5.1lf\ ms GPRINT:1ping_avg:LAST:\	Last\\:\ %5.1lf\ ms\\l LINE2:2ping_plot#cbc714:\\:\\:1\ \ \ \  GPRINT:2ping_avg:AVERAGE:\	Avg\\:\ %5.1lf\ ms GPRINT:2ping_avg:LAST:\	Last\\:\ %5.1lf\ ms\\l
```

Since the `command` parameter value includes escapes for semicolons outside of the IPv6 RRD file path, it seems that double escaping of the path is the intended behavior.