### PR TITLE
luci-app-bmx7: fix displaying values

### DIFF
--- a/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/admin_status/index/bmx7_nodes.htm
+++ b/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/admin_status/index/bmx7_nodes.htm
@@ -20,7 +20,7 @@
 
 <script type="text/javascript" src="<%=resource%>/bmx7/js/polling.js"></script>
 <script type="text/javascript">//<![CDATA[
-		new TablePooler(10,"/cgi-bin/bmx7-info", {'$originators':''}, "nodes_div", function(st){
+		new TablePooler(10,"/cgi-bin/bmx7-info", {'originators':''}, "nodes_div", function(st){
 			var originators = st.originators;
 			var res = Array();
 			originators.forEach(function(originator,i){

--- a/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/bmx7/nodes_j.htm
+++ b/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/bmx7/nodes_j.htm
@@ -92,7 +92,7 @@
 		var displayExtraInfo = function ( id ) {
 			document.getElementById('extra-info').innerHTML = document.getElementById(id).innerHTML;
 		}
-		new TablePooler(5,"/cgi-bin/bmx7-info", {'$originators':''}, "nodes_div", function(st){
+		new TablePooler(5,"/cgi-bin/bmx7-info", {'originators':''}, "nodes_div", function(st){
 			var infoicon = "<%=resource%>/bmx7/world_small.png";
 			var originators = st.originators;
 			var res = Array();

--- a/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/bmx7/status_j.htm
+++ b/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/bmx7/status_j.htm
@@ -88,14 +88,14 @@
 </div>
 
 <script type="text/javascript">//<![CDATA[
-	new TablePooler(1,"/cgi-bin/bmx7-info", {'$info':''}, "config_div", function(st){
+	new TablePooler(10,"/cgi-bin/bmx7-info", {'info':''}, "config_div", function(st){
 		var res = Array();
 		var sta = st.info[0].status;
 		res.push([sta.shortId, sta.name, sta.primaryIp, sta.nodeKey, sta.shortDhash, sta.revision]);
 		return res;
 	});
 
-	new TablePooler(1,"/cgi-bin/bmx7-info", {'$info':''}, "status_div", function(st){
+	new TablePooler(10,"/cgi-bin/bmx7-info", {'info':''}, "status_div", function(st){
 		var res = Array();
 		var sta = st.info[0].status;
 		var mem = st.info[3].memory.bmx7;
@@ -105,7 +105,7 @@
 		return res;
 	});
 
-	new TablePooler(1,"/cgi-bin/bmx7-info", {'$info':''}, "ifaces_div", function(st){
+	new TablePooler(10,"/cgi-bin/bmx7-info", {'info':''}, "ifaces_div", function(st){
 		var res = Array();
 		var ifaces = st.info[1].interfaces;
 
@@ -115,7 +115,7 @@
 		return res;
 	});
 
-	new TablePooler(1,"/cgi-bin/bmx7-info", {'$info':''}, "links_div", function(st){
+	new TablePooler(10,"/cgi-bin/bmx7-info", {'info':''}, "links_div", function(st){
 		var res = Array();
 		links = st.info[2].links;
 

--- a/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/bmx7/tunnels_j.htm
+++ b/applications/luci-app-bmx7/root/usr/lib/lua/luci/view/bmx7/tunnels_j.htm
@@ -51,7 +51,7 @@
 </div>
 
 <script type="text/javascript">//<![CDATA[
-		new TablePooler(5,"/cgi-bin/bmx7-info", {'$tunnels':''}, "tunnels_div", function(st){
+		new TablePooler(5,"/cgi-bin/bmx7-info", {'tunnels':''}, "tunnels_div", function(st){
         var tunicon = "<%=resource%>/icons/tunnel.png";
         var tunicon_dis = "<%=resource%>/icons/tunnel_disabled.png";
         var applyicon = "<%=resource%>/cbi/apply.gif";

--- a/applications/luci-app-bmx7/root/www/cgi-bin/bmx7-info
+++ b/applications/luci-app-bmx7/root/www/cgi-bin/bmx7-info
@@ -90,7 +90,7 @@ if [ "${QUERY##*/}" == "all" ]; then
 	QALL=1
 fi
 
-if [ "$QUERY" == '$info' ]; then
+if [ "$QUERY" == 'info' ]; then
 	echo '{ "info": [ '
 	print_query status
 	echo -n ","
@@ -100,7 +100,7 @@ if [ "$QUERY" == '$info' ]; then
 	echo "] }"
 fi
 
-if [ "$QUERY" == '$neighbours' ]; then
+if [ "$QUERY" == 'neighbours' ]; then
 	QALL=1
 	echo '{ "neighbours": [ '
 	echo '{ "originators": '
@@ -111,11 +111,11 @@ if [ "$QUERY" == '$neighbours' ]; then
 	echo "} ] }"
 	exit 0
 
-else if [ "$QUERY" == '$tunnels' ]; then
+else if [ "$QUERY" == 'tunnels' ]; then
 	bmx7 -c --jshow tunnels /r=0
 	exit 0
 
-	else if [ "$QUERY" == '$originators' ]; then
+	else if [ "$QUERY" == 'originators' ]; then
 		bmx7 -c --jshow originators /r=0
 		exit 0
 


### PR DESCRIPTION
nice to see luci-app-bmx7, but nothing goes except the topology sub-page.
here is a fix for all other status pages. modern webbrowsers do convert the $ to %24.
info-page is reloaded too much atm, so i delayed it.

p.s. do i have to pull-request this for openwrt-1907 repo too? would be a nice small test for opkg upgrade

Signed-off-by: FreifunkUFO ufo@rund.freifunk.net

see also: https://github.com/openwrt/luci/pull/4144 as first try to fix this bug some months ago