### PR TITLE
luci-app-advanced-reboot: Advanced Reboot support for Linksys EA7300 v2

### DIFF
--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -14,6 +14,7 @@ Currently supported dual-partition devices include:
 - Linksys E4200v2
 - Linksys EA4500
 - Linksys EA6350v3
+- Linksys EA7300v2
 - Linksys EA8300
 - Linksys MR8300
 - Linksys EA8500

--- a/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea7300.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/advanced-reboot/devices/linksys-ea7300.lua
@@ -1,0 +1,14 @@
+return {
+	vendorName = "Linksys",
+	deviceName = "EA7300v2",
+	boardNames = { "linksys,ea7300-v2" },
+	partition1MTD = "mtd5",
+	partition2MTD = "mtd7",
+	labelOffset = 32,
+	bootEnv1 = "boot_part",
+	bootEnv1Partition1Value = 1,
+	bootEnv1Partition2Value = 2,
+	bootEnv2 = nil,
+	bootEnv2Partition1Value = nil,
+	bootEnv2Partition2Value = nil
+}


### PR DESCRIPTION
Add support for new (recently supported) hardware. Image with this change in place,

![image](https://user-images.githubusercontent.com/8756384/94754305-82b67b00-0356-11eb-9f83-b1041d083028.png)

Thanks!