### PR TITLE
luci-mod-status: add support for add device to wifi black/whitelist

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1414,6 +1414,23 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 	outline: 0;
 }
 
+.cbi-dropdown.btn {
+	min-height: 1.8rem;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	padding-right: 0px;
+}
+
+.cbi-dropdown.btn > .open {
+	font-size: 0.8rem;
+	padding: 0px;
+	margin: 0 5px;
+}
+
+.cbi-dropdown.btn > div {
+	margin: 0px;
+}
+
 .cbi-dropdown > .more,
 .cbi-dropdown > ul > li[placeholder] {
 	font-weight: bold;


### PR DESCRIPTION
Add support for one-click add device to wifi black/whitelist in the status page. If the black/whitelist feature is enabled a combobox is displayed with the disconnect option.
Device already added will display only the disconnect button.

Fixes: #3675

@jow-  Another easy UTOPIA task ahahha

The first commit is needed since  theme-material have a display bug that show all the combo box bigger than expected....
(is problematic with the new introduced combobox in the wifi row)
![Immagine 2020-10-10 010050](https://user-images.githubusercontent.com/20289090/95638241-31179a00-0a94-11eb-8af1-ce4d75e8d542.jpg)

Also is there a way to make the disconnect button display first?
