### PR TITLE
rpcd-mod-*: improve postinst script

### DIFF
--- a/libs/rpcd-mod-luci/Makefile
+++ b/libs/rpcd-mod-luci/Makefile
@@ -48,8 +48,7 @@ endef
 
 define Package/rpcd-mod-luci/postinst
 #!/bin/sh
-killall -HUP rpcd 2>/dev/null
-exit 0
+[ -n "$$IPKG_INSTROOT" ] || /etc/init.d/rpcd reload
 endef
 
 $(eval $(call BuildPackage,rpcd-mod-luci))

--- a/libs/rpcd-mod-rad2-enc/Makefile
+++ b/libs/rpcd-mod-rad2-enc/Makefile
@@ -41,8 +41,7 @@ endef
 
 define Package/rpcd-mod-rad2-enc/postinst
 #!/bin/sh
-killall -HUP rpcd 2>/dev/null
-exit 0
+[ -n "$$IPKG_INSTROOT" ] || /etc/init.d/rpcd reload
 endef
 
 $(eval $(call BuildPackage,rpcd-mod-rad2-enc))

--- a/libs/rpcd-mod-rrdns/Makefile
+++ b/libs/rpcd-mod-rrdns/Makefile
@@ -40,8 +40,7 @@ endef
 
 define Package/rpcd-mod-rrdns/postinst
 #!/bin/sh
-killall -HUP rpcd 2>/dev/null
-exit 0
+[ -n "$$IPKG_INSTROOT" ] || /etc/init.d/rpcd reload
 endef
 
 $(eval $(call BuildPackage,rpcd-mod-rrdns))


### PR DESCRIPTION
Usage of killall is replaced with init script. This is cleaner solution
as it does not consider some implementation detail but rather passes
that on to init script implementation.

IPKG_INSTROOT was added to prevent execution when not running in current
root. It is invalid to request reload if install-root is not current
root. In this case it can be considered harmless but it is invalid
nonetheless.

Last change is removal of `exit 0`. This caused skip of default
postinst. Execution of default postinst does no harm and is more
standard considering possible future expansion of it.
