### PR TITLE
protocols: rename type to maptype for map

### DIFF
--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js
@@ -40,7 +40,7 @@ return network.registerProtocol('map', {
 	renderFormOptions: function(s) {
 		var o;
 
-		o = s.taboption('general', form.ListValue, 'type', _('Type'));
+		o = s.taboption('general', form.ListValue, 'maptype', _('Type'));
 		o.value('map-e', 'MAP-E');
 		o.value('map-t', 'MAP-T');
 		o.value('lw4o6', 'LW4over6');


### PR DESCRIPTION
"type" is already used as a common option for all protocols. This makes
the configuration ambiguous, and Luci sees JS errors when trying to save
a MAP configuration.

Switch to "maptype" instead to avoid the conflict. MAP currently uses
"maptype" and falls back to "type" when not specified.

Signed-off-by: Remi NGUYEN VAN <remi.nguyenvan+openwrt@gmail.com>