### PR TITLE
luci-app-throughput-measurements: add iperf3 app

### DIFF
--- a/applications/luci-app-throughput-measurements/Makefile
+++ b/applications/luci-app-throughput-measurements/Makefile
@@ -1,0 +1,13 @@
+# Copyright 2020 Wojciech Jowsa (wojciech.jowsa@gmail.com)
+# This is free software, licensed under the Apache License, Version 2.0
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Throughput measurements application
+LUCI_DEPENDS:=+luci-mod-admin-full +iperf3
+PKG_MAINTAINER:=Wojciech Jowsa <wojciech.jowsa@gmail.com>
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-throughput-measurements/htdocs/luci-static/resources/view/tputmeas/client.js
+++ b/applications/luci-app-throughput-measurements/htdocs/luci-static/resources/view/tputmeas/client.js
@@ -1,0 +1,240 @@
+'use strict';
+'require rpc';
+'require uci';
+'require ui';
+'require fs';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+var eventSource,
+	hideStart = false;
+
+var callIperf3Start = rpc.declare({
+	object: 'luci.tputmeas',
+	method: 'iperf3Start',
+	params:  [ "mode", "server_address", "interface", "interface_address", "port",
+			   "duration", "bytes", "udp", "bitrate", "reverse", "bidir", "connections", "interval" ],
+	expect: { '': {} }
+});
+
+var callIperf3Stop =  rpc.declare({
+	object: 'luci.tputmeas',
+	method: 'iperf3Stop',
+	expect: { '': {} }
+});
+
+function stopIperf3() {
+	callIperf3Stop().then(function(replay) {
+		if (eventSource)
+			eventSource.close();
+	}.bind(this)).catch(function(error) {
+	});
+}
+
+window.addEventListener('beforeunload', stopIperf3);
+
+function addOutput() {
+	var iperf3Out = document.querySelectorAll('[id$="iperf3_out"]')[0];
+	if (iperf3Out)
+		return;
+
+	var frameEl = E('div', {'class': 'cbi-value'});
+
+	frameEl.appendChild(E('textarea', {
+			'id': 'iperf3_out',
+			'class': 'cbi-input-textarea',
+			'readonly': '',
+			'style': 'width:100%',
+			'rows': 30,
+	}));
+
+	frameEl.firstElementChild.style.fontFamily = 'monospace';
+
+	var stopBtn = document.querySelectorAll('[id$="stop_iperf3"]')[0];
+	if (stopBtn)
+		stopBtn.parentNode.insertBefore(frameEl, stopBtn.nextSibling);
+}
+
+function subscribeIperf3() {
+	if (eventSource)
+		eventSource.close();
+
+	eventSource = new EventSource('/ubus/subscribe/luci.tputmeas.notify')
+	eventSource.onerror = function(event) {
+		console.log(event);
+		eventSource.close();
+	};
+
+	addOutput();
+	var textOut = document.querySelectorAll('[id$="iperf3_out"]')[0];
+	textOut.value = ""
+	eventSource.addEventListener("luci.tputmeas.notify.data", function(event) {
+		textOut.value = textOut.value + "\n" + JSON.parse(event.data).data;
+	});
+};
+
+function updateButtons() {
+	var tasks = [];
+	tasks.push(fs.stat("/var/run/luci-iperf3.pid").then(L.bind(function(list) {
+			if (!eventSource || eventSource.readyState == 2)
+				subscribeIperf3();
+			var textOut = document.querySelectorAll('[id$="iperf3_out"]')[0];
+			if (textOut)
+				textOut.style.borderColor = "green";
+			var startBtn = document.querySelectorAll('[id$="start_iperf3"]')[0];
+			if (startBtn)
+				startBtn.hidden = true;
+			var stopBtn = document.querySelectorAll('[id$="stop_iperf3"]')[0];
+			if (stopBtn)
+				stopBtn.hidden = false;
+			return;
+		})).catch(function(error) {
+			var textOut = document.querySelectorAll('[id$="iperf3_out"]')[0];
+			if (textOut)
+				textOut.style.borderColor = "red";
+			var startBtn = document.querySelectorAll('[id$="start_iperf3"]')[0];
+			if (startBtn)
+				startBtn.hidden = hideStart;
+			var stopBtn = document.querySelectorAll('[id$="stop_iperf3"]')[0];
+			if (stopBtn)
+				stopBtn.hidden = true;
+			if (eventSource)
+				eventSource.close();
+	}));
+
+	return  Promise.all(tasks);
+}
+
+return L.view.extend({
+
+	render: function(processes) {
+		var m, s, o;
+
+		m = new form.Map('luci_tputmeas', _('Throughput Measurements - Iperf3 Client'), _('Iperf3 is a tool for performing network throughput measurements. It can test TCP, UDP, or SCTP throughput. To perform an iperf3 test the user must establish both a server and a client.'));
+		s = m.section(form.TypedSection, 'iperf3')
+		s.anonymous = 1;
+
+		o = s.option(form.Value, 'server_address', _('Server address'), _('Address of the iperf3 server'));
+		o.optional = false;
+		o.datatype = 'ip4addr("nomask")';
+
+		o = s.option(widgets.DeviceSelect, 'interface', _('Interface'), _('Bind to the specific interface associated with address host.'))
+		o.noaliases = true;
+
+		o = s.option(form.Value, 'interface_address', _('Interface address'), _('Bind to the specific interface address associated with address host.'));
+		o.optional = false;
+		o.datatype = 'ip4addr("nomask")';
+		o.depends('interface', undefined);
+
+		o = s.option(form.Value, 'port', _('Port'), _('Set server port to listen on/connect to to n (default 5201)'));
+		o.modalonly = false;
+		o.datatype = 'list(neg(port))';
+		o.default = '5201'
+
+		o = s.option(form.Value, 'duration', _('Duration'), _('Time in seconds to transmit for (default 10 secs)'));
+		o.modalonly = false;
+		o.datatype = 'range(1,4294967296)'
+		o.validate =function(section_id, value) {
+			var bytes_input = document.querySelectorAll('[id$="bytes"]'),
+				duration_input = document.querySelectorAll('[id$="duration"]');
+
+			if (bytes_input[2] && bytes_input[2].value && duration_input[2].value){
+				hideStart = true;
+				return _("Only one test end condition (duration or bytes) may be specified")
+			}
+			hideStart = false;
+
+			return true;
+		}
+
+		o = s.option(form.Value, 'bytes', _('Bytes'), _('Number of bytes to transmit (instead of duration)'));
+		o.modalonly = false;
+		o.validate = function(section_id, value) {
+			var bytes_input = document.querySelectorAll('[id$="bytes"]'),
+				duration_input = document.querySelectorAll('[id$="duration"]');
+
+			if (duration_input[2] && duration_input[2].value && bytes_input[2].value) {
+				hideStart = true;
+				return _("Only one test end condition (duration or bytes) may be specified")
+			}
+			hideStart = false;
+
+			return true;
+		}
+
+		o = s.option(form.Value, 'bitrate', _('Bitrate'), _('Set target bitrate to n bits/sec (default 1 Mbit/sec for UDP, unlimited for TCP/SCTP).'));
+		o.modalonly = false;
+
+		o = s.option(form.Value, 'connections', _('Connections'), _('Number of parallel client streams to run. '));
+		o.modalonly = false;
+		o.datatype = 'range(1,4294967296)';
+
+		o = s.option(form.Value, 'interval', _('Interval'), _('Pause n seconds between periodic throughput reports; default is 1, use 0 to disable'));
+		o.modalonly = false;
+		o.datatype = 'range(1,4294967296)';
+
+		o = s.option(form.Flag, 'udp', _('Udp'), _("Use UDP rather than TCP"));
+
+		o = s.option(form.Flag, 'reverse', _('Reverse'), _("Reverse the direction of a test, so that the server sends data to the client"));
+
+		o = s.option(form.Flag, 'bidir', _('Bidirectional'), _("Run in bidirectional mode"))
+
+		o = s.option(form.Button, 'start_iperf3', _('Start iperf3'), _(''));
+		o.inputstyle = 'apply';
+		o.onclick = ui.createHandlerFn(this, function(section_id, ev) {
+			var iface = document.querySelectorAll('[id$="interface"]')[1].value ? document.querySelectorAll('[id$="interface"]')[1].value : null,
+				port = document.querySelectorAll('[id$="port"]')[2].value ?  document.querySelectorAll('[id$="port"]')[2].value : null,
+				server_address = document.querySelectorAll('[id$="server_address"]')[2].value ? document.querySelectorAll('[id$="server_address"]')[2].value : null,
+				interface_address = document.querySelectorAll('[id$="interface_address"]')[2].value ? document.querySelectorAll('[id$="interface_address"]')[2].value : null,
+				duration = document.querySelectorAll('[id$="duration"]')[2].value ? document.querySelectorAll('[id$="duration"]')[2].value : null,
+				bytes = document.querySelectorAll('[id$="bytes"]')[2].value ? document.querySelectorAll('[id$="bytes"]')[2].value : null,
+				bitrate = document.querySelectorAll('[id$="bitrate"]')[2].value ? document.querySelectorAll('[id$="bitrate"]')[2].value : null,
+				connections = document.querySelectorAll('[id$="connections"]')[2].value ? document.querySelectorAll('[id$="connections"]')[2].value : null,
+				interval = document.querySelectorAll('[id$="interval"]')[2].value ? document.querySelectorAll('[id$="interval"]')[2].value : null,
+				udp = document.querySelectorAll('[data-widget-id$="udp"]')[0].checked ? true : false,
+				reverse = document.querySelectorAll('[data-widget-id$="reverse"]')[0].checked ? true : false,
+				bidir = document.querySelectorAll('[data-widget-id$="bidir"]')[0].checked ? true : false;
+
+			return callIperf3Start("-c", server_address, iface, interface_address, port,
+									duration, bytes, udp, bitrate, reverse, bidir, connections, interval).then(function(replay) {
+				if (replay.error){
+					ui.showModal(_(replay.error), [
+						E('div', { 'class': 'right' }, [
+							E('button', {
+								'class': 'cbi-button cbi-button-negative important',
+								'click': function(ev) {
+									ui.hideModal();
+								}
+							}, _('Close')),
+						])
+					]);
+					return;
+				}
+				rpc.list.apply(rpc).then(function(res) {
+					for (var k in res) {
+						if (res[k] == "luci.tputmeas.notify")
+							subscribeIperf3()
+					}
+				}.bind(this))}.bind(this)).catch(function(error) {
+					console.log(error);
+				});
+		});
+
+		o = s.option(form.Button, 'stop_iperf3', _('Stop iperf3'), _(''));
+		o.inputstyle = 'apply';
+		o.onclick =  ui.createHandlerFn(this, function(section_id, ev) {
+			if (!eventSource)
+				return;
+			return callIperf3Stop().then(function(replay) {
+				eventSource.close();
+			}.bind(this)).catch(function(error) {
+				console.log(error);
+			});
+		});
+
+		L.Poll.add(L.bind(updateButtons, m),1);
+
+		return m.render();
+	},
+});

