### PR TITLE
[19.07] luci-app-opkg: flush menu cache after opkg actions

### DIFF
--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -775,6 +775,9 @@ function handleOpkg(ev)
 				E('div', {
 					'class': 'btn',
 					'click': L.bind(function(res) {
+						if (L.ui.menu && L.ui.menu.flushCache)
+							L.ui.menu.flushCache();
+
 						L.hideModal();
 						updateLists();
 


### PR DESCRIPTION
This is a partial backport of dc57e4bc6c83d6c869c318256057e3636bfc5d66

Fixes: #4077

Signed-off-by: Baptiste Jonglez <git@bitsofnetworks.org>