### PR TITLE
luci-app-advanced-reboot: support for Linksys MR8300

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -12,7 +12,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 	routers are listed at https://github.com/openwrt/luci/blob/master/applications/luci-app-advanced-reboot/README.md
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=54
+PKG_RELEASE:=55
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -14,6 +14,7 @@ Currently supported dual-partition devices include:
 - Linksys EA6350v3
 - Linksys EA8300
 - Linksys EA8500
+- Linksys MR8300
 - Linksys WRT1200AC
 - Linksys WRT1900AC
 - Linksys WRT1900ACv2

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-mr8300.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-mr8300.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "MR8300",
+	boardNames = { "linksys-mr8300", "linksys,mr8300" },
+	partition1MTD = "mtd10",
+	partition2MTD = "mtd12",
+	labelOffset = 192,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}


### PR DESCRIPTION
Adding support for the Linksys MR8300 (clone of EA8300 but with 512MB RAM)

Tested on MR8300

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>