### PR TITLE
luci-mod-admin-full: fix fstab get device by uuid

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
@@ -155,7 +155,7 @@ dev.cfgvalue = function(self, section)
 	local v, e
 
 	v = m.uci:get("fstab", section, "uuid")
-	e = v and devices[v:lower()]
+	e = v and devices[v]
 	if v and e and e.size then
 		return "UUID: %s (%s, %d MB)" %{ tp.pcdata(v), e.dev, e.size }
 	elseif v and e then


### PR DESCRIPTION
UUID is uppercased in NTFS, fstab page always say "not present" because it looks up by lowercased one

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>