### PR TITLE
luci-mod-network: wireless.js Disable 802.11b by default

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -883,6 +883,8 @@ return view.extend({
 				o.ucisection = s.section;
 
 				if (hwtype == 'mac80211') {
+					o = ss.taboption('general', form.Flag, 'legacy_rates', _('Allow legacy 802.11b rates'), _('Legacy or badly behaving devices may require legacy 802.11b rates to interoperate. Airtime efficiency may be significantly reduced where these are used. It is recommended to not allow 802.11b rates where possible.'));
+
 					o = ss.taboption('general', CBIWifiTxPowerValue, 'txpower', _('Maximum transmit power'), _('Specifies the maximum transmit power the wireless radio may use. Depending on regulatory requirements and wireless usage, the actual transmit power may be reduced by the driver.'));
 					o.wifiNetwork = radioNet;
 
@@ -894,9 +896,6 @@ return view.extend({
 					o.value('1', _('Normal'));
 					o.value('2', _('High'));
 					o.value('3', _('Very High'));
-
-					o = ss.taboption('advanced', form.Flag, 'legacy_rates', _('Allow legacy 802.11b rates'));
-					o.default = o.enabled;
 
 					o = ss.taboption('advanced', form.Value, 'distance', _('Distance Optimization'), _('Distance to farthest network member in meters.'));
 					o.datatype = 'or(range(0,114750),"auto")';


### PR DESCRIPTION
The time has long come where 802.11b DSSS/CCK data rates should be disabled
by default in OpenWRT. Users in need of 802.11b client support can reasonably
enable these where they are needed.

The balance of equities has significantly, and for a long time, tipped
such that dropping backwards compatibility by default with 802.11b
devices is appropriate, proportionate and justified. By doing so,
management and control traffic is moved by default to a 20
MHz wide 6 Mb/s OFDM data rate instead of a 22 MHz wide 1 Mb/s data rate.
This is significantly more airtime efficient.

Signed-off-by: Nick Lowe nick.lowe@gmail.com