### PR TITLE
luci-app-ttyd: rename menu entry to terminal

### DIFF
--- a/applications/luci-app-ttyd/root/usr/share/luci/menu.d/luci-app-ttyd.json
+++ b/applications/luci-app-ttyd/root/usr/share/luci/menu.d/luci-app-ttyd.json
@@ -1,6 +1,6 @@
 {
 	"admin/services/ttyd": {
-		"title": "ttyd",
+		"title": "Terminal",
 		"action": {
 			"type": "firstchild"
 		},


### PR DESCRIPTION
Nobody can do anything with the title ttyd.
To make it more meaningful the menu entry is renamed to Terminal.