### PR TITLE
luci-base: Add possiblity to set path and timeout of ubus connection

### DIFF
--- a/libs/luci-lib-base/luasrc/util.lua
+++ b/libs/luci-lib-base/luasrc/util.lua
@@ -663,9 +663,9 @@ local function ubus_return(...)
 	return ...
 end
 
-function ubus(object, method, data)
+function ubus(object, method, data, path, timeout)
 	if not _ubus_connection then
-		_ubus_connection = _ubus.connect()
+		_ubus_connection = _ubus.connect(path, timeout)
 		assert(_ubus_connection, "Unable to establish ubus connection")
 	end
 


### PR DESCRIPTION
It might happen (e.g. when downloading a large file with low speed connection) that the ubus connection will time out.
The ubus_connect function allows to specify ubus socket path and ubus connection timeout so it should allowed to set these arguments from luci.
