### PR TITLE
luci-mod-network Add description: Hidden SSID, WMM

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1068,11 +1068,11 @@ return view.extend({
 						return mode;
 					};
 
-					o = ss.taboption('general', form.Flag, 'hidden', _('Hide <abbr title="Extended Service Set Identifier">ESSID</abbr>'));
+					o = ss.taboption('general', form.Flag, 'hidden', _('Hide <abbr title="Extended Service Set Identifier">ESSID</abbr>'), _('Where the ESSID is hidden, clients may fail to roam and airtime efficiency may be significantly reduced.'));
 					o.depends('mode', 'ap');
 					o.depends('mode', 'ap-wds');
 
-					o = ss.taboption('general', form.Flag, 'wmm', _('WMM Mode'));
+					o = ss.taboption('general', form.Flag, 'wmm', _('WMM Mode'), _('Where Wi-Fi Multimedia (WMM) Mode QoS is disabled, clients may be limited to 802.11a/802.11g rates.'));
 					o.depends('mode', 'ap');
 					o.depends('mode', 'ap-wds');
 					o.default = o.enabled;


### PR DESCRIPTION
luci-mod-network Describe issues: Hidden SSID, WMM

The performance and reliability implications of hiding SSIDs or disabling
WMM are not commonly known and these settings often end up being
misconfigured to harmful effect.

To seek to mitigate this, add descriptions explaining that:

Where the ESSID is hidden, clients may fail to roam and airtime efficiency
may be significantly reduced.

Where Wi-Fi Multimedia (WMM) Mode QoS is disabled, clients may be limited
to 802.11a/802.11g rates.

Signed-off-by: Nick Lowe <nick.lowe@gmail.com>