### PR TITLE
[19.07] luci-app-simple-adblock: support for config auto-update

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=49
+PKG_RELEASE:=50
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua
@@ -8,17 +8,23 @@ end
 
 function simple_adblock_action(name)
 	local packageName = "simple-adblock"
+	local http = require "luci.http"
+	local sys = require "luci.sys"
+	local uci = require "luci.model.uci".cursor()
+	local util = require "luci.util"
 	if name == "start" then
-		luci.sys.init.start(packageName)
+		sys.init.start(packageName)
 	elseif name == "action" then
-		luci.util.exec("/etc/init.d/" .. packageName .. " dl >/dev/null 2>&1")
+		util.exec("/etc/init.d/" .. packageName .. " dl >/dev/null 2>&1")
 	elseif name == "stop" then
-		luci.sys.init.stop(packageName)
+		sys.init.stop(packageName)
 	elseif name == "enable" then
-		luci.util.exec("uci set " .. packageName .. ".config.enabled=1; uci commit " .. packageName)
+		uci:set(packageName, "config", "enabled", "1")
+		uci:commit(packageName)
 	elseif name == "disable" then
-		luci.util.exec("uci set " .. packageName .. ".config.enabled=0; uci commit " .. packageName)
+		uci:set(packageName, "config", "enabled", "0")
+		uci:commit(packageName)
 	end
-	luci.http.prepare_content("text/plain")
-	luci.http.write("0")
+	http.prepare_content("text/plain")
+	http.write("0")
 end

