### PR TITLE
luci-app-xinetd: fix problem app not appearing in menu if config is e…

### DIFF
--- a/applications/luci-app-xinetd/root/usr/share/luci/menu.d/luci-app-xinetd.json
+++ b/applications/luci-app-xinetd/root/usr/share/luci/menu.d/luci-app-xinetd.json
@@ -7,8 +7,7 @@
 			"path": "xinetd/xinetd"
 		},
 		"depends": {
-			"acl": [ "luci-app-xinetd" ],
-			"uci": { "xinetd": true }
+			"acl": [ "luci-app-xinetd" ]
 		}
 	}
 }


### PR DESCRIPTION
If the uci config (/etc/config/xinetd) doesn't contain any information, e.g. an empty file if the last section had been cleared,
the app is no more shown in the main menu of LuCI.

This has been fixed
