### PR TITLE
luci-app-firewall: map proto '*' and 'any' to all on rule config

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js
@@ -522,6 +522,9 @@ return baseclass.extend({
 				}
 			}, this));
 
+			if (cfgvalue == '*' || cfgvalue == 'any' || cfgvalue == 'all')
+				cfgvalue = 'all';
+
 			return cfgvalue;
 		},
 


### PR DESCRIPTION
Before the change, the options '*' and 'any' in the drop down were not
recognized as valid options, when loaded from the uci. With this change,
the options '*' and 'any' are mapped to 'all' and saved as such. This
change is especially important if the proto option is changed manually
to '*' or 'any' in shell and then further configured via LuCI.
