### PR TITLE
luci-app-firewall: rules: add ICMPv6 Packet Too Big (Type 2)

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
@@ -308,6 +308,7 @@ return view.extend({
 		o.value('network-redirect');
 		o.value('network-unknown');
 		o.value('network-unreachable');
+		o.value('packet-too-big');
 		o.value('parameter-problem');
 		o.value('port-unreachable');
 		o.value('precedence-cutoff');


### PR DESCRIPTION
The "Match ICMP type" drop-down menu was missing this ICMPv6 type. According to RFC 4890 section 4.3.1 it is essential for communications and must not be dropped. This patch allows for doing this through LuCI.