### PR TITLE
luci-app-travelmate: fix uci wireless permission

### DIFF
--- a/applications/luci-app-travelmate/root/usr/share/rpcd/acl.d/luci-app-travelmate.json
+++ b/applications/luci-app-travelmate/root/usr/share/rpcd/acl.d/luci-app-travelmate.json
@@ -2,10 +2,10 @@
 	"luci-app-travelmate": {
 		"description": "Grant UCI access for luci-app-travelmate",
 		"read": {
-			"uci": [ "travelmate" ]
+			"uci": [ "travelmate", "wireless" ]
 		},
 		"write": {
-			"uci": [ "travelmate" ]
+			"uci": [ "travelmate", "wireless" ]
 		}
 	}
 }


### PR DESCRIPTION
add uci read/write permissions to make luci-app-travelmate work with luci master, since travelmate needs to write /etc/config/wireless