### PR TITLE
luci-app-ddns: fix wrong service with custom selected

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -486,7 +486,7 @@ return L.view.extend({
 		o.value('-',"-- " + _("custom") + " --");
 
 		o.cfgvalue = function(section_id) {
-			return uci.get('ddns', section_id, 'service_name');
+			return uci.get('ddns', section_id, 'service_name') || '-';
 		}
 
 		o.write = function(section_id, formvalue) {


### PR DESCRIPTION
If custom service is selected, no service is actually set in the uci config.
Fallback to custom service if no service is detected in the config.

Fixes #4301

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

@jow- 