### PR TITLE
master: mosquitto: support notifications_local_only flag

### DIFF
--- a/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
+++ b/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
@@ -161,6 +161,7 @@ OptionalFlag(s, "cleansession", _("Clean session"))
 OptionalFlag(s, "notifications", _("notifications"),
     _("Attempt to notify the local and remote broker of connection status, defaults to $SYS/broker/connections/<clientid>/state"))
 s:option(Value, "notification_topic", _("Topic to use for local+remote remote for notifications.")).optional = true
+OptionalFlag(s, "notification_local_only", _("Notifications local only"), _("Bridge connection states should only be published locally"))
 
 s:option(Value, "remote_clientid", _("Client id to use on remote end of this bridge connection")).optional = true
 s:option(Value, "local_clientid", _("Client id to use locally. Important when bridging to yourself")).optional = true


### PR DESCRIPTION
Supported since mosquitto 1.5 released in May 2018, and has long
been supported in the init scripts.

Signed-off-by: Karl Palsson <karlp@etactica.com>