### PR TITLE
[RFC] luci-base: introduce afterRender function

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -1954,7 +1954,9 @@
 
 					DOM.content(vp, nodes);
 					DOM.append(vp, this.addFooter());
-				}, this)).catch(LuCI.prototype.error);
+				}, this))
+				.then(LuCI.prototype.bind(this.afterRender, this))
+				.catch(LuCI.prototype.error);
 		},
 
 		/**
@@ -2010,6 +2012,31 @@
 		 * to a `Node` value.
 		 */
 		render: function() {},
+
+		/**
+		 * The afterRender function is invoked after the
+		 * {@link LuCI.dom#append dom.append()} function and can be
+		 * used to manipulate the DOM immediately after it has been
+		 * appended and written to the webpage.
+		 *
+		 * The invocation of this function is wrapped by
+		 * `Promise.resolve()` so it may return Promises if needed.
+		 *
+		 * The return value of the function (or the resolved values
+		 * of the promise returned by it) will be ignored.
+		 *
+		 * This function is supposed to be overwritten by subclasses,
+		 * the default implementation does nothing.
+		 *
+		 * @instance
+		 * @abstract
+		 * @memberof LuCI.view
+		 * @param {null}
+		 *
+		 * @returns {Node|Promise<Node>}
+		 * May return any value or a Promise resolving to any value.
+		 */
+		afterRender: function() {},
 
 		/**
 		 * The handleSave function is invoked when the user clicks


### PR DESCRIPTION
Add new afterRender function. This function can optionally used to execute function after the view rendering. This can be really handy when it's needed the width and height of some element and this kind of data are available only AFTER the page render.

Inspecting the realtime stats scripts I notice that every graph base they width and height value based on the `#view` element. This looks wrong and can cause some problem (I could be wrong and be a problem specific to the material skin) for example the width is wrongly calculated in the wireless graph where the tab bar adds padding on the left and on the right and the graph doesn't count this missing space).
 
Another solution to this problem would be create a one time pool that parse the width and height after some time but this would add extra time to the page generation and looks hacky.
Append some extra function after the DOM generation looks cleaner and quicker. 

I know this is very specific and we really need this just for the graph that needs this kind of parsing so I understand a NAK on this.

@jow- (sorry... i know I'm bothering you A LOT)

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>