### PR TITLE
luci-app-statistics: add noavg option

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool.js
@@ -516,7 +516,8 @@ return baseclass.extend({
 				_args.push('GPRINT:%s_min:MIN:\tMin\\: %s'.format(source.sname, numfmt));
 
 			/* always include AVERAGE */
-			_args.push('GPRINT:%s_avg:AVERAGE:\tAvg\\: %s'.format(source.sname, numfmt));
+			if (!source.noavg)
+				_args.push('GPRINT:%s_avg:AVERAGE:\tAvg\\: %s'.format(source.sname, numfmt));
 
 			/* don't include MAX if rrasingle is enabled */
 			if (!gopts.rrasingle)
@@ -605,6 +606,7 @@ return baseclass.extend({
 						overlay: dopts.overlay || false,
 						transform_rpn: dopts.transform_rpn || '0,+',
 						noarea: dopts.noarea || false,
+						noavg: dopts.noavg || false,
 						title: dopts.title || null,
 						weight: dopts.weight || (dopts.negweight ? -+data_instances[j] : null) || (dopts.posweight ? +data_instances[j] : null) || null,
 						ds: data_sources[k],


### PR DESCRIPTION
It is sometimes useful not to display avg values int the graph.
This option is used to prevent this from appearing in the graph.
In a graph definition this option must be set to *true*,
 if the avg values should not be displayed.

```
options = {
	gauge = {
		title = "Status",
		color = "0000ff",
		noarea = true,
		noavg = true
	}
```