### PR TITLE
Set the fallback default of rollback timeout to 90s

### DIFF
--- a/applications/luci-app-dockerman/luasrc/view/dockerman/apply_widget.htm
+++ b/applications/luci-app-dockerman/luasrc/view/dockerman/apply_widget.htm
@@ -44,7 +44,7 @@
 
 <script type="text/javascript">//<![CDATA[
 	var xhr = new XHR(),
-	uci_apply_rollback = <%=math.max(luci.config and luci.config.apply and luci.config.apply.rollback or 30, 30)%>,
+	uci_apply_rollback = <%=math.max(luci.config and luci.config.apply and luci.config.apply.rollback or 90, 90)%>,
 	uci_apply_holdoff = <%=math.max(luci.config and luci.config.apply and luci.config.apply.holdoff or 4, 1)%>,
 	uci_apply_timeout = <%=math.max(luci.config and luci.config.apply and luci.config.apply.timeout or 5, 1)%>,
 	uci_apply_display = <%=math.max(luci.config and luci.config.apply and luci.config.apply.display or 1.5, 1)%>,

--- a/modules/luci-base/luasrc/model/uci.lua
+++ b/modules/luci-base/luasrc/model/uci.lua
@@ -123,10 +123,10 @@ function apply(self, rollback)
 	if rollback then
 		local sys = require "luci.sys"
 		local conf = require "luci.config"
-		local timeout = tonumber(conf and conf.apply and conf.apply.rollback or 30) or 0
+		local timeout = tonumber(conf and conf.apply and conf.apply.rollback or 90) or 0
 
 		_, err = call("apply", {
-			timeout = (timeout > 30) and timeout or 30,
+			timeout = (timeout > 90) and timeout or 90,
 			rollback = true
 		})
 

--- a/modules/luci-base/luasrc/view/header.htm
+++ b/modules/luci-base/luasrc/view/header.htm
@@ -29,7 +29,7 @@
 		ubuspath       = luci.config.main.ubuspath or '/ubus/',
 		sessionid      = luci.dispatcher.context.authsession,
 		nodespec       = luci.dispatcher.context.dispatched,
-		apply_rollback = math.max(applyconf and applyconf.rollback or 30, 30),
+		apply_rollback = math.max(applyconf and applyconf.rollback or 90, 90),
 		apply_holdoff  = math.max(applyconf and applyconf.holdoff or 4, 1),
 		apply_timeout  = math.max(applyconf and applyconf.timeout or 5, 1),
 		apply_display  = math.max(applyconf and applyconf.display or 1.5, 1),


### PR DESCRIPTION
cc @jow- @feckert 

luci-base & luci-app-dockerman: set the fallback default of rollback timeout to 90s

Set the fallback value of the config change rollback timeout to 90 seconds to match the change in /etc/config/luci by commit 81cf99a50.

That commit changed the default value in the config file, but did not change the underlying fallback values that do get applied when there is no proper config item in etc/config/luci.

Users sysupgrading from old systems may have carried an ancient /etc/config/luci (without rollback config) with them, so this change should help them to see the intended user experience of 90 seconds instead of 30 seconds that may be too short e.g. for wifi changes.

Related to forum discussion at https://forum.openwrt.org/t/luci-changing-wifi-config-results-in-timeout/77104/9

Ps.
The luci-base part should also be backported to 19.07.