--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
@@ -153,7 +153,9 @@ errorTable["errorRestoreCache"] = translatef("failed to move '%s' to '%s'", outp
 errorTable["errorOhSnap"] = translate("failed to create block-list or restart DNS resolver")
 errorTable["errorStopping"] = translatef("failed to stop %s", packageName)
 errorTable["errorDNSReload"] = translate("failed to reload/restart DNS resolver")
+errorTable["errorDownloadingConfigUpdate"] = translate("failed to download Config Update file")
 errorTable["errorDownloadingList"] = translate("failed to download")
+errorTable["errorParsingConfigUpdate"] = translate("failed to parse Config Update file")
 errorTable["errorParsingList"] = translate("failed to parse")
 errorTable["errorNoSSLSupport"] = translate("no HTTPS/SSL support on device")
 
@@ -228,6 +230,11 @@ end
 s = m:section(NamedSection, "config", "simple-adblock", translate("Configuration"))
 -- General options
 s:tab("basic", translate("Basic Configuration"))
+
+o1 = s:taboption("basic", ListValue, "config_update_enabled", translate("Automatic Config Update"), translate("Perform config update before downloading the block/allow-lists."))
+o1:value("0", translate("Disable"))
+o1:value("1", translate("Enable"))
+o1.default = 0
 
 o2 = s:taboption("basic", ListValue, "verbosity", translate("Output Verbosity Setting"), translate("Controls system log and console output verbosity."))
 o2:value("0", translate("Suppress output"))

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -1,15 +1,15 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:217
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:219
 msgid "%s Error: %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:215
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:217
 msgid "%s Error: %s %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:200
 msgid "%s is blocking %s domains (with %s)."
 msgstr ""
 
@@ -17,120 +17,125 @@ msgstr ""
 msgid "%s is not installed or not found"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:290
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:297
 msgid "Add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:295
 msgid "Add IPv6 entries to block-list."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:258
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:337
 msgid "Allowed Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:332
 msgid "Allowed Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:323
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
 msgid "Allowed and Blocked Lists Management"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:319
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:230
-msgid "Basic Configuration"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
-msgid "Blocked Domain URLs"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
-msgid "Blocked Domains"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
-msgid "Blocked Hosts URLs"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
-msgid "Cache file containing %s domains found."
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
-msgid "Collected Errors"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:192
-msgid "Compressed cache file found."
-msgstr ""
-
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:228
-msgid "Configuration"
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
+msgid "Automatic Config Update"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+msgid "Basic Configuration"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:347
+msgid "Blocked Domain URLs"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:342
+msgid "Blocked Domains"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:352
+msgid "Blocked Hosts URLs"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:190
+msgid "Cache file containing %s domains found."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:210
+msgid "Collected Errors"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:194
+msgid "Compressed cache file found."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:230
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
 msgid "Controls system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:303
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:310
 msgid "Curl download retry"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:281
 msgid "DNS Service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:276
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:283
 msgid "DNSMASQ Additional Hosts"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:277
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
 msgid "DNSMASQ Config"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:279
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:286
 msgid "DNSMASQ IP Set"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:281
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
 msgid "DNSMASQ Servers File"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:295
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:302
 msgid "Delay (in seconds) for on-boot start"
 msgstr ""
 
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:235
 #: applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm:68
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:318
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:289
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:296
 msgid "Do not add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:313
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:320
 msgid "Do not store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:315
 msgid "Do not use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:299
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:306
 msgid "Download time-out (in seconds)"
 msgstr ""
 
@@ -138,16 +143,17 @@ msgstr ""
 msgid "Downloading"
 msgstr ""
 
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
 #: applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm:65
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:319
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:324
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:326
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:324
 msgid "Enables debug output to /tmp/simple-adblock.log."
 msgstr ""
 
@@ -167,52 +173,56 @@ msgstr ""
 msgid "Force Reloading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:245
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:240
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:245
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
+#: applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json:3
+msgid "Grant UCI and file access for luci-app-simple-adblock"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:295
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:303
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:310
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:332
 msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:342
 msgid "Individual domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:190
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:192
 msgid "Info"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:249
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:256
 msgid "LED to indicate status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:307
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:314
 msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:246
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
@@ -220,30 +230,34 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:203
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:205
 msgid "Message"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:260
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
+msgid "Perform config update before downloading the block/allow-lists."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:267
 msgid ""
 "Pick the DNS resolution option to create the adblock list for, see the <a "
 "href=\"%s#dns-resolution-option\" target=\"_blank\">README</a> for details."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:250
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:257
 msgid "Pick the LED not already used in %sSystem LED Configuration%s."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:263
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:264
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:266
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:268
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:270
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:271
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:272
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:273
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:275
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:278
 msgid "Please note that %s is not supported on this system."
 msgstr ""
 
@@ -251,17 +265,17 @@ msgstr ""
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:295
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:302
 msgid "Run service after set delay on boot."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:195
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:174
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:184
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:197
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:166
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:168
 msgid "Service Status [%s %s]"
 msgstr ""
 
@@ -269,15 +283,15 @@ msgstr ""
 msgid "Simple AdBlock"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:160
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:162
 msgid "Simple AdBlock Settings"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:307
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:314
 msgid "Simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:241
 msgid "Some output"
 msgstr ""
 
@@ -293,7 +307,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:299
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:306
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
@@ -301,11 +315,11 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:314
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:321
 msgid "Store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:319
 msgid "Store compressed cache file on router"
 msgstr ""
 
@@ -313,35 +327,35 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:233
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:240
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:178
 msgid "Task"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:337
 msgid "URLs to lists of domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:347
 msgid "URLs to lists of domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:352
 msgid "URLs to lists of hosts to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:291
 msgid "Unbound AdBlock List"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:309
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:316
 msgid "Use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:235
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:242
 msgid "Verbose output"
 msgstr ""
 
@@ -365,8 +379,12 @@ msgstr ""
 msgid "failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:156
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
 msgid "failed to download"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:156
+msgid "failed to download Config Update file"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:147
@@ -385,8 +403,12 @@ msgstr ""
 msgid "failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:159
 msgid "failed to parse"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:158
+msgid "failed to parse Config Update file"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:146
@@ -417,10 +439,10 @@ msgstr ""
 msgid "failed to unpack compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:158
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:160
 msgid "no HTTPS/SSL support on device"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:252
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:259
 msgid "none"
 msgstr ""

--- a/applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json
+++ b/applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json
@@ -21,6 +21,9 @@
 				"/usr/sbin/dnsmasq *": [
 					"exec"
 				],
+				"/usr/sbin/unbound *": [
+					"exec"
+				],
 				"/usr/sbin/ipset *": [
 					"exec"
 				]


### PR DESCRIPTION
Also small tweaks for controller and ACL. Dependent on https://github.com/openwrt/packages/pull/13434.

Signed-off-by: Stan Grishin <stangri@melmac.net>