### PR TITLE
luci-app-advanced-reboot: support for Linksys MR8300

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -12,7 +12,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 	routers are listed at https://github.com/openwrt/luci/blob/master/applications/luci-app-advanced-reboot/README.md
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=54
+PKG_RELEASE:=55
 
 include ../../luci.mk
 


### PR DESCRIPTION
Adding support for the Linksys MR8300 (clone of EA8300 but with 512MB RAM)

Tested on MR8300

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>