### PR TITLE
luci-app-advanced-reboot: support for Linksys MR8300

### DIFF
--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -14,6 +14,7 @@ Currently supported dual-partition devices include:
 - Linksys EA6350v3
 - Linksys EA8300
 - Linksys EA8500
+- Linksys MR8300
 - Linksys WRT1200AC
 - Linksys WRT1900AC
 - Linksys WRT1900ACv2


### PR DESCRIPTION
Adding support for the Linksys MR8300 (clone of EA8300 but with 512MB RAM)

Tested on MR8300

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>