### PR TITLE
luci-base: add new duid datatype

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -272,6 +272,11 @@ var ValidatorFactory = baseclass.extend({
 				_('valid IPv6 prefix value (0-128)'));
 		},
 
+		duid: function() {
+			var hex = this.value.replace(/:/g, '');
+			return this.assert(this.apply('rangelength', hex, [20, 36]) && this.apply('hexstring', hex), _('valid DUID'));
+		},
+
 		cidr: function() {
 			return this.assert(this.apply('cidr4') || this.apply('cidr6'), _('valid IPv4 or IPv6 CIDR'));
 		},

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -496,7 +496,7 @@ return view.extend({
 		so.rmempty = true;
 
 		so = ss.option(form.Value, 'duid', _('<abbr title="The DHCP Unique Identifier">DUID</abbr>'));
-		so.datatype = 'and(rangelength(20,36),hexstring)';
+		so.datatype = 'duid';
 		Object.keys(duids).forEach(function(duid) {
 			so.value(duid, '%s (%s)'.format(duid, duids[duid].hostname || duids[duid].macaddr || duids[duid].ip6addr || '?'));
 		});


### PR DESCRIPTION
Useful to validate duid that can contains colon and should be checked without.

@jow-  should we fix the generated dropdown or investigate why we can find some value with colon from the start instead of a new type?

Fixes: #4543
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>