### PR TITLE
luci-app-sqm: fix missing interface in selection

### DIFF
--- a/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
+++ b/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
@@ -68,7 +68,7 @@ return view.extend({
 			return uci.set("sqm", section, "enabled", value);
 		}, this);
 
-		o = s.taboption("tab_basic", widgets.NetworkSelect, "interface", _("Interface name"));
+		o = s.taboption("tab_basic", widgets.DeviceSelect, "interface", _("Interface name"));
 		o.rmempty = false;
 
 		o = s.taboption("tab_basic", form.Value, "download", _("Download speed (kbit/s) (ingress) set to 0 to selectively disable ingress shaping:"));


### PR DESCRIPTION
Show device instead of interface in interface selection.

Fixes: #4539
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>