### PR TITLE
luci-app-advanced-reboot: Correct board name for linksys-ea3500 (to match updating naming approach)

### DIFF
--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea3500.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea3500.lua
@@ -1,7 +1,7 @@
 return {
 	vendorName = "Linksys",
 	deviceName = "EA3500",
-	boardNames = { "linksys-audi", "linksys,audi" },
+	boardNames = { "linksys-ea3500", "linksys,ea3500" },
 	partition1MTD = "mtd3",
 	partition2MTD = "mtd5",
 	labelOffset = 32,

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
@@ -42,12 +42,12 @@
 				<%- if bev1p1 == current_partition then -%>
 				<form method="post" action="<%=url('admin/system/advanced_reboot/reboot')%>">
 					<input type="hidden" name="token" value="<%=token%>" />
-					<input id="reboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to current partition%>" />
+					<input id="reboot-button" type="submit" class="btn cbi-button cbi-button-apply important" value="<%:Reboot to current partition%>" />
 				</form>
 			<%- else -%>
 			<form method="post" action="<%=url('admin/system/advanced_reboot/alternative_reboot')%>">
 				<input type="hidden" name="token" value="<%=token%>" />
-				<input id="altreboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to alternative partition...%>" />
+				<input id="altreboot-button" type="submit" class="btn cbi-button cbi-button-apply important" value="<%:Reboot to alternative partition...%>" />
 			</form>
 				<%- end -%>
 			</div>
@@ -66,12 +66,12 @@
 				<%- if bev1p2 == current_partition then -%>
 					<form method="post" action="<%=url('admin/system/advanced_reboot/reboot')%>">
 						<input type="hidden" name="token" value="<%=token%>" />
-						<input id="reboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to current partition%>" />
+						<input id="reboot-button" type="submit" class="btn cbi-button cbi-button-apply important" value="<%:Reboot to current partition%>" />
 					</form>
 				<%- else -%>
 				<form method="post" action="<%=url('admin/system/advanced_reboot/alternative_reboot')%>">
 					<input type="hidden" name="token" value="<%=token%>" />
-					<input id="altreboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to alternative partition...%>" />
+					<input id="altreboot-button" type="submit" class="btn cbi-button cbi-button-apply important" value="<%:Reboot to alternative partition...%>" />
 				</form>
 				<%- end -%>
 			</div>
@@ -91,7 +91,7 @@
 <%- if nixio.fs.access("/sbin/poweroff") then -%>
 <form method="post" action="<%=url('admin/system/advanced_reboot/power_off')%>">
 	<input type="hidden" name="token" value="<%=token%>" />
-	<input id="poweroff-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Perform power off...%>" />
+	<input id="poweroff-button" type="submit" class="btn cbi-button cbi-button-apply important" value="<%:Perform power off...%>" />
 </form>
 <%- else -%>
 	<p class="alert-message warning"><%:Warning: This system does not support powering off!%></p>

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm
@@ -21,8 +21,8 @@
 	<form class="inline" action="<%=REQUEST_URI%>" method="post">
 		<input type="hidden" name="token" value="<%=token%>" />
 		<input type="hidden" name="step" value="2" />
-		<input class="cbi-button cbi-button-reset important" name="cancel" type="submit" value="<%:Cancel%>" />
-		<input class="cbi-button cbi-button-apply important" type="submit" value="<%:Proceed%>" />
+		<input class="btn cbi-button cbi-button-reset important" name="cancel" type="submit" value="<%:Cancel%>" />
+		<input class="btn cbi-button cbi-button-apply important" type="submit" value="<%:Proceed%>" />
 	</form>
 </div>
 

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm
@@ -17,8 +17,8 @@
 	<form class="inline" action="<%=REQUEST_URI%>" method="post">
 		<input type="hidden" name="token" value="<%=token%>" />
 		<input type="hidden" name="step" value="2" />
-		<input class="cbi-button cbi-button-reset important" name="cancel" type="submit" value="<%:Cancel%>" />
-		<input class="cbi-button cbi-button-apply important" type="submit" value="<%:Proceed%>" />
+		<input class="btn cbi-button cbi-button-reset important" name="cancel" type="submit" value="<%:Cancel%>" />
+		<input class="btn cbi-button cbi-button-apply important" type="submit" value="<%:Proceed%>" />
 	</form>
 </div>
 


### PR DESCRIPTION
Tested - corrects failure in advanced-reboot, due to updated board naming (i.e. link below),
https://forum.openwrt.org/t/advanced-reboot-warning-unable-to-obtain-device-information/72276/2
