### PR TITLE
luci-proto-qmi: add missing proto default options

### DIFF
--- a/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
+++ b/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
@@ -103,5 +103,22 @@ return network.registerProtocol('qmi', {
 		o.value('ipv4', 'IPv4');
 		o.value('ipv6', 'IPv6');
 		o.default = 'ipv4v6';
+
+		o = s.taboption('advanced', form.Flag, 'defaultroute',
+			_('Use default gateway'),
+			_('If unchecked, no default route is configured'));
+		o.default = o.enabled;
+
+		o = s.taboption('advanced', form.Value, 'metric',
+			_('Use gateway metric'));
+			o.placeholder = '0';
+		o.datatype = 'uinteger';
+		o.depends('defaultroute', '1');
+
+		o = s.taboption('advanced', form.Flag, 'peerdns',
+			_('Use DNS servers advertised by peer'),
+			_('If unchecked, the advertised DNS server addresses are ignored'));
+		o.default = o.enabled;
+
 	}
 });


### PR DESCRIPTION
This change add the following missing default options.
- defaulroute
- peerdns
- metric
This should fixes #4577 

@Nowaker **Since I do not use the qmi I cannot test it**.
Can you please check if it meets your requirements and give a feedback?