### PR TITLE
luci-ssl: switch to WolfSSL

### DIFF
--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2016 The LuCI Team
+# Copyright (C) 2008-2020 The LuCI Team
 #
 # This is free software, licensed under the Apache License, Version 2.0 .
 #
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
-LUCI_TITLE:=LuCI with HTTPS support (mbedTLS as SSL backend)
-LUCI_DEPENDS:=+luci +libustream-mbedtls +px5g
+LUCI_TITLE:=LuCI with HTTPS support (WolfSSL as SSL backend)
+LUCI_DEPENDS:=+luci +libustream-wolfssl +px5g-wolfssl
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
OpenWrt installs WolfSSL per default to offer WPA3. To save some space
switch to a WolfSSL based px5g implementation for self-signed
certificate generation instead of a MbedTLS version.

Signed-off-by: Paul Spooren <mail@aparcar.org>