### PR TITLE
luci-lib-ip: fix tolinklocal invalid ipv6 result

### DIFF
--- a/libs/luci-lib-ip/src/ip.c
+++ b/libs/luci-lib-ip/src/ip.c
@@ -837,6 +837,12 @@ static int cidr_tolinklocal(lua_State *L)
 	p2->bits = AF_BITS(AF_INET6);
 	p2->addr.u8[0] = 0xFE;
 	p2->addr.u8[1] = 0x80;
+	p2->addr.u8[2] = 0x00;
+	p2->addr.u8[3] = 0x00;
+	p2->addr.u8[4] = 0x00;
+	p2->addr.u8[5] = 0x00;
+	p2->addr.u8[6] = 0x00;
+	p2->addr.u8[7] = 0x00;
 	p2->addr.u8[8] = p1->addr.u8[0] ^ 0x02;
 	p2->addr.u8[9] = p1->addr.u8[1];
 	p2->addr.u8[10] = p1->addr.u8[2];


### PR DESCRIPTION
The bug can be reproduced with the following script at least in qemu and mips.
```
local ip = require("luci.ip")
for i = 1,10,1 do
    print(ip.MAC('a8:40:41:1c:aa:aa'):tolinklocal())
end
```
```
root@node:~# lua linklocak.lua 
fe80:736f:2f:6970:aa40:41ff:fe1c:aaaa
fe80:2f6c:7561:2f6c:aa40:41ff:fe1c:aaaa
fe80:bc90::aa40:41ff:fe1c:aaaa
fe80:272e:2f6c:7563:aa40:41ff:fe1c:aaaa
fe80:4::aa40:41ff:fe1c:aaaa
fe80:4::aa40:41ff:fe1c:aaaa
fe80:31::111:aa40:41ff:fe1c:aaaa
fe80:a09:6e6f:2066:aa40:41ff:fe1c:aaaa
fe80::aa40:41ff:fe1c:aaaa
fe80::aa40:41ff:fe1c:aaaa
```