### PR TITLE
luci-mod-status: fix WPS button to wrong interface

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
@@ -119,7 +119,7 @@ return baseclass.extend({
 			else
 				icon = L.resource('icons/signal-75-100.png');
 
-			var WPS_button;
+			var WPS_button = null;
 
 			if (this.isWPSEnabled[net.sid]) {
 				if (net.wps_status == 'Active') {


### PR DESCRIPTION
Reset the WPS_button variable to correctly add the button to the enabled interface.

@jow- 

Fixes: #4625
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>