### PR TITLE
luci-mod-network: diagnostics.js: don't pass IP version flag to ping6

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
@@ -28,7 +28,7 @@ return view.extend({
 	handlePing: function(ev, cmd) {
 		var exec = cmd || 'ping',
 		    addr = ev.currentTarget.parentNode.previousSibling.value,
-		    args = (exec == 'ping') ? [ '-4', '-c', '5', '-W', '1', addr ] : [ '-6', '-c', '5', addr ];
+		    args = (exec == 'ping') ? [ '-4', '-c', '5', '-W', '1', addr ] : [ '-c', '5', addr ];
 
 		return this.handleCommand(exec, args);
 	},


### PR DESCRIPTION
Passing "-6" to ping6 from the iputils package will lead to the
following error:
	"ping6: only one -4 or -6 option may be specified"

It does not make sense either.

Fixes: 547776327a71 ("luci-mod-network: diagnostics.js: pass IP version flag to ping/ping6")
Signed-off-by: Martin Schiller <ms@dev.tdt.de>