### PR TITLE
luci-base: Fix using isActive in widget-change notification.

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -3351,10 +3351,10 @@ var CBIValue = CBIAbstractValue.extend(/** @lends LuCI.form.Value.prototype */ {
 			optionEl.classList.add('hidden');
 
 		optionEl.addEventListener('widget-change',
-			L.bind(this.handleValueChange, this, section_id, {}));
+			L.bind(this.map.checkDepends, this.map));
 
 		optionEl.addEventListener('widget-change',
-			L.bind(this.map.checkDepends, this.map));
+			L.bind(this.handleValueChange, this, section_id, {}));
 
 		dom.bindClassInstance(optionEl, this);
 


### PR DESCRIPTION
The `onchange` notification handler is called too early to be able to evaluate other widget's `isActive()` status. Solve this by changing order of event handling - first register/execute `map.checkDepends` and then `onchange`.

Fixes: openwrt/luci#4516.