--- a/applications/luci-app-throughput-measurements/htdocs/luci-static/resources/view/tputmeas/server.js
+++ b/applications/luci-app-throughput-measurements/htdocs/luci-static/resources/view/tputmeas/server.js
@@ -1,0 +1,177 @@
+'use strict';
+'require rpc';
+'require uci';
+'require ui';
+'require fs';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+var eventSource;
+
+var callIperf3Start = rpc.declare({
+	object: 'luci.tputmeas',
+	method: 'iperf3Start',
+	params:  [ "mode", "server_address", "interface", "interface_address", "port",
+			   "duration", "bytes", "udp", "bitrate", "reverse", "connections", "interval" ],
+	expect: { '': {} }
+});
+var callIperf3Stop =  rpc.declare({
+	object: 'luci.tputmeas',
+	method: 'iperf3Stop',
+	expect: { '': {} }
+});
+
+function stopIperf3() {
+	callIperf3Stop().then(function(replay) {
+		if (eventSource)
+			eventSource.close();
+	}.bind(this)).catch(function(error) {
+		console.log(error);
+	});
+}
+
+window.addEventListener('beforeunload', stopIperf3);
+
+function addOutput() {
+	var iperf3Out = document.querySelectorAll('[id$="iperf3_out"]')[0];
+	if (iperf3Out)
+		return;
+
+	var frameEl = E('div', {'class': 'cbi-value'});
+
+	frameEl.appendChild(E('textarea', {
+			'id': 'iperf3_out',
+			'class': 'cbi-input-textarea',
+			'readonly': '',
+			'style': 'width:100%',
+			'rows': 30,
+	}));
+
+	frameEl.firstElementChild.style.fontFamily = 'monospace';
+	var stopBtn = document.querySelectorAll('[id$="stop_iperf3"]')[0];
+	if (stopBtn)
+		stopBtn.parentNode.insertBefore(frameEl, stopBtn.nextSibling);
+}
+
+function subscribeIperf3() {
+	if (eventSource)
+		eventSource.close();
+
+	eventSource = new EventSource('/ubus/subscribe/luci.tputmeas.notify');
+	eventSource.onerror = function(event) {
+		eventSource.close();
+	};
+
+	addOutput();
+	var textOut = document.querySelectorAll('[id$="iperf3_out"]')[0];
+	textOut.value = "";
+	eventSource.addEventListener("luci.tputmeas.notify.data", function(event) {
+		textOut.value = textOut.value + "\n" + JSON.parse(event.data).data;
+	});
+};
+
+function updateButtons() {
+	var tasks = [];
+	tasks.push(fs.stat("/var/run/luci-iperf3.pid").then(L.bind(function(list) {
+			if (!eventSource || eventSource.readyState == 2)
+				subscribeIperf3();
+			var textOut = document.querySelectorAll('[id$="iperf3_out"]')[0];
+			if (textOut)
+				textOut.style.borderColor = "green";
+			var startBtn = document.querySelectorAll('[id$="start_iperf3"]')[0];
+			if (startBtn)
+				startBtn.hidden = true;
+			var stopBtn = document.querySelectorAll('[id$="stop_iperf3"]')[0];
+			if (stopBtn)
+				stopBtn.hidden = false;
+			return;
+		})).catch(function(error) {
+			var textOut = document.querySelectorAll('[id$="iperf3_out"]')[0];
+			if (textOut)
+				textOut.style.borderColor = "red";
+			var startBtn = document.querySelectorAll('[id$="start_iperf3"]')[0];
+			if (startBtn)
+				startBtn.hidden = false;
+			var stopBtn = document.querySelectorAll('[id$="stop_iperf3"]')[0];
+			if (stopBtn)
+				stopBtn.hidden = true;
+			if (eventSource)
+				eventSource.close();
+	}));
+
+	return  Promise.all(tasks);
+}
+
+return L.view.extend({
+
+	load: function() {},
+
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('luci_tputmeas', _('Throughput Measurements - Iperf3 Server'), _('Iperf3 is a tool for performing network throughput measurements. It can test TCP, UDP, or SCTP throughput. To perform an iperf3 test the user must establish both a server and a client.'));
+		s = m.section(form.TypedSection, 'iperf3')
+		s.anonymous = 1;
+
+		o = s.option(widgets.DeviceSelect, 'interface', _('Interface'), _('Bind to the specific interface associated with address host.'))
+		o.noaliases = true;
+
+		o = s.option(form.Value, 'interface_address', _('Interface address'), _('Bind to the specific interface address associated with address host.'));
+		o.optional = false;
+		o.datatype = 'ip4addr("nomask")';
+		o.depends('interface', undefined);
+
+		o = s.option(form.Value, 'port', _('Port'), _('Set server port to listen on/connect to to n (default 5201)'));
+		o.modalonly = false;
+		o.datatype = 'list(neg(port))';
+
+		o = s.option(form.Button, 'start_iperf3', _('Start iperf3'), _(''));
+		o.inputstyle = 'apply';
+		o.onclick = ui.createHandlerFn(this, function(section_id, ev) {
+			var iface = document.querySelectorAll('[id$="interface"]')[1].value,
+				interface_address = document.querySelectorAll('[id$="interface_address"]')[2].value,
+				port = document.querySelectorAll('[id$="port"]')[2].value;
+
+			return callIperf3Start("-s", null, iface, interface_address, port,
+				null, null, null, null, null, null, null).then(function(replay) {
+				if (replay.error){
+					ui.showModal(_(replay.error), [
+						E('div', { 'class': 'right' }, [
+							E('button', {
+								'class': 'cbi-button cbi-button-negative important',
+								'click': function(ev) {
+									ui.hideModal();
+								}
+							}, _('Close')),
+						])
+					]);
+					return;
+				}
+				rpc.list.apply(rpc).then(function(res) {
+					for (var k in res) {
+						if (res[k] == "luci.tputmeas.notify")
+							subscribeIperf3()
+					}
+				}.bind(this));
+			}.bind(this)).catch(function(error) {
+				console.log(error);
+			});
+		});
+
+		o = s.option(form.Button, 'stop_iperf3', _('Stop iperf3'), _(''));
+		o.inputstyle = 'apply';
+		o.onclick =  ui.createHandlerFn(this, function(section_id, ev) {
+			if (!eventSource)
+				return;
+			return callIperf3Stop().then(function(replay) {
+				eventSource.close();
+			}.bind(this)).catch(function(error) {
+			});
+		});
+
+		L.Poll.add(L.bind(updateButtons, m),1);
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-throughput-measurements/root/etc/config/luci_tputmeas
+++ b/applications/luci-app-throughput-measurements/root/etc/config/luci_tputmeas
@@ -1,0 +1,13 @@
+config iperf3
+    option mode ''
+    option server_address ''
+    option interface ''
+    option interface_address ''
+    option port ''
+    option duration ''
+    option bytes ''
+    option udp ''
+    option bitrate ''
+    option reverse ''
+    option connections ''
+    option interval ''

--- a/applications/luci-app-throughput-measurements/root/usr/libexec/rpcd/luci.tputmeas
+++ b/applications/luci-app-throughput-measurements/root/usr/libexec/rpcd/luci.tputmeas
@@ -1,0 +1,238 @@
+#!/usr/bin/env lua
+
+local ubus = require "ubus"
+local uci = require "luci.model.uci"
+local nixio = require "nixio"
+local fs = require "nixio.fs"
+local json = require "luci.jsonc"
+local sys = require "luci.sys"
+
+local methods = {
+	iperf3Start = {
+		args = { mode = "mode", server_address = "server_address", interface = "interface",
+				interface_address = "interface_address", port = "port", duration = "duration",
+				bytes = "bytes", udp = false,  bitrate = "bitrate", reverse = false, bidir = false,
+				connections = "connections", interval = "interval" },
+		call = function(args)
+			local iperf3_cmd = "/usr/bin/iperf3 --forceflush "
+
+			if not args then
+				return { error = "Lack of arguments" }
+			end
+
+			if (not args.mode or (args.mode ~= "-c" and args.mode ~= "-s")) then
+				return { error = "mode has not been specified " }
+			end
+
+			iperf3_cmd = iperf3_cmd .. args.mode
+
+			if args.server_address and args.server_address ~= '' then
+				local addr = luci.ip.new(args.server_address)
+				if addr then
+					iperf3_cmd = iperf3_cmd .. " " .. tostring(addr:host())
+				else
+					return { error = "Invalid server address" }
+				end
+			end
+
+			if args.interface and args.interface ~= '' then
+				local ifa = nixio.getifaddrs()
+				for k, v in pairs(ifa) do
+					if ifa[k].name == args.interface and ifa[k].family == "inet" and ifa[k].addr then
+						iperf3_cmd = iperf3_cmd .. " -B " .. ifa[k].addr
+					end
+				end
+			elseif args.interface_address and args.interface_address ~= '' then
+				local ifa = nixio.getifaddrs()
+				local ok = false
+				for k, v in pairs(ifa) do
+					if ifa[k].addr == args.interface_address then
+						iperf3_cmd = iperf3_cmd .. " -B " .. ifa[k].addr
+						ok = true
+					end
+				end
+				if not ok then
+					return { error = "Incorrect format of an interface address" }
+				end
+			end
+
+			if args.port and args.port ~= '' then
+			    local port_num = tonumber(args.port)
+				if port_num and port_num > 0 and port_num <= 65535 then
+					iperf3_cmd = iperf3_cmd .. " -p " .. args.port
+				else
+					return { error = "Incorrect port argument" }
+				end
+			end
+
+			if args.duration and args.duration ~= '' then
+				local duration_num = tonumber(args.duration)
+				if duration_num and duration_num > 0 then
+					iperf3_cmd = iperf3_cmd .. " -t " .. args.duration
+				else
+					return { error = "Incorrect duration argument" }
+				end
+			end
+
+			if args.bytes and args.bytes ~= '' then
+				if args.bytes:match("^[0-9]*$") or args.bytes:match("^[0-9]*[kKmM]$") then
+					iperf3_cmd = iperf3_cmd .. " -n " .. args.bytes
+				else
+					return { error = "Incorrect bytes argument" }
+				end
+			end
+
+			if args.udp then
+				iperf3_cmd = iperf3_cmd .. " -u"
+			end
+
+			if args.bitrate then
+				if args.bitrate:match("^[0-9]*$") or args.bitrate:match("^[0-9]*[kKmM]$") then
+					iperf3_cmd = iperf3_cmd .. " -b " .. args.bitrate
+				else
+					return { error = "Incorrect bitrate argument" }
+				end
+			end
+
+			if args.reverse then
+				iperf3_cmd = iperf3_cmd .. " -R"
+			end
+
+			if args.bidir then
+				iperf3_cmd = iperf3_cmd .. " --bidir"
+			end
+
+			if args.connections then
+				if tonumber(args.connections) then
+					iperf3_cmd = iperf3_cmd .. " -P " .. args.connections
+				else
+					return { error = "Incorrect connections argument" }
+				end
+			end
+
+			if args.interval then
+				if tonumber(args.interval) then
+					iperf3_cmd = iperf3_cmd .. " -i " .. args.interval
+				else
+					return { error = "Incorrect interval argument" }
+				end
+			end
+
+			iperf3_cmd = iperf3_cmd .. "  2>&1"
+
+			local pid = nixio.fork()
+			if pid == 0 then
+				local conn = ubus.connect()
+				if not conn then
+					print("Failed to connect to ubus")
+					os.exit(1)
+				end
+
+				local cpid = nixio.getpid()
+				fs.writefile("/var/run/luci-iperf3.pid", cpid)
+
+				local ubus_objects = {
+					["luci.tputmeas.notify"] = {
+					}
+				}
+				conn:add( ubus_objects )
+
+				nixio.poll({}, 1000)
+
+				local pipe, err = io.popen("flock -n -x /var/lock/luci-iperf3.lock /bin/sh -c 'echo $$ > /var/run/luci-iperf3.pid && sleep 1 && exec %s'" % iperf3_cmd)
+				if pipe then
+					for line in pipe:lines() do
+					local params = {
+							data = line
+					}
+					conn:notify(ubus_objects["luci.tputmeas.notify"].__ubusobj, "luci.tputmeas.notify.data", params)
+					end
+				else
+					return { error = "Failed to execute iperf3 client: " .. err }
+				end
+
+				conn:close()
+				pipe:close()
+				fs.remove("/var/run/luci-iperf3.pid")
+			else
+				return { result = "success" }
+			end
+		end
+	},
+	iperf3Stop = {
+		call = function(args)
+			local pid = fs.readfile("/var/run/luci-iperf3.pid")
+			if not pid then
+				return { error = "iperf3 process in not running" }
+			end
+			if fs.readlink("/proc/%d/exe" % pid) == "/usr/bin/iperf3" then
+				nixio.kill(pid, 15)
+			else
+				return { error = "iperf3 process is already stopped" }
+			end
+
+			return { result = "success" }
+		end
+	},
+}
+
+local function parseInput()
+	local parse = json.new()
+	local done, err
+
+	while true do
+		local chunk = io.read(4096)
+		if not chunk then
+			break
+		elseif not done and not err then
+			done, err = parse:parse(chunk)
+		end
+	end
+
+	if not done then
+		print(json.stringify({ error = err or "Incomplete input" }))
+		os.exit(1)
+	end
+
+	return parse:get()
+end
+
+local function validateArgs(func, uargs)
+	local method = methods[func]
+	if not method then
+		print(json.stringify({ error = "Method not found" }))
+		os.exit(1)
+	end
+
+	if type(uargs) ~= "table" then
+		print(json.stringify({ error = "Invalid arguments" }))
+		os.exit(1)
+	end
+
+	uargs.ubus_rpc_session = nil
+
+	local k, v
+	local margs = method.args or {}
+	for k, v in pairs(uargs) do
+		if margs[k] == nil or
+		   (v ~= nil and type(v) ~= type(margs[k]))
+		then
+			print(json.stringify({ error = "Invalid arguments" }))
+			os.exit(1)
+		end
+	end
+
+	return method
+end
+
+if arg[1] == "list" then
+	local _, method, rv = nil, nil, {}
+	for _, method in pairs(methods) do rv[_] = method.args or {} end
+	print((json.stringify(rv):gsub(":%[%]", ":{}")))
+elseif arg[1] == "call" then
+	local args = parseInput()
+	local method = validateArgs(arg[2], args)
+	local result, code = method.call(args)
+	print((json.stringify(result):gsub("^%[%]$", "{}")))
+	os.exit(code or 0)
+end

--- a/applications/luci-app-throughput-measurements/root/usr/share/luci/menu.d/luci-app-throughput-measurements.json
+++ b/applications/luci-app-throughput-measurements/root/usr/share/luci/menu.d/luci-app-throughput-measurements.json
@@ -1,0 +1,41 @@
+{
+	"admin/troubleshooting": {
+		"title": "Troubleshooting",
+		"order": 80,
+		"action": {
+			"type": "firstchild"
+		}
+	},
+
+	"admin/troubleshooting/tputmeas": {
+		"title": "Throughput Measurements",
+		"order": 1,
+		"action": {
+			"type": "alias",
+			"path": "admin/troubleshooting/tputmeas/client"
+		},
+		"depends" : {
+			"acl": [ "luci-app-throughput-measurements" ],
+			"uci": { "luci_tputmeas": true },
+			"fs": { "/usr/libexec/rpcd/luci.tputmeas": "executable" }
+		}
+	},
+
+	"admin/troubleshooting/tputmeas/client": {
+		"title": "Iperf3 Client",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "tputmeas/client"
+		}
+	},
+
+	"admin/troubleshooting/tputmeas/server": {
+		"title": "Iperf3 Server",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "tputmeas/server"
+		}
+	}
+}

