### PR TITLE
rpcd-mod-luci: strip colon from dnsmasq duid

### DIFF
--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -313,6 +313,15 @@ duid2ea(const char *duid)
 	return &ea;
 }
 
+static void strip_colon_duid(char *str) {
+	char *pr = str, *pw = str;
+
+	while (*pr) {
+		*pw = *pr++;
+		pw += (*pw != ':');
+	}
+	*pw = '\0';
+}
 
 static struct {
 	time_t now;
@@ -556,6 +565,8 @@ lease_next(void)
 
 				if (!e.hostname || !e.duid)
 					continue;
+
+				strip_colon_duid(e.duid);
 
 				if (!strcmp(e.hostname, "*"))
 					e.hostname = NULL;


### PR DESCRIPTION
Dnsmasq DHCPv6 use colons in the generated duid present in the lease file. Strip the colon as this is not supported by the OpenWrt config and follow the same way odhcpd use to display duid.
@jow- 
Fixes: #4543

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>