### PR TITLE
luci-app-advanced-reboot: add support for linksys mr8300

### DIFF
--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -15,6 +15,7 @@ Currently supported dual-partition devices include:
 - Linksys EA4500
 - Linksys EA6350v3
 - Linksys EA8300
+- Linksys MR8300
 - Linksys EA8500
 - Linksys WRT1200AC
 - Linksys WRT1900AC

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-mr8300.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-mr8300.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "MR8300",
+	boardNames = { "linksys-mr8300", "linksys,mr8300" },
+	partition1MTD = "mtd10",
+	partition2MTD = "mtd12",
+	labelOffset = 192,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}


### PR DESCRIPTION
Adding Pre-emptive support for Linksys MR8300 based on Linksys EA8300. PR for MR8300 will be submitted soon after.

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>

Tested and confirmed working properly Linksys MR8300 using Master