--- a/applications/luci-app-throughput-measurements/root/usr/share/rpcd/acl.d/luci-app-throughput-measurements.json
+++ b/applications/luci-app-throughput-measurements/root/usr/share/rpcd/acl.d/luci-app-throughput-measurements.json
@@ -1,0 +1,22 @@
+{
+	"luci-app-throughput-measurements": {
+		"description": "Grant access to tputmeas ubus object",
+		"read": {
+			"cgi-io": [ "exec" ],
+			"uci": [ "luci_tputmeas" ],
+			"ubus": {
+				"luci.tputmeas": [ "*" ]
+			}
+		},
+		"write": {
+			"uci": [ "luci_tputmeas" ]
+		}
+	},
+	"unauthenticated": {
+		"read": {
+			"ubus": {
+				"luci.tputmeas.notify": [ "*" ]
+			}
+		 }
+	}
+}


### PR DESCRIPTION
In some troubleshooting situations (e.g. testing network performance) it is useful to run network troubleshooting tools like iperf3, directly from the Luci interface. This PR introduces a Throughput Measurements application. 
Throughput Measurements application is a fronted for iperf3. With this application, a user is able to configure iperrf3 as a server or client with the most important and commonly used configuration options. The output of the iperf3 is lived streamed to the browser view. 
~~The application uses the new uhttpd API. The EventSource interface is used to handle server-sent events. However, in order to make the API work properly, there is one uhttpd patch be applied~~ 

 ~~* Because the EventSource does not allow to set custom header fields, the uhttpd has to be patched to support passing rpcd session id in the subscription url. [patch 1](https://patchwork.ozlabs.org/project/openwrt/patch/20201110080209.6368-1-wojciech.jowsa@gmail.com/)~~

I have tested this application on TP-Link WDR4300 and PCEngines APU3 using the latest openwrt master.

![client](https://user-images.githubusercontent.com/4362399/101895617-0e932180-3ba8-11eb-840a-398aab8c3974.gif)
![server](https://user-images.githubusercontent.com/4362399/101895622-0fc44e80-3ba8-11eb-9732-f4880e882402.gif)
