### PR TITLE
luasrc luci-app-advanced-reboot: support Linksys MR8300

### DIFF
--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-mr8300.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-mr8300.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "MR8300",
+	boardNames = { "linksys-mr8300", "linksys,mr8300" },
+	partition1MTD = "mtd10",
+	partition2MTD = "mtd12",
+	labelOffset = 192,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}


### PR DESCRIPTION
Adding support for the Linksys MR8300 (clone of EA8300 but with 512MB RAM)

Tested on MR8300

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>