### PR TITLE
luci-app-firewall: force user to add a meaningful name

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
@@ -214,6 +214,18 @@ return view.extend({
 		o = s.taboption('general', form.Value, 'name', _('Name'));
 		o.placeholder = _('Unnamed rule');
 		o.modalonly = true;
+		o.validate = function(section_id, value) {
+			if (value == '') return _('Please enter a meaningful name');
+			var rules = uci.sections('firewall', 'rule');
+			for (var i = 0; i < rules.length; i++) {
+				var name = rules[i].name;
+				if ( name == value ) {
+					if ( section_id != rules[i]['.name'] )
+						return _('Rule name is already assigned');
+				}
+			}
+			return true
+		};
 
 		o = s.option(form.DummyValue, '_match', _('Match'));
 		o.modalonly = false;


### PR DESCRIPTION
The uci name option is set as a comment by fw3 into iptables.
If no name es set, then the name in the comment of the rule is
for exmaple set to @rule[1].

You will surely wonder why I need this!
Explanation:
I have the requirement that I want to combine several firewall rules into one group. These should then be switched on together. For example the firewall rules you have to set for IPsec. I have decided to define an additional firewall section with the name group where the names of the single rules are listed. When I call up the group, all rules with the defined names are switched on and the firewall is reloaded. But this is currently not possible because the name is optional and not clear.
I can remember the rule id @rule[1], but it is not unique and can move under circumstances, because the position of the uci section in the firewall configuration is important.
This is only a suggestion or does anyone else or @jow- have something else in mind?

Feedback welcome ;-)