### PR TITLE
luci-app-transmission: add dependency for transmission-daemon

### DIFF
--- a/applications/luci-app-transmission/Makefile
+++ b/applications/luci-app-transmission/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Support for Transmission
-LUCI_DEPENDS:=
+LUCI_DEPENDS:=+transmission-daemon
 
 include ../../luci.mk
 


### PR DESCRIPTION
In recent changes in packages feed
(https://github.com/openwrt/packages/commit/56e4edad82211c14528122566f56168f1bee0fd8),
there were removed variants, so if you will install
luci-app-transmission now, it will pull also transmission-daemon
and users do not need to install it separately.

Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>