### PR TITLE
luci-base: make translatable default values for dhcp hostname

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
+++ b/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
@@ -21,8 +21,8 @@ return network.registerProtocol('dhcp', {
 
 		o = s.taboption('general', form.Value, 'hostname', _('Hostname to send when requesting DHCP'));
 		o.default = '';
-		o.value('', 'Send the hostname of this device');
-		o.value('*', 'Do not send a hostname');
+		o.value('', _('Send the hostname of this device'));
+		o.value('*', _('Do not send a hostname'));
 		o.datatype    = 'or(hostname, "*")';
 		o.load = function(section_id) {
 			return callFileRead('/proc/sys/kernel/hostname').then(L.bind(function(hostname) {


### PR DESCRIPTION
We must be able to translate these values.

Fixes: fd75c2b7c ("luci-base: add default value options dhcp hostname")
Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>