### PR TITLE
luci-app-frp: add the dynamiclist for additional parameters

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -33,7 +33,8 @@ var commonConf = [
 	[form.ListValue, 'protocol', _('Protocol'), _('Protocol specifies the protocol to use when interacting with the server. Valid values are "tcp", "kcp", and "websocket".<br>By default, this value is "tcp".'), {values: ['tcp', 'kcp', 'websocket']}],
 	[form.Flag, 'tls_enable', _('TLS'), _('TLSEnable specifies whether or not TLS should be used when communicating with the server.'), {datatype: 'bool'}],
 	[form.Value, 'heartbeat_interval', _('Heartbeat interval'), _('HeartBeatInterval specifies at what interval heartbeats are sent to the server, in seconds. It is not recommended to change this value.<br>By default, this value is 30.'), {datatype: 'uinteger'}],
-	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'), _('HeartBeatTimeout specifies the maximum allowed heartbeat response delay before the connection is terminated, in seconds. It is not recommended to change this value.<br>By default, this value is 90.'), {datatype: 'uinteger'}]
+	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'), _('HeartBeatTimeout specifies the maximum allowed heartbeat response delay before the connection is terminated, in seconds. It is not recommended to change this value.<br>By default, this value is 90.'), {datatype: 'uinteger'}],
+	[form.DynamicList, '_', _('Additional settings'), _('This list can be used to specify some additional parameters which have not been included in this LuCI.'), {placeholder: 'Key-A=Value-A'}]
 ];
 
 var baseProxyConf = [

--- a/applications/luci-app-frpc/po/ar/frpc.po
+++ b/applications/luci-app-frpc/po/ar/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/bg/frpc.po
+++ b/applications/luci-app-frpc/po/bg/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/bn_BD/frpc.po
+++ b/applications/luci-app-frpc/po/bn_BD/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/ca/frpc.po
+++ b/applications/luci-app-frpc/po/ca/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/cs/frpc.po
+++ b/applications/luci-app-frpc/po/cs/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Obecná nastavení"
 
@@ -112,11 +116,11 @@ msgstr "Obecná nastavení"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/de/frpc.po
+++ b/applications/luci-app-frpc/po/de/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Zusätzliche Konfiguration"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "Admin-Adresse"
@@ -79,11 +83,11 @@ msgstr ""
 "mitgelieferten ausführbaren Datei mittels statik geladen.<br>Standardwert "
 "ist \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "Gemeinsame Einstellungen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "Komprimierung"
 
@@ -91,7 +95,7 @@ msgstr "Komprimierung"
 msgid "Config files include in temporary config file"
 msgstr "Konfigurationsdateien die in temporärer Konfiguration enthalten sind"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr "Benutzerdefinierte Domains"
 
@@ -107,7 +111,7 @@ msgstr ""
 "DisableLogColor deaktiviert farbiges Log wenn LogWay == \"console\" "
 "aktiviert ist."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
@@ -119,7 +123,7 @@ msgstr "Umgebungsvariable"
 msgid "Exit when login fail"
 msgstr "Beende Programm bei Loginfehler"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -127,11 +131,11 @@ msgstr "Allgemeine Einstellungen"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "HTTP-Einstellungen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "HTTP-Passwort"
 
@@ -139,7 +143,7 @@ msgstr "HTTP-Passwort"
 msgid "HTTP proxy"
 msgstr "HTTP-Proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "HTTP-User"
 
@@ -171,7 +175,7 @@ msgstr "Heartbeat-Intervall"
 msgid "Heartbeat timeout"
 msgstr "Heartbeat-Timeout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr "Host-Header umschreiben"
 
@@ -186,34 +190,34 @@ msgstr ""
 "<br>Standardwert hierfür wird aus der \"http_proxy\"-Umgebungsvariable "
 "gelesen."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr ""
 "Falls remote_port auf 0 gesetzt ist, wird frps einen zufälligen Port-Wert "
 "zuweisen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "Lokale IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "Lokaler Port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #, fuzzy
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 "LocalIp spezifiziert die IP-Adresse oder den Hostnamen der als Proxy "
 "verwendet werden soll."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr "Standorte"
 
@@ -248,7 +252,7 @@ msgstr ""
 "Loginversuch beenden soll. Falls es auf falsch steht, wir es der client so "
 "oft versuchen, bis es erfolgreich war.<br>Standardwert hierfür ist wahr."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr "Der Name kann nicht \"common\" sein"
 
@@ -275,16 +279,16 @@ msgstr ""
 "verwendet werden soll. Gültige Werte sind \"tcp\", \"kcp\" und \"websocket\"."
 "<br>Standardwert hierfür ist \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "Proxy-Einstellungen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr "Proxy-Typ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
@@ -294,7 +298,7 @@ msgstr ""
 "\"tcp\", \"udp\", \"https\", \"stcp\" und \"xtcp\".<br>Standardwert hierfür "
 "ist \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr "Remote-Port"
 
@@ -302,7 +306,7 @@ msgstr "Remote-Port"
 msgid "Respawn when crashed"
 msgstr "Starte nach Crash neu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "Rolle"
 
@@ -338,16 +342,16 @@ msgstr ""
 "ServerPort spezifiziert den Port des Servers zu dem verbunden werden soll."
 "<br>Standardwert hierfür ist 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr "Startparameter"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr "Subdomain"
 
@@ -379,6 +383,12 @@ msgstr ""
 "auf wahr steht, muss der Server ebenfalls TCP-Multiplexing aktiviert haben."
 "<br>Standardwert hierfür ist wahr."
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Token"
@@ -394,7 +404,7 @@ msgstr ""
 "ein gleichlautendes Token zur Authorisation eingestellt haben."
 "<br>Standardwert hierfür ist \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
@@ -402,7 +412,7 @@ msgstr ""
 "UseCompression legt fest, ob die Datenverbindung mit dem Server komprimiert "
 "werden soll.<br>Standardwert hierfür ist falsch."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -426,7 +436,7 @@ msgstr ""
 "Clients. Falls dieser Wert \"\" beträgt, werden Proxy-Namen automatisch zu "
 "\"{user} {proxy_name} \" umgeschrieben.<br>Standardwert hierfür ist \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "frp Client"

--- a/applications/luci-app-frpc/po/el/frpc.po
+++ b/applications/luci-app-frpc/po/el/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/en/frpc.po
+++ b/applications/luci-app-frpc/po/en/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/es/frpc.po
+++ b/applications/luci-app-frpc/po/es/frpc.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configuraciones adicionales"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "Dirección del administrador"
@@ -82,11 +86,11 @@ msgstr ""
 "cargarán desde el ejecutable incluido usando statik.<br>Por defecto, este "
 "valor es \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "Configuraciones comunes"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "Compresión"
 
@@ -96,7 +100,7 @@ msgstr ""
 "Los archivos de configuración incluyen en el archivo de configuración "
 "temporal"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr "Dominios personalizados"
 
@@ -112,7 +116,7 @@ msgstr ""
 "DisableLogColor desactiva los colores de registro cuando LogWay == \"console"
 "\" cuando se establece en verdadero."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Encriptación"
 
@@ -124,7 +128,7 @@ msgstr "Variable ambiental"
 msgid "Exit when login fail"
 msgstr "Salir cuando falla el inicio de sesión"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Configuración general"
 
@@ -132,11 +136,11 @@ msgstr "Configuración general"
 msgid "Grant access to LuCI app frpc"
 msgstr "Conceder acceso a la aplicación frpc de LuCI"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "Configuraciones HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "Contraseña HTTP"
 
@@ -144,7 +148,7 @@ msgstr "Contraseña HTTP"
 msgid "HTTP proxy"
 msgstr "Proxy HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "Usuario HTTP"
 
@@ -176,7 +180,7 @@ msgstr "Intervalo de latidos"
 msgid "Heartbeat timeout"
 msgstr "Tiempo de espera de latidos"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr "Reescritura de encabezado de host"
 
@@ -191,29 +195,29 @@ msgstr ""
 "predeterminada, este valor se lee desde la variable de entorno \"http_proxy"
 "\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr "Si remote_port es 0, frps le asignará un puerto aleatorio"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "IP local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "Puerto local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr "LocalIp especifica la dirección IP o el nombre de host para el proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr "LocalPort especifica el puerto al proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr "Localizaciones"
 
@@ -249,7 +253,7 @@ msgstr ""
 "hasta que un intento de inicio de sesión tenga éxito.<br>Por defecto, este "
 "valor es verdadero."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr "El nombre no puede ser \"común\""
 
@@ -276,16 +280,16 @@ msgstr ""
 "servidor. Los valores válidos son \"tcp\", \"kcp\" y \"websocket\".<br>De "
 "manera predeterminada, este valor es \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "Configuraciónes del proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr "Tipo de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
@@ -295,7 +299,7 @@ msgstr ""
 "\"tcp\", \"udp\", \"http\", \"https\", \"stcp\" y \"xtcp\".<br>Por defecto, "
 "este valor es \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr "Puerto remoto"
 
@@ -303,7 +307,7 @@ msgstr "Puerto remoto"
 msgid "Respawn when crashed"
 msgstr "Reaparecer cuando se estrelló"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "Rol"
 
@@ -339,16 +343,16 @@ msgstr ""
 "ServerPort especifica el puerto para conectarse al servidor.<br>Por defecto, "
 "este valor es 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr "Configuraciones de inicio"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr "Subdominio"
 
@@ -380,6 +384,12 @@ msgstr ""
 "verdadero, el servidor también debe tener habilitada la multiplexación TCP."
 "<br>De manera predeterminada, este valor es verdadero."
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Token"
@@ -394,7 +404,7 @@ msgstr ""
 "enviar al servidor. El servidor debe tener un token coincidente para que la "
 "autorización tenga éxito.<br>Por defecto, este valor es \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
@@ -402,7 +412,7 @@ msgstr ""
 "UseCompression controla si la comunicación con el servidor se comprimirá o "
 "no.<br>Por defecto, este valor es falso."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -428,7 +438,7 @@ msgstr ""
 "proxy se cambiarán automáticamente a \"{user}.{Proxy_name}\".<br>De manera "
 "predeterminada, este valor es \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "Cliente frp"

--- a/applications/luci-app-frpc/po/fi/frpc.po
+++ b/applications/luci-app-frpc/po/fi/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Salaus"
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Yleisasetukset"
 
@@ -112,11 +116,11 @@ msgstr "Yleisasetukset"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/fr/frpc.po
+++ b/applications/luci-app-frpc/po/fr/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurations supplémentaires"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "Adresse administrateur"
@@ -79,11 +83,11 @@ msgstr ""
 "actifs seront chargés à partir de l'exécutable fourni à l'aide de statik."
 "<br>Par défaut, cette valeur est \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "Paramètres communs"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "Compression"
 
@@ -93,7 +97,7 @@ msgstr ""
 "Les fichiers de configuration incluent dans le fichier de configuration "
 "temporaire"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr "Domaines personnalisés"
 
@@ -109,7 +113,7 @@ msgstr ""
 "DisableLogColor désactive les couleurs du journal lorsque LogWay == \"console"
 "\" lorsqu'il est défini sur true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Chiffrement"
 
@@ -121,7 +125,7 @@ msgstr "Variable d'environnement"
 msgid "Exit when login fail"
 msgstr "Quitter lorsque la connexion échoue"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
@@ -129,11 +133,11 @@ msgstr "Paramètres généraux"
 msgid "Grant access to LuCI app frpc"
 msgstr "Accorder l'accès à l'application LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "Paramètres HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "Mot de passe HTTP"
 
@@ -141,7 +145,7 @@ msgstr "Mot de passe HTTP"
 msgid "HTTP proxy"
 msgstr "Http proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "Utilisateur HTTP"
 
@@ -173,7 +177,7 @@ msgstr "Intervalle des battements cardiaques"
 msgid "Heartbeat timeout"
 msgstr "Délai d'expiration du rythme cardiaque"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr "Réécriture de l'en-tête de l'hôte"
 
@@ -187,29 +191,29 @@ msgstr ""
 "cette valeur est \"\", le serveur sera directement connecté.<br>Par défaut, "
 "cette valeur est lue à partir de la variable d'environnement \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr "Si remote_port vaut 0, frps vous attribuera un port aléatoire"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "IP locale"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "Local port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr "LocalIp spécifie l'adresse IP ou le nom d'hôte vers lequel proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr "LocalPort spécifie le port vers lequel proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr "Emplacements"
 
@@ -245,7 +249,7 @@ msgstr ""
 "ce qu'une tentative de connexion réussisse.<br>Par défaut, cette valeur est "
 "vraie."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr "Le nom ne peut pas être \"commun\""
 
@@ -272,16 +276,16 @@ msgstr ""
 "serveur. Les valeurs valides sont \"tcp\", \"kcp\" et \"websocket\".<br>Par "
 "défaut, cette valeur est \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "Paramètres du proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr "Type de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
@@ -291,7 +295,7 @@ msgstr ""
 "\"udp\", \"http\", \"https\", \"stcp\" et \"xtcp\".<br>Par défaut, cette "
 "valeur est \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr "Port distant"
 
@@ -299,7 +303,7 @@ msgstr "Port distant"
 msgid "Respawn when crashed"
 msgstr "Réapparaître en cas de crash"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "Rôle"
 
@@ -335,16 +339,16 @@ msgstr ""
 "ServerPort spécifie le port sur lequel se connecter au serveur.<br>Par "
 "défaut, cette valeur est 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr "Paramètres de démarrage"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr "Sous-domaine"
 
@@ -376,6 +380,12 @@ msgstr ""
 "le multiplexage TCP doit également être activé sur le serveur.<br>Par "
 "défaut, cette valeur est vraie."
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Token"
@@ -390,7 +400,7 @@ msgstr ""
 "au serveur. Le serveur doit avoir un jeton correspondant pour que "
 "l'autorisation réussisse.<br>Par défaut, cette valeur est \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
@@ -398,7 +408,7 @@ msgstr ""
 "UseCompression contrôle si la communication avec le serveur sera compressée "
 "ou non.<br>Par défaut, cette valeur est false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -424,7 +434,7 @@ msgstr ""
 "automatiquement modifiés en \"{user}.{Proxy_name}\".<br>Par défaut, cette "
 "valeur est \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "frp Client"

--- a/applications/luci-app-frpc/po/he/frpc.po
+++ b/applications/luci-app-frpc/po/he/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/hi/frpc.po
+++ b/applications/luci-app-frpc/po/hi/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/hu/frpc.po
+++ b/applications/luci-app-frpc/po/hu/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Titkosítás"
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Általános beállítások"
 
@@ -112,11 +116,11 @@ msgstr "Általános beállítások"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "Helyi port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "Szerep"
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Token"
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/it/frpc.po
+++ b/applications/luci-app-frpc/po/it/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Crittografia"
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Impostazioni generali"
 
@@ -112,11 +116,11 @@ msgstr "Impostazioni generali"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/ja/frpc.po
+++ b/applications/luci-app-frpc/po/ja/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "追加の構成"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "共通設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "圧縮"
 
@@ -78,7 +82,7 @@ msgstr "圧縮"
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "暗号化"
 
@@ -104,7 +108,7 @@ msgstr "環境変数"
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -112,11 +116,11 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "HTTP 設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "HTTP パスワード"
 
@@ -124,7 +128,7 @@ msgstr "HTTP パスワード"
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "HTTP ユーザー"
 
@@ -150,7 +154,7 @@ msgstr "ハートビート間隔"
 msgid "Heartbeat timeout"
 msgstr "ハートビート・タイムアウト"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "ローカル IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "ローカル・ポート"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "プロキシ設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "役割"
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "トークン"
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/ko/frpc.po
+++ b/applications/luci-app-frpc/po/ko/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/mr/frpc.po
+++ b/applications/luci-app-frpc/po/mr/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "अतिरिक्त कॉन्फिगरेशन"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "सामान्य सेटिंग्ज"
 
@@ -112,11 +116,11 @@ msgstr "सामान्य सेटिंग्ज"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/ms/frpc.po
+++ b/applications/luci-app-frpc/po/ms/frpc.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -60,11 +64,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -72,7 +76,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -86,7 +90,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -98,7 +102,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -106,11 +110,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -118,7 +122,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -155,29 +159,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -206,7 +210,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -227,23 +231,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -283,16 +287,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -318,6 +322,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -329,13 +339,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -353,7 +363,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/nb_NO/frpc.po
+++ b/applications/luci-app-frpc/po/nb_NO/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -112,11 +116,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/pl/frpc.po
+++ b/applications/luci-app-frpc/po/pl/frpc.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Dodatkowe konfiguracje"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "Adres administratora"
@@ -79,11 +83,11 @@ msgstr ""
 "ładował zasoby. Jeśli ta wartość to \"\", zasoby zostaną załadowane z "
 "pakietu wykonywalnego przy użyciu statik. <br> Domyślnie ta wartość to \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "Wspólne ustawienia"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "Kompresja"
 
@@ -91,7 +95,7 @@ msgstr "Kompresja"
 msgid "Config files include in temporary config file"
 msgstr "Pliki konfiguracyjne znajdują się w tymczasowym pliku konfiguracyjnym"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr "Własne domeny"
 
@@ -107,7 +111,7 @@ msgstr ""
 "DisableLogColor wyłącza kolory dziennika, gdy LogWay == \"konsola\", jest "
 "ustawiona na true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Szyfrowanie"
 
@@ -119,7 +123,7 @@ msgstr "Zmienna środowiskowa"
 msgid "Exit when login fail"
 msgstr "Wyjdź, gdy logowanie się nie powiedzie"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
@@ -127,11 +131,11 @@ msgstr "Ustawienia główne"
 msgid "Grant access to LuCI app frpc"
 msgstr "Udziel dostępu LuCI do aplikacji frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "Ustawienia HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "Hasło HTTP"
 
@@ -139,7 +143,7 @@ msgstr "Hasło HTTP"
 msgid "HTTP proxy"
 msgstr "HTTP proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "Użytkownik HTTP"
 
@@ -171,7 +175,7 @@ msgstr "Interwał pulsu"
 msgid "Heartbeat timeout"
 msgstr "Limit czasu pulsu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr "Przepisz nagłówek hosta"
 
@@ -185,30 +189,30 @@ msgstr ""
 "\"\", serwer zostanie podłączony bezpośrednio. <br> Domyślnie ta wartość "
 "jest odczytywana ze zmiennej środowiskowej \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr "Jeśli port_zdalny wynosi 0, frps przypisze Ci losowy port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "Lokalny IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "Port lokalny"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 "LocalIp określa adres IP lub nazwę hosta, do którego ma zostać wysłany proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr "LocalPort określa port, do którego należy się zwrócić."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr "Lokalizacje"
 
@@ -242,7 +246,7 @@ msgstr ""
 "logowania. Jeśli jest ona nieprawdziwa, klient spróbuje ponownie, dopóki "
 "próba logowania nie zakończy się sukcesem.<br> Domyślnie wartość true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr "Nazwa nie może być „wspólna”"
 
@@ -269,16 +273,16 @@ msgstr ""
 "wartości to \"tcp\", \"kcp\" i \"websocket\". <br> Domyślnie ta wartość to "
 "\"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "Ustawienia proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr "Typ proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
@@ -288,7 +292,7 @@ msgstr ""
 "\"http\", \"https\", \"stcp\" i \"xtcp\". <br> Domyślnie ta wartość to \"tcp"
 "\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr "Port zdalny"
 
@@ -296,7 +300,7 @@ msgstr "Port zdalny"
 msgid "Respawn when crashed"
 msgstr "Odradzaj się po awarii"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "Rola"
 
@@ -332,16 +336,16 @@ msgstr ""
 "ServerPort określa port do połączenia z serwerem on.<br> Domyślnie wartość "
 "ta wynosi 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr "Ustawienia uruchamiania"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr "Subdomena"
 
@@ -373,6 +377,12 @@ msgstr ""
 "prawdą, serwer musi również mieć włączone multipleksowanie TCP. <br> "
 "Domyślnie ta wartość to true."
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Token"
@@ -387,7 +397,7 @@ msgstr ""
 "zostać wysłane na serwer. Serwer musi mieć pasujący token, aby autoryzacja "
 "zakończyła się powodzeniem. <br> Domyślnie ta wartość to \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
@@ -395,7 +405,7 @@ msgstr ""
 "UseCompression kontroluje, czy komunikacja z serwerem będzie kompresowana. "
 "<br> Domyślnie ta wartość to false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -420,7 +430,7 @@ msgstr ""
 "automatycznie zmienione na \"{user}. {proxy_name}\". <br>W razie domyślnie "
 "ta wartość to \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "Klient frp"

--- a/applications/luci-app-frpc/po/pt/frpc.po
+++ b/applications/luci-app-frpc/po/pt/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "Endereço do administrador"
@@ -78,11 +82,11 @@ msgstr ""
 "Se o valor for \"\", os ativos serão carregados do que estiver embutido no "
 "executável usando o statik. <br>O valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "Configurações Comuns"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "Compressão"
 
@@ -91,7 +95,7 @@ msgid "Config files include in temporary config file"
 msgstr ""
 "Ficheiros de configuração incluídos no ficheiro de configuração temporário"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr "Domínios personalizados"
 
@@ -107,7 +111,7 @@ msgstr ""
 "DisableLogColor desativa o registo de cores quando LogWay == \"console\" for "
 "definido como true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Encriptação"
 
@@ -119,7 +123,7 @@ msgstr "Variável de ambiente"
 msgid "Exit when login fail"
 msgstr "Saír caso início de sessão falhar"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -127,11 +131,11 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app frpc"
 msgstr "Conceder acesso à app LuCI frps"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "Configurações HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "Palavra-passe HTTP"
 
@@ -139,7 +143,7 @@ msgstr "Palavra-passe HTTP"
 msgid "HTTP proxy"
 msgstr "Proxy HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "Utilizador HTTP"
 
@@ -171,7 +175,7 @@ msgstr "Intervalo do heartbeat"
 msgid "Heartbeat timeout"
 msgstr "Tempo limite do heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr "Reescrever o cabeçalho do host"
 
@@ -185,29 +189,29 @@ msgstr ""
 "dele. Se esse valor for \"\", o servidor será conectado diretamente. <br>O "
 "valor predefinido desse valor é lido da variável do ambiente \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr "Se remote_port for 0, frps atribuirá uma porta aleatória para si"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "IP local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "Porta local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr "LocalIp especifica o endereço IP ou nome de host para ser proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr "LocalPort especifica a porta para ser proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr "Locais"
 
@@ -242,7 +246,7 @@ msgstr ""
 "tentativa de login. Se falso, o cliente tentará novamente até que uma "
 "tentativa de login seja bem sucedida. <br>O valor predefinido é true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr "O nome pode não ser \"common\""
 
@@ -269,16 +273,16 @@ msgstr ""
 "Os valores válidos são \"tcp\", \"kcp\" e \"websocket\". <br>O valor "
 "predefinido é \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "Configurações de Proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr "Tipo de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
@@ -288,7 +292,7 @@ msgstr ""
 "\"udp\", \"http\", \"https\", \"stcp\", e \"xtcp\".<br>O valor predefinido é "
 "\"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr "Porta remota"
 
@@ -296,7 +300,7 @@ msgstr "Porta remota"
 msgid "Respawn when crashed"
 msgstr "Reiniciar caso travado"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "Função"
 
@@ -332,16 +336,16 @@ msgstr ""
 "ServerPort especifica a porta ao qual se conectar no servidor.<br>O valor "
 "predefinido é 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr "Configurações de inicialização"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr "Subdomínio"
 
@@ -373,6 +377,12 @@ msgstr ""
 "for true, o servidor deve ter multiplexing TCP ativado também. <br>O valor "
 "predefinido é verdadeiro."
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Chave eletrónica"
@@ -387,7 +397,7 @@ msgstr ""
 "enviadas para o servidor. O servidor deve ter um token correspondente para a "
 "autorização ter sucesso. O valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
@@ -395,7 +405,7 @@ msgstr ""
 "UseCompression controla se a comunicação com o servidor será compactada ou "
 "não. <br>O valor predefinido é false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -420,7 +430,7 @@ msgstr ""
 "automaticamente alterados para \"{utilizador}. {nome_do_proxy}\". <br>O "
 "valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "Cliente frp"

--- a/applications/luci-app-frpc/po/pt_BR/frpc.po
+++ b/applications/luci-app-frpc/po/pt_BR/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "Endereço do administrador"
@@ -79,11 +83,11 @@ msgstr ""
 "carregados do que estiver embutido no executável usando o statik.<br>O valor "
 "predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "Configurações Comuns"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "Compressão"
 
@@ -92,7 +96,7 @@ msgid "Config files include in temporary config file"
 msgstr ""
 "Arquivos de configuração incluídos no arquivo de configuração temporário"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr "Domínios customizados"
 
@@ -108,7 +112,7 @@ msgstr ""
 "DisableLogColor desativa as cores nos registros de log quando LogWay == "
 "\"console\" for definido como verdadeiro."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Criptografia"
 
@@ -120,7 +124,7 @@ msgstr "Variável de ambiente"
 msgid "Exit when login fail"
 msgstr "Encerre caso a autenticação falhe"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
@@ -128,11 +132,11 @@ msgstr "Configurações Gerais"
 msgid "Grant access to LuCI app frpc"
 msgstr "Conceder acesso ao aplicativo LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "Configurações HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "Senha HTTP"
 
@@ -140,7 +144,7 @@ msgstr "Senha HTTP"
 msgid "HTTP proxy"
 msgstr "Proxy HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "Usuário HTTP"
 
@@ -172,7 +176,7 @@ msgstr "Intervalo do Heartbeat"
 msgid "Heartbeat timeout"
 msgstr "Tempo limite do heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr "Reescrever cabeçalho do host"
 
@@ -186,30 +190,30 @@ msgstr ""
 "valor for \"\", o servidor usará conexão direta. <br>O valor predefinido é "
 "lido a partir da variável \"http_proxy\" do ambiente."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr ""
 "Se o remote_port for 0, o frps irá atribuir uma porta aleatória para você"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "IP Local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "Porta local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr "LocalIp determina o endereço IP ou o nome do host a ser procurado."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr "O LocalPort determina a porta a ser procurada."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr "Locais"
 
@@ -244,7 +248,7 @@ msgstr ""
 "login fracassada. Se falso, o cliente tentará novamente até que uma "
 "tentativa de login seja bem sucedida. <br>O valor predefinido é verdadeiro."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr "O nome não pode ser \"common\""
 
@@ -271,16 +275,16 @@ msgstr ""
 "Os valores válidos são \"tcp\", \"kcp\" e \"websocket\". <br>O valor "
 "predefinido é \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "Configurações de Proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr "Tipo de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
@@ -290,7 +294,7 @@ msgstr ""
 "\"udp\", \"http\", \"https\", \"stcp\" e \"xtcp\". <br>O valor predefinido é "
 "\"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr "Porta remota"
 
@@ -298,7 +302,7 @@ msgstr "Porta remota"
 msgid "Respawn when crashed"
 msgstr "Reiniciar caso entre em colapso"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "Papel"
 
@@ -334,16 +338,16 @@ msgstr ""
 "O ServerPort determina a porta para se conectar ao servidor. <br>O valor "
 "predefinido é 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr "Configurações de inicialização"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr "Subdomínio"
 
@@ -375,6 +379,12 @@ msgstr ""
 "for verdadeiro, o servidor também deve ter a multiplexação TCP ativada. "
 "<br>O valor predefinido é verdadeiro."
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Token"
@@ -389,7 +399,7 @@ msgstr ""
 "enviadas ao servidor. O servidor deve ter um token correspondente para que a "
 "autorização seja bem sucedida. <br>O valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
@@ -397,7 +407,7 @@ msgstr ""
 "UseCompression controla se a comunicação com o servidor será compactada ou "
 "não. <br>O valor predefinido é falso."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -422,7 +432,7 @@ msgstr ""
 "automaticamente alterados para \"{user}. {proxy_name}\". <br>O valor "
 "predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "Cliente frp"

--- a/applications/luci-app-frpc/po/ro/frpc.po
+++ b/applications/luci-app-frpc/po/ro/frpc.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurații adiționale"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -67,11 +71,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -79,7 +83,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -93,7 +97,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -105,7 +109,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Setări generale"
 
@@ -113,11 +117,11 @@ msgstr "Setări generale"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -125,7 +129,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -151,7 +155,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -162,29 +166,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -213,7 +217,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -234,23 +238,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -258,7 +262,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -290,16 +294,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -325,6 +329,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -336,13 +346,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -360,7 +370,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/ru/frpc.po
+++ b/applications/luci-app-frpc/po/ru/frpc.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Дополнительные настройки"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "Админ адрес"
@@ -67,11 +71,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -79,7 +83,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -93,7 +97,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Шифрование"
 
@@ -105,7 +109,7 @@ msgstr "Переменные окружения"
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Основные настройки"
 
@@ -113,11 +117,11 @@ msgstr "Основные настройки"
 msgid "Grant access to LuCI app frpc"
 msgstr "Предоставить доступ LuCI к приложению frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -125,7 +129,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -151,7 +155,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -162,29 +166,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -213,7 +217,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -234,23 +238,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -258,7 +262,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -290,16 +294,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -325,6 +329,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "Токен"
@@ -336,13 +346,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -360,7 +370,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/sk/frpc.po
+++ b/applications/luci-app-frpc/po/sk/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Šifrovanie"
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Všeobecné nastavenia"
 
@@ -112,11 +116,11 @@ msgstr "Všeobecné nastavenia"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/sv/frpc.po
+++ b/applications/luci-app-frpc/po/sv/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Extra konfigurationer"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Generella inställningar"
 
@@ -112,11 +116,11 @@ msgstr "Generella inställningar"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/templates/frpc.pot
+++ b/applications/luci-app-frpc/po/templates/frpc.pot
@@ -5,6 +5,10 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -57,11 +61,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -69,7 +73,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -83,7 +87,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -95,7 +99,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -103,11 +107,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -115,7 +119,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -141,7 +145,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -152,29 +156,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -203,7 +207,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -224,23 +228,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -248,7 +252,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -280,16 +284,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -315,6 +319,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -326,13 +336,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -350,7 +360,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/tr/frpc.po
+++ b/applications/luci-app-frpc/po/tr/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Şifreleme"
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
@@ -112,11 +116,11 @@ msgstr "Genel Ayarlar"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/uk/frpc.po
+++ b/applications/luci-app-frpc/po/uk/frpc.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -67,11 +71,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -79,7 +83,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -93,7 +97,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "Шифрування"
 
@@ -105,7 +109,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "Головні налаштування"
 
@@ -113,11 +117,11 @@ msgstr "Головні налаштування"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "Налаштування HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "Пароль HTTP"
 
@@ -125,7 +129,7 @@ msgstr "Пароль HTTP"
 msgid "HTTP proxy"
 msgstr "Проксі HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "Користувач HTTP"
 
@@ -151,7 +155,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -162,29 +166,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -213,7 +217,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -234,23 +238,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -258,7 +262,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -290,16 +294,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -325,6 +329,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -336,13 +346,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -360,7 +370,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/vi/frpc.po
+++ b/applications/luci-app-frpc/po/vi/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr ""
 
@@ -112,11 +116,11 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr ""
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frpc/po/zh_Hans/frpc.po
+++ b/applications/luci-app-frpc/po/zh_Hans/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "额外配置"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr "管理地址"
@@ -72,11 +76,11 @@ msgstr ""
 "AssetsDir指定管理服务器用于加载资源的本地目录。如果此值为空，则使用statik从可"
 "执行文件中加载资源。<br>默认情况下，此值为空。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr "通用设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr "压缩"
 
@@ -84,7 +88,7 @@ msgstr "压缩"
 msgid "Config files include in temporary config file"
 msgstr "配置文件包含在临时配置文件中"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr "自定义域名"
 
@@ -98,7 +102,7 @@ msgid ""
 "true."
 msgstr "当DisableLogColor设置为true且LogWay==\"console\"时禁用日志颜色。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr "加密"
 
@@ -110,7 +114,7 @@ msgstr "环境变量"
 msgid "Exit when login fail"
 msgstr "当登录失败时退出"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "常规设置"
 
@@ -118,11 +122,11 @@ msgstr "常规设置"
 msgid "Grant access to LuCI app frpc"
 msgstr "授予对LuCI应用程序frpc的访问权限"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr "HTTP 设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr "HTTP 密码"
 
@@ -130,7 +134,7 @@ msgstr "HTTP 密码"
 msgid "HTTP proxy"
 msgstr "HTTP 代理"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr "HTTP 用户"
 
@@ -160,7 +164,7 @@ msgstr "心跳包间隔时间"
 msgid "Heartbeat timeout"
 msgstr "心跳包超时"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr "主机头重写"
 
@@ -173,29 +177,29 @@ msgstr ""
 "HttpProxy 指定连接到服务器所用的代理地址。如果此值空，则直接连接服务器。<br>"
 "默认情况下，从\"http_proxy\"环境变量中读取此值。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr "如果remote_port为 0，frps 将为您随机分配一个端口"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
 msgid "Local IP"
 msgstr "本地 IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr "监听端口"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr "LocalIp 指定要被代理的 IP 地址或主机名。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr "LocalPort 指定要被代理的端口。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr "位置"
 
@@ -228,7 +232,7 @@ msgstr ""
 "LoginFailExit 控制客户端在尝试登录失败后是否应退出。如果为 false，客户端将重"
 "试，直到登录成功。<br>默认情况下，此值为 true。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr "名称不能\"common\""
 
@@ -253,25 +257,25 @@ msgstr ""
 "Protocol 指定在与服务器交互时要使用的协议。有效值为\"tcp\"、\"kcp\"和"
 "\"websocket\"。<br>默认情况下，此值为\"tcp\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr "代理设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr "代理类型"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
-"ProxyType 指定此代理的类型。有效值包括\"tcp\"、\"udp\"、\"http\"、\"http\"、\"https\"、\"stcp\"和"
-"\"xtcp\"。<br>默认情况下，此值为\"tcp\"。"
+"ProxyType 指定此代理的类型。有效值包括\"tcp\"、\"udp\"、\"http\"、\"http"
+"\"、\"https\"、\"stcp\"和\"xtcp\"。<br>默认情况下，此值为\"tcp\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr "远程端口"
 
@@ -279,7 +283,7 @@ msgstr "远程端口"
 msgid "Respawn when crashed"
 msgstr "崩溃时重启"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr "角色"
 
@@ -312,16 +316,16 @@ msgid ""
 "this value is 7000."
 msgstr "ServerPort 指定要连接到的服务器端口。<br>默认情况下，此值为 7000。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr "启动设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr "子域名"
 
@@ -349,6 +353,12 @@ msgstr ""
 "TcpMux 切换 TCP 流多路复用。这允许来自客户端的多个请求共享单个 TCP 连接。如果"
 "此值为 true，则服务器必须启用 TCP 多路复用。<br>默认情况下，此值为 true。"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "令牌"
@@ -362,14 +372,14 @@ msgstr ""
 "Token 指定用于创建要发送到服务器的密钥的授权令牌。服务器必须具有匹配的令牌才"
 "能成功进行授权。<br>默认情况下，此值为空。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 "UseCompression 控制是否压缩与服务器的通信。<br>默认情况下，此值为 false。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -391,7 +401,7 @@ msgstr ""
 "User 为代理名称指定前缀，以将它们与其他客户端区分开来。如果此值不为空，则代理"
 "名称将自动更改为\"{user}.{proxy_name}\"。<br>默认情况下，此值为空。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "frp 客户端"

--- a/applications/luci-app-frpc/po/zh_Hant/frpc.po
+++ b/applications/luci-app-frpc/po/zh_Hant/frpc.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "額外設定"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Admin address"
 msgstr ""
@@ -66,11 +70,11 @@ msgid ""
 "bundled executable using statik.<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:126
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid "Compression"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Config files include in temporary config file"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:52
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
 msgid "Custom domains"
 msgstr ""
 
@@ -92,7 +96,7 @@ msgid ""
 "true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid "Encryption"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr ""
 msgid "Exit when login fail"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:151
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -112,11 +116,11 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "HTTP Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
 msgid "HTTP password"
 msgstr ""
 
@@ -124,7 +128,7 @@ msgstr ""
 msgid "HTTP proxy"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "HTTP user"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:60
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:61
 msgid "Host header rewrite"
 msgstr ""
 
@@ -161,29 +165,29 @@ msgid ""
 "this value is read from the \"http_proxy\" environment variable."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
-msgid "Local IP"
 msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:156
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:157
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
 msgid "LocalPort specifies the port to proxy to."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Locations"
 msgstr ""
 
@@ -212,7 +216,7 @@ msgid ""
 "succeeds.<br>By default, this value is true."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:145
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:146
 msgid "Name can not be \"common\""
 msgstr ""
 
@@ -233,23 +237,23 @@ msgid ""
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:138
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:139
 msgid "Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:154
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br>By default, this "
 "value is \"tcp\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "Remote port"
 msgstr ""
 
@@ -257,7 +261,7 @@ msgstr ""
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Role"
 msgstr ""
 
@@ -289,16 +293,16 @@ msgid ""
 "this value is 7000."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:67
 msgid "Sk"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:127
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:131
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:128
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "Subdomain"
 msgstr ""
 
@@ -324,6 +328,12 @@ msgid ""
 "true."
 msgstr ""
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
+
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Token"
 msgstr "權杖"
@@ -335,13 +345,13 @@ msgid ""
 "succeed. <br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:43
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br>By default, this value is false."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:42
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -359,7 +369,7 @@ msgid ""
 "changed to \"{user}.{proxy_name}\".<br>By default, this value is \"\"."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:121
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:122
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr ""

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -38,7 +38,8 @@ var commonConf = [
 	[form.Value, 'custom_404_page', _('Custom 404 page'), _('Custom404Page specifies a path to a custom 404 page to display. If this value is "", a default page will be displayed.<br>By default, this value is "".')],
 	[form.Value, 'allow_ports', _('Allow ports'), _('AllowPorts specifies a set of ports that clients are able to proxy to. If the length of this value is 0, all ports are allowed.<br>By default, this value is an empty set.')],
 	[form.Value, 'max_ports_per_client', _('Max ports per client'), _('MaxPortsPerClient specifies the maximum number of ports a single client may proxy to. If this value is 0, no limit will be applied.<br>By default, this value is 0.'), {datatype: 'uinteger'}],
-	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'), _('HeartBeatTimeout specifies the maximum time to wait for a heartbeat before terminating the connection. It is not recommended to change this value.<br>By default, this value is 90.'), {datatype: 'uinteger'}]
+	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'), _('HeartBeatTimeout specifies the maximum time to wait for a heartbeat before terminating the connection. It is not recommended to change this value.<br>By default, this value is 90.'), {datatype: 'uinteger'}],
+	[form.DynamicList, '_', _('Additional settings'), _('This list can be used to specify some additional parameters which have not been included in this LuCI.'), {placeholder: 'Key-A=Value-A'}]
 ];
 
 function setParams(o, params) {

--- a/applications/luci-app-frps/po/ar/frps.po
+++ b/applications/luci-app-frps/po/ar/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/bg/frps.po
+++ b/applications/luci-app-frps/po/bg/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/bn_BD/frps.po
+++ b/applications/luci-app-frps/po/bn_BD/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/ca/frps.po
+++ b/applications/luci-app-frps/po/ca/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/cs/frps.po
+++ b/applications/luci-app-frps/po/cs/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/de/frps.po
+++ b/applications/luci-app-frps/po/de/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Zusätzliche Konfiguration"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Erlaube Ports"
@@ -86,7 +90,7 @@ msgstr ""
 "Wert 0 ist, lauscht der Server nicht auf KCP-Verbindungen.<br>Standardmäßig "
 "ist dieser Wert 0"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -292,8 +296,8 @@ msgstr "Daemon als Gruppe ausführen"
 msgid "Run daemon as user"
 msgstr "Daemon als Gruppe ausführen"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr "Start-Einstellungen"
 
@@ -327,6 +331,12 @@ msgstr ""
 "TcpMux schaltet das TCP-Stream-Multiplexing um. Dies erlaubt mehreren "
 "Anfragen von einem Client, sich eine einzige TCP-Verbindung zu teilen.<br>In "
 "der Voreinstellung ist dieser Wert wahr."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Token"
@@ -387,7 +397,7 @@ msgstr ""
 "abhört. Wenn dieser Wert 0 ist, lauscht der Server nicht auf HTTP-Anfragen."
 "<br>Standardmäßig ist dieser Wert 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "frp-Server"

--- a/applications/luci-app-frps/po/el/frps.po
+++ b/applications/luci-app-frps/po/el/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -70,7 +74,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -242,8 +246,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -268,6 +272,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -317,7 +327,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/en/frps.po
+++ b/applications/luci-app-frps/po/en/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/es/frps.po
+++ b/applications/luci-app-frps/po/es/frps.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configuraciones adicionales"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Permitir puertos"
@@ -89,7 +93,7 @@ msgstr ""
 "valor es 0, el servidor no escuchará las conexiones UDP.<br>Por defecto, "
 "este valor es 0"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "Configuraciones comunes"
 
@@ -298,8 +302,8 @@ msgstr "Ejecutar demonio como grupo"
 msgid "Run daemon as user"
 msgstr "Ejecutar demonio como usuario"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr "Configuraciones de inicio"
 
@@ -333,6 +337,12 @@ msgstr ""
 "TcpMux alterna la multiplexación de flujo TCP. Esto permite que múltiples "
 "solicitudes de un cliente compartan una sola conexión TCP.<br>Por defecto, "
 "este valor es verdadero."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Token"
@@ -393,7 +403,7 @@ msgstr ""
 "solicitudes HTTPS Vhost. Si este valor es 0, el servidor no escuchará las "
 "solicitudes HTTPS.<br>Por defecto, este valor es 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "Servidor frp"

--- a/applications/luci-app-frps/po/fi/frps.po
+++ b/applications/luci-app-frps/po/fi/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -70,7 +74,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -242,8 +246,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -268,6 +272,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -317,7 +327,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/fr/frps.po
+++ b/applications/luci-app-frps/po/fr/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurations supplémentaires"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Autoriser les ports"
@@ -87,7 +91,7 @@ msgstr ""
 "valeur est 0, le serveur n'écoutera pas les connexions UDP.<br>Par défaut, "
 "cette valeur est 0"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "Paramètres communs"
 
@@ -295,8 +299,8 @@ msgstr "Exécuter le démon en tant que groupe"
 msgid "Run daemon as user"
 msgstr "Exécuter le démon en tant qu'utilisateur"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr "Paramètres de démarrage"
 
@@ -330,6 +334,12 @@ msgstr ""
 "TcpMux bascule le multiplexage de flux TCP. Cela permet à plusieurs demandes "
 "d'un client de partager une seule connexion TCP.<br>Par défaut, cette valeur "
 "est vraie."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Token"
@@ -389,7 +399,7 @@ msgstr ""
 "HTTPS Vhost. Si cette valeur est 0, le serveur n'écoutera pas les requêtes "
 "HTTPS.<br>Par défaut, cette valeur est 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "frp Server"

--- a/applications/luci-app-frps/po/he/frps.po
+++ b/applications/luci-app-frps/po/he/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/hi/frps.po
+++ b/applications/luci-app-frps/po/hi/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/hu/frps.po
+++ b/applications/luci-app-frps/po/hu/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -70,7 +74,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -242,8 +246,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr "Démon futtatása felhasználóként"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -268,6 +272,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -317,7 +327,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/it/frps.po
+++ b/applications/luci-app-frps/po/it/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/ja/frps.po
+++ b/applications/luci-app-frps/po/ja/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "追加の構成"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -70,7 +74,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "共通設定"
 
@@ -242,8 +246,8 @@ msgstr "デーモンをグループとして実行"
 msgid "Run daemon as user"
 msgstr "デーモンをユーザーとして実行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -268,6 +272,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -317,7 +327,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/ko/frps.po
+++ b/applications/luci-app-frps/po/ko/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/mr/frps.po
+++ b/applications/luci-app-frps/po/mr/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "अतिरिक्त कॉन्फिगरेशन"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -70,7 +74,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -242,8 +246,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -268,6 +272,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -317,7 +327,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/ms/frps.po
+++ b/applications/luci-app-frps/po/ms/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/nb_NO/frps.po
+++ b/applications/luci-app-frps/po/nb_NO/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/pl/frps.po
+++ b/applications/luci-app-frps/po/pl/frps.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Dodatkowe konfiguracje"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Zezwalaj na porty"
@@ -87,7 +91,7 @@ msgstr ""
 "wynosi 0, serwer nie będzie nasłuchiwał połączeń UDP. <br> Domyślnie ta "
 "wartość wynosi 0"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "Wspólne ustawienia"
 
@@ -292,8 +296,8 @@ msgstr "Uruchom demona jako grupę"
 msgid "Run daemon as user"
 msgstr "Uruchom daemona jako użytkownik"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr "Ustawienia startowe"
 
@@ -326,6 +330,12 @@ msgstr ""
 "TcpMux przełącza multipleksowanie strumienia TCP. Pozwala to na "
 "współdzielenie wielu żądań od klienta na jedno połączenie TCP.<br> Domyślnie "
 "wartość ta jest true."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Token"
@@ -385,7 +395,7 @@ msgstr ""
 "Jeśli ta wartość wynosi 0, serwer nie będzie nasłuchiwał żądań HTTPS. <br> "
 "Domyślnie ta wartość wynosi 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "Serwer frp"

--- a/applications/luci-app-frps/po/pt/frps.po
+++ b/applications/luci-app-frps/po/pt/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Permitir portas"
@@ -84,7 +88,7 @@ msgstr ""
 "BindUdpPort determina a porta UDP em que o servidor atende. Se esse valor "
 "for 0, o servidor não atenderá às conexões UDP. <br>O valor predefinido é 0"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "Configurações Comuns"
 
@@ -290,8 +294,8 @@ msgstr "Executar daemon como grupo"
 msgid "Run daemon as user"
 msgstr "Executar serviço como utilizador"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr "Configurações de inicialização"
 
@@ -325,6 +329,12 @@ msgstr ""
 "TcpMux alterna a multiplexação do fluxo TCP. Isso permite que várias "
 "solicitações de um cliente compartilhem uma única ligação TCP.<br>O valor "
 "predefinido é verdadeiro."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Token"
@@ -384,7 +394,7 @@ msgstr ""
 "HTTPS Vhost. Se esse valor for 0, o servidor não atenderá solicitações "
 "https. <br>O valor predefinido é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "Servidor frp"

--- a/applications/luci-app-frps/po/pt_BR/frps.po
+++ b/applications/luci-app-frps/po/pt_BR/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Permitir portas"
@@ -84,7 +88,7 @@ msgstr ""
 "BindUdpPort determina a porta UDP em que o servidor atende. Se esse valor "
 "for 0, o servidor não atenderá às conexões UDP. <br>O valor predefinido é 0"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "Configurações Comuns"
 
@@ -290,8 +294,8 @@ msgstr "Executar serviço como usuário"
 msgid "Run daemon as user"
 msgstr "Executar serviço como usuário"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr "Configurações de inicialização"
 
@@ -325,6 +329,12 @@ msgstr ""
 "TcpMux alterna a multiplexação do fluxo TCP. Isso permite que várias "
 "solicitações de um cliente compartilhem uma única conexão TCP.<br>O valor "
 "predefinido é verdadeiro."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Token"
@@ -384,7 +394,7 @@ msgstr ""
 "Vhost. Se esse valor for 0, o servidor não atenderá solicitações https. "
 "<br>O valor predefinido é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "Servidor frp"

--- a/applications/luci-app-frps/po/ro/frps.po
+++ b/applications/luci-app-frps/po/ro/frps.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Configurații adiționale"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Permite porturi"
@@ -77,7 +81,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -249,8 +253,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -275,6 +279,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -324,7 +334,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/ru/frps.po
+++ b/applications/luci-app-frps/po/ru/frps.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Дополнительные настройки"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Разрешить порты"
@@ -71,7 +75,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "Общие настройки"
 
@@ -243,8 +247,8 @@ msgstr "Запуск демона от имени группы"
 msgid "Run daemon as user"
 msgstr "Запуск демона от имени пользователя"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -269,6 +273,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -318,7 +328,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/sk/frps.po
+++ b/applications/luci-app-frps/po/sk/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/sv/frps.po
+++ b/applications/luci-app-frps/po/sv/frps.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "Extra konfigurationer"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "Tillåt portar"
@@ -71,7 +75,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -243,8 +247,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -269,6 +273,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -318,7 +328,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/templates/frps.pot
+++ b/applications/luci-app-frps/po/templates/frps.pot
@@ -5,6 +5,10 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -61,7 +65,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -233,8 +237,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -259,6 +263,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -308,7 +318,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/tr/frps.po
+++ b/applications/luci-app-frps/po/tr/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -70,7 +74,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -242,8 +246,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -268,6 +272,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -317,7 +327,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/uk/frps.po
+++ b/applications/luci-app-frps/po/uk/frps.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -71,7 +75,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -243,8 +247,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -269,6 +273,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -318,7 +328,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/vi/frps.po
+++ b/applications/luci-app-frps/po/vi/frps.po
@@ -8,6 +8,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr ""
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -64,7 +68,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -236,8 +240,8 @@ msgstr ""
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -262,6 +266,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -311,7 +321,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""

--- a/applications/luci-app-frps/po/zh_Hans/frps.po
+++ b/applications/luci-app-frps/po/zh_Hans/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "额外配置"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr "允许的端口"
@@ -59,7 +63,9 @@ msgid ""
 "BindKcpPort specifies the KCP port that the server listens on. If this value "
 "is 0, the server will not listen for KCP connections.<br>By default, this "
 "value is 0."
-msgstr "BindKcpPort 指定服务器侦听的 KCP 端口。如果此值为 0，则服务器将不会侦听 KCP 连接。<br>默认值为 0。"
+msgstr ""
+"BindKcpPort 指定服务器侦听的 KCP 端口。如果此值为 0，则服务器将不会侦听 KCP "
+"连接。<br>默认值为 0。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
 msgid ""
@@ -72,9 +78,11 @@ msgid ""
 "BindUdpPort specifies the UDP port that the server listens on. If this value "
 "is 0, the server will not listen for UDP connections.<br>By default, this "
 "value is 0"
-msgstr "BindUdpPort 指定服务器侦听的 UDP 端口。如果此值为 0，则服务器将不会侦听 UDP 连接。<br>默认值为 0"
+msgstr ""
+"BindUdpPort 指定服务器侦听的 UDP 端口。如果此值为 0，则服务器将不会侦听 UDP "
+"连接。<br>默认值为 0"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr "常规设置"
 
@@ -91,7 +99,9 @@ msgid ""
 "Custom404Page specifies a path to a custom 404 page to display. If this "
 "value is \"\", a default page will be displayed.<br>By default, this value "
 "is \"\"."
-msgstr "Custom404Page 指定要显示的自定义 404 页面的路径。如果此值为\"\"，将显示默认页面。<br>默认值为\"\"。"
+msgstr ""
+"Custom404Page 指定要显示的自定义 404 页面的路径。如果此值为\"\"，将显示默认页"
+"面。<br>默认值为\"\"。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
 msgid "Dashboard address"
@@ -120,7 +130,9 @@ msgid ""
 "DashboardPort specifies the port that the dashboard listens on. If this "
 "value is 0, the dashboard will not be started.<br>By default, this value is "
 "0."
-msgstr "DashboardPort 指定仪表板侦听的端口。如果此值为 0，则不会启动仪表板。<br>默认值为 0。"
+msgstr ""
+"DashboardPort 指定仪表板侦听的端口。如果此值为 0，则不会启动仪表板。<br>默认"
+"值为 0。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
 msgid ""
@@ -143,7 +155,8 @@ msgid ""
 "DisableLogColor disables log colors when LogWay == \"console\" when set to "
 "true.<br>By default, this value is false."
 msgstr ""
-"当 LogWay == \"console\" 设置为 true 时，DisableLogColor 禁用日志颜色 。<br>默认值为 false。"
+"当 LogWay == \"console\" 设置为 true 时，DisableLogColor 禁用日志颜色 。<br>"
+"默认值为 false。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
 msgid "Environment variable"
@@ -158,7 +171,9 @@ msgid ""
 "HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
 "terminating the connection. It is not recommended to change this value."
 "<br>By default, this value is 90."
-msgstr "HeartBeatTimeout 指定在终止连接前等待检测心跳包的最长时间。不建议更改此值。<br>默认值为 90。"
+msgstr ""
+"HeartBeatTimeout 指定在终止连接前等待检测心跳包的最长时间。不建议更改此值。"
+"<br>默认值为 90。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
 msgid "Heartbeat timeout"
@@ -193,7 +208,9 @@ msgid ""
 "LogFile specifies a file where logs will be written to. This value will only "
 "be used if LogWay is set appropriately.<br>By default, this value is "
 "\"console\"."
-msgstr "LogFile 指定写入日志的文件。仅当正确设置 LogWay 时，才会使用此值。<br>默认值为“console”。"
+msgstr ""
+"LogFile 指定写入日志的文件。仅当正确设置 LogWay 时，才会使用此值。<br>默认值"
+"为“console”。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
 msgid ""
@@ -208,7 +225,9 @@ msgid ""
 "LogMaxDays specifies the maximum number of days to store log information "
 "before deletion. This is only used if LogWay == \"file\".<br>By default, "
 "this value is 0."
-msgstr "LogMaxDays 指定删除前存储日志信息的最长天数。仅当 LogWay == \"file\" 时才使用。<br>默认值为 0。"
+msgstr ""
+"LogMaxDays 指定删除前存储日志信息的最长天数。仅当 LogWay == \"file\" 时才使"
+"用。<br>默认值为 0。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
 msgid "Max ports per client"
@@ -219,7 +238,9 @@ msgid ""
 "MaxPortsPerClient specifies the maximum number of ports a single client may "
 "proxy to. If this value is 0, no limit will be applied.<br>By default, this "
 "value is 0."
-msgstr "MaxPortsPerClient 指定单个客户端可以代理的最大端口数。如果此值为 0，则不作任何限制。<br>默认值为 0。"
+msgstr ""
+"MaxPortsPerClient 指定单个客户端可以代理的最大端口数。如果此值为 0，则不作任"
+"何限制。<br>默认值为 0。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
 msgid ""
@@ -237,7 +258,9 @@ msgstr "代理绑定地址"
 msgid ""
 "ProxyBindAddr specifies the address that the proxy binds to. This value may "
 "be the same as BindAddr.<br>By default, this value is \"0.0.0.0\"."
-msgstr "ProxyBindAddr 指定代理绑定到的地址。此值可能与 BindAddr 相同。<br>默认值为“0.0.0.0”。"
+msgstr ""
+"ProxyBindAddr 指定代理绑定到的地址。此值可能与 BindAddr 相同。<br>默认值"
+"为“0.0.0.0”。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
 msgid "Respawn when crashed"
@@ -251,8 +274,8 @@ msgstr "以此组权限运行"
 msgid "Run daemon as user"
 msgstr "以此用户权限运行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr "启动设置"
 
@@ -264,8 +287,9 @@ msgid ""
 "\", the resulting URL would be \"test.frps.com\".<br>By default, this value "
 "is \"\"."
 msgstr ""
-"SubDomainHost 指定使用 Vhost 代理时附加到客户端请求的子域的域名。例如：如果此值设置为“frps."
-"com”，并且客户端请求子域“test”，则生成的 URL 将是“test.frps.com”。<br>默认值为\"\"。"
+"SubDomainHost 指定使用 Vhost 代理时附加到客户端请求的子域的域名。例如：如果此"
+"值设置为“frps.com”，并且客户端请求子域“test”，则生成的 URL 将是“test.frps."
+"com”。<br>默认值为\"\"。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
 msgid "Subdomain host"
@@ -279,7 +303,15 @@ msgstr "TCP 多路复用"
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
-msgstr "TcpMux切换TCP流复用。这允许来自一个客户端的多个请求共享一个TCP连接。<br>该值默认为true。"
+msgstr ""
+"TcpMux切换TCP流复用。这允许来自一个客户端的多个请求共享一个TCP连接。<br>该值"
+"默认为true。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
+msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Token"
@@ -290,7 +322,9 @@ msgid ""
 "Token specifies the authorization token used to authenticate keys received "
 "from clients. Clients must have a matching token to be authorized to use the "
 "server.<br>By default, this value is \"\"."
-msgstr "令牌指定用于对从客户端接收的密钥进行验证的授权令牌。客户端必须有匹配的令牌才能被授权使用服务器。<br>该值默认为 \"\"。"
+msgstr ""
+"令牌指定用于对从客户端接收的密钥进行验证的授权令牌。客户端必须有匹配的令牌才"
+"能被授权使用服务器。<br>该值默认为 \"\"。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
 msgid "UDP bind port"
@@ -313,13 +347,17 @@ msgid ""
 "VhostHttpPort specifies the port that the server listens for HTTP Vhost "
 "requests. If this value is 0, the server will not listen for HTTP requests."
 "<br>By default, this value is 0."
-msgstr "VhostHttpPort指定服务器侦听HTTP Vhost请求的端口。如果该值为0，服务器将不侦听HTTP请求。<br>该值默认为0。"
+msgstr ""
+"VhostHttpPort指定服务器侦听HTTP Vhost请求的端口。如果该值为0，服务器将不侦听"
+"HTTP请求。<br>该值默认为0。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
 msgid ""
 "VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
 "server, in seconds.<br>By default, this value is 60."
-msgstr "VhostHttpTimeout指定Vhost HTTP服务器的响应头超时，单位为秒。<br>该值默认为 60。"
+msgstr ""
+"VhostHttpTimeout指定Vhost HTTP服务器的响应头超时，单位为秒。<br>该值默认为 "
+"60。"
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
 msgid ""
@@ -327,9 +365,10 @@ msgid ""
 "requests. If this value is 0, the server will not listen for HTTPS requests."
 "<br>By default, this value is 0."
 msgstr ""
-"VhostHttpsPort指定服务器侦听HTTPS Vhost请求的端口。如果该值为0，服务器将不侦听HTTPS请求。.<br>该值默认为 0。"
+"VhostHttpsPort指定服务器侦听HTTPS Vhost请求的端口。如果该值为0，服务器将不侦"
+"听HTTPS请求。.<br>该值默认为 0。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "frp 服务器"

--- a/applications/luci-app-frps/po/zh_Hant/frps.po
+++ b/applications/luci-app-frps/po/zh_Hant/frps.po
@@ -14,6 +14,10 @@ msgstr ""
 msgid "Additional configs"
 msgstr "額外設定"
 
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid "Additional settings"
+msgstr ""
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "Allow ports"
 msgstr ""
@@ -70,7 +74,7 @@ msgid ""
 "value is 0"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:101
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Common settings"
 msgstr ""
 
@@ -242,8 +246,8 @@ msgstr "以群組執行背景執行"
 msgid "Run daemon as user"
 msgstr "以此使用者權限執行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:106
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:103
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:107
 msgid "Startup settings"
 msgstr ""
 
@@ -268,6 +272,12 @@ msgstr ""
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br>By default, this value is true."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+msgid ""
+"This list can be used to specify some additional parameters which have not "
+"been included in this LuCI."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
@@ -317,7 +327,7 @@ msgid ""
 "<br>By default, this value is 0."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:96
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:97
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr ""


### PR DESCRIPTION
Maintainer: @ysc3839 
Add a dynamiclist which can be used to define some additional parameters. The init.d scripts have already supported this option.