### PR TITLE
luci-proto-gre: remove extra parenthesis

### DIFF
--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
@@ -79,7 +79,7 @@ return network.registerProtocol('grev6', {
 		o = s.taboption('advanced', form.Value, 'tos', _("Traffic Class"), _("Specify a Traffic Class. Can be <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value <code>00..FF</code> (optional)."));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i)))
+			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i))
 				return _("Invalid Traffic Class value, expected 00..FF or inherit");
 
 			return true;


### PR DESCRIPTION
fix the following error:
SyntaxError
Unexpected token ')'
  in http://192.168.122.131/luci-static/resources/protocol/grev6.js:?
  at http://192.168.122.131/luci-static/resources/luci.js:22
  at async Promise.all (index 4)
  at async Promise.all (index 5)

Fixes: 2b7fd1292 ("luci-proto-gre: improvement of LuCI interface")
Signed-off-by: Chuanhong Guo <gch981213@gmail.com>

Not quite sure how the developments here works so I decided to create a PR.