### PR TITLE
Allow configuration of HTTPS redirection

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
@@ -1,0 +1,22 @@
+'use strict';
+'require view';
+'require form';
+
+return view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('uhttpd', _('HTTP(S) Access'), _('uHTTPd offers <abbr title="Hypertext Transfer Protocol">HTTP</abbr> or <abbr title="Hypertext Transfer Protocol Secure">HTTPS</abbr> network access.'));
+
+		s = m.section(form.NamedSection, 'main', 'uhttpd', _('Settings'));
+		s.addremove = false;
+
+		o = s.option(form.Flag, 'redirect_https', _('Redirect to HTTPS'), _('Enable automatic redirection of <abbr title="Hypertext Transfer Protocol">HTTP</abbr> requests to <abbr title="Hypertext Transfer Protocol Secure">HTTPS</abbr> port.'));
+		o.enabled  = 'on';
+		o.disabled = 'off';
+		o.default  = o.disabled;
+		o.rmempty = false;
+
+		return m.render();
+	}
+});

--- a/modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json
@@ -60,6 +60,20 @@
 		}
 	},
 
+	"admin/system/admin/uhttpd": {
+		"title": "HTTP(S) Access",
+		"order": 4,
+		"action": {
+			"type": "view",
+			"path": "system/uhttpd"
+		},
+		"depends": {
+			"acl": [ "luci-mod-system-uhttpd" ],
+			"fs": {	"/usr/sbin/uhttpd": "executable" }
+		}
+	},
+
+
 	"admin/system/startup": {
 		"title": "Startup",
 		"order": 45,

--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -38,6 +38,20 @@
 		}
 	},
 
+	"luci-mod-system-uhttpd": {
+		"description": "Grant access to uHTTPd configuration",
+		"read": {
+			"uci": [ "uhttpd" ]
+		},
+		"write": {
+			"ubus": {
+				"luci": [ "setInitAction" ]
+			},
+			"uci": [ "uhttpd" ]
+		}
+	},
+
+
 	"luci-mod-system-init": {
 		"description": "Grant access to startup configuration",
 		"read": {

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -53,6 +53,10 @@ body {
 	min-width: 100%;
 }
 
+abbr[title], acronym[title] {
+	text-decoration: dotted underline;
+}
+
 /*
  * scaffholding
  */


### PR DESCRIPTION
Add a possibility to control uHTTPd's `redirect_https` config option from LuCI. While at it, add some missing abbreviations found in SSH keys and add missing styling of abbreviations as well.

![image](https://user-images.githubusercontent.com/43848/102084960-3f788e00-3e16-11eb-9e73-58311363bb5b.png)

References: https://lists.infradead.org/pipermail/openwrt-devel/2020-December/032718.html