### PR TITLE
luci-base: hide "No password set!" notification if password login is disabled

### DIFF
--- a/modules/luci-base/luasrc/sys.lua
+++ b/modules/luci-base/luasrc/sys.lua
@@ -509,7 +509,7 @@ user.getuser = nixio.getpw
 function user.getpasswd(username)
 	local pwe = nixio.getsp and nixio.getsp(username) or nixio.getpw(username)
 	local pwh = pwe and (pwe.pwdp or pwe.passwd)
-	if not pwh or #pwh < 1 or pwh == "!" or pwh == "x" then
+	if not pwh or #pwh < 1 then
 		return nil, pwe
 	else
 		return pwh, pwe


### PR DESCRIPTION
The special characters '!' and '*' in /etc/shadow are
used to disable password login for a specific account.

The character 'x' has no special meaning, but should not
be interpreted as an empty password.

However, Luci treats the special characters '!' and 'x' like no password is
set and displays the "No password set!" notification.

As this might be misleading, the extra check for these special
characters is removed, so the invalid hash is returned in that case.

This aligns the behavior of this notification with a change in rpcd,
which also removed these extra checks, so no login is possible, if
password login is disabled [1].

[1] https://git.openwrt.org/?p=project/rpcd.git;a=commit;h=3df62bcebd2caff47506ccffb42df8d2d2123c06

Signed-off-by: Fabian Bläse <fabian@blaese.de>