### PR TITLE
luci-app-mwan3: Add UDP rule hint for QUIC

### DIFF
--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua
@@ -48,6 +48,7 @@ mwan_rule = m:section(TypedSection, "rule", nil,
 	"Rules are based on IP address, port or protocol<br />" ..
 	"Rules are matched from top to bottom<br />" ..
 	"Rules below a matching rule are ignored<br />" ..
+	"Traffic over port 443/HTTPS using QUIC or Chrome requires UDP<br />" ..
 	"Traffic not matching any rule is routed using the main routing table<br />" ..
 	"Traffic destined for known (other than default) networks is handled by the main routing table<br />" ..
 	"Traffic matching a rule, but all WAN interfaces for that policy are down will be blackholed<br />" ..


### PR DESCRIPTION
@feckert QUIC uses UDP and while new, is widespread enough that users may not even be aware it's not over TCP. Adding a rule hint seems less invasive than creating a whole template. Most users who are aware of what QUIC is are probably aware they need to swap the rule to UDP. Perhaps at some point in the future, this would default to UDP.
Closes https://github.com/openwrt/packages/issues/11571

Avinash H. Duduskar 2946372+Strykar@users.noreply.github.com