### PR TITLE
luci-proto-wireguard: change allowed range of mtu

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -95,7 +95,7 @@ return network.registerProtocol('wireguard', {
 		o.optional = true;
 
 		o = s.taboption('advanced', form.Value, 'mtu', _('MTU'), _('Optional. Maximum Transmission Unit of tunnel interface.'));
-		o.datatype = 'range(1280,1420)';
+		o.datatype = 'range(0,8940)';
 		o.placeholder = '1420';
 		o.optional = true;
 


### PR DESCRIPTION
`range(1280,1420)` => `range(0,8940)`
default value 1420 keeps unchanged
fix #4282