### PR TITLE
luci-base/luci-compat: Replace legend element with h3.

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2219,7 +2219,7 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 			});
 
 		if (this.title != null && this.title != '')
-			sectionEl.appendChild(E('legend', {}, this.title));
+			sectionEl.appendChild(E('h3', {}, this.title));
 
 		if (this.description != null && this.description != '')
 			sectionEl.appendChild(E('div', { 'class': 'cbi-section-descr' }, this.description));
@@ -3138,7 +3138,7 @@ var CBINamedSection = CBIAbstractSection.extend(/** @lends LuCI.form.NamedSectio
 			});
 
 		if (typeof(this.title) === 'string' && this.title !== '')
-			sectionEl.appendChild(E('legend', {}, this.title));
+			sectionEl.appendChild(E('h3', {}, this.title));
 
 		if (typeof(this.description) === 'string' && this.description !== '')
 			sectionEl.appendChild(E('div', { 'class': 'cbi-section-descr' }, this.description));

--- a/modules/luci-compat/luasrc/view/cbi/nsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/nsection.htm
@@ -1,7 +1,7 @@
 <% if self:cfgvalue(self.section) then section = self.section %>
 	<div class="cbi-section">
 		<% if self.title and #self.title > 0 then -%>
-			<legend><%=self.title%></legend>
+			<h3><%=self.title%></h3>
 		<%- end %>
 		<% if self.description and #self.description > 0 then -%>
 			<div class="cbi-section-descr"><%=self.description%></div>
@@ -19,7 +19,7 @@
 	<% if self.template_addremove then include(self.template_addremove) else -%>
 	<div class="cbi-section" id="cbi-<%=self.config%>-<%=self.section%>">
 		<% if self.title and #self.title > 0 then -%>
-			<legend><%=self.title%></legend>
+			<h3><%=self.title%></h3>
 		<%- end %>
 		<div class="cbi-section-descr"><%=self.description%></div>
 		<input type="submit" class="btn cbi-button cbi-button-add" name="cbi.cns.<%=self.config%>.<%=self.section%>" value="<%:Add%>" />

--- a/modules/luci-compat/luasrc/view/cbi/nullsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/nullsection.htm
@@ -1,6 +1,6 @@
 <div class="cbi-section">
 	<% if self.title and #self.title > 0 then -%>
-		<legend><%=self.title%></legend>
+		<h3><%=self.title%></h3>
 	<%- end %>
 	<% if self.description and #self.description > 0 then -%>
 		<div class="cbi-section-descr"><%=self.description%></div>

--- a/modules/luci-compat/luasrc/view/cbi/tsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tsection.htm
@@ -1,6 +1,6 @@
 <div class="cbi-section" id="cbi-<%=self.config%>-<%=self.sectiontype%>">
 	<% if self.title and #self.title > 0 then -%>
-		<legend><%=self.title%></legend>
+		<h3><%=self.title%></h3>
 	<%- end %>
 	<% if self.error_msg and #self.error_msg > 0 then -%>
 		<div class="cbi-section-error">

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -754,7 +754,6 @@ fieldset > fieldset,
 	border-bottom: thin solid #eee;
 }
 
-.cbi-section > h3:first-child,
 .cbi-section > h4:first-child,
 .cbi-section > p:first-child,
 [data-tab-title] > h3:first-child,
@@ -2547,6 +2546,7 @@ input[name="nslookup"] {
 		padding: .2rem .5rem;
 	}
 
+	.cbi-section > h3:first-child,
 	.panel-title {
 		font-size: 1.1rem;
 		padding-bottom: 1rem;
@@ -2951,6 +2951,7 @@ input[name="nslookup"] {
 		display: none;
 	}
 
+	.cbi-section > h3:first-child,
 	.panel-title {
 		font-size: 1.4rem;
 		padding-bottom: 1rem;


### PR DESCRIPTION
The `legend` HTML element is allowed only as first element in `fieldset`, so use `h3` instead, which is rendered the same within themes.

Fixes #3149.