### PR TITLE
luci-app-adblock: sync with adblock 4.0.8

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -290,12 +290,25 @@ return view.extend({
 		o.nocreate = true;
 		o.rmempty = true;
 
-		o = s.taboption('general', form.Flag, 'adb_forcedns', _('Force Local DNS'), _('Redirect all DNS queries from \'lan\' zone to the local DNS resolver, applies to UDP and TCP protocol.'));
+		o = s.taboption('general', form.Flag, 'adb_forcedns', _('Force Local DNS'), _('Redirect all DNS queries from specified zones to the local DNS resolver, applies to UDP and TCP protocol.'));
 		o.rmempty = false;
 
-		o = s.taboption('general', form.Value, 'adb_portlist', _('Local DNS Ports'), _('Space separated list of DNS-related firewall ports which should be forced locally.'));
+		o = s.taboption('general', widgets.ZoneSelect, 'adb_zonelist', _('Forced Zones'), _('Firewall source zones that should be forced locally.'));
 		o.depends('adb_forcedns', '1');
-		o.placeholder = '53 853 5353';
+		o.unspecified = true;
+		o.multiple = true;
+		o.nocreate = true;
+		o.rmempty = true;
+
+		o = s.taboption('general', form.DynamicList, 'adb_portlist', _('Forced Ports'), _('Firewall ports that should be forced locally.'));
+		o.depends('adb_forcedns', '1');
+		o.unspecified = true;
+		o.multiple = true;
+		o.nocreate = false;
+		o.datatype = 'port';
+		o.value('53');
+		o.value('853');
+		o.value('5353');
 		o.rmempty = true;
 
 		o = s.taboption('general', form.Flag, 'adb_safesearch', _('Enable SafeSearch'), _('Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and pixabay.'));
@@ -368,11 +381,12 @@ return view.extend({
 		o.rmempty = true;
 
 		o = s.taboption('additional', form.ListValue, 'adb_fetchutil', _('Download Utility'), _('List of supported and fully pre-configured download utilities.'));
+		o.value('', _('- unspecified -'));
 		o.value('uclient-fetch');
 		o.value('wget');
 		o.value('curl');
 		o.value('aria2c');
-		o.rmempty = false;
+		o.rmempty = true;
 
 		o = s.taboption('additional', form.Value, 'adb_fetchparm', _('Download Parameters'), _('Special config options for the selected download utility.'))
 		o.rmempty = true;
@@ -382,12 +396,13 @@ return view.extend({
 		*/
 		o = s.taboption('adv_dns', form.ListValue, 'adb_dns', _('DNS Backend'), _('List of supported DNS backends with their default list directory. \
 			To overwrite the default path use the \'DNS Directory\' option.'));
+		o.value('', _('- unspecified -'));
 		o.value('dnsmasq', _('dnsmasq (/tmp/dnsmasq.d)'));
 		o.value('unbound', _('unbound (/var/lib/unbound)'));
 		o.value('named', _('named (/var/lib/bind)'));
 		o.value('kresd', _('kresd (/etc/kresd)'));
 		o.value('raw', _('raw (/tmp)'));
-		o.rmempty = false;
+		o.rmempty = true;
 
 		o = s.taboption('adv_dns', form.Value, 'adb_dnsdir', _('DNS Directory'), _('Target directory for the generated blocklist \'adb_list.overall\'.'));
 		o.placeholder = '/tmp';

--- a/applications/luci-app-adblock/po/ar/adblock.po
+++ b/applications/luci-app-adblock/po/ar/adblock.po
@@ -11,6 +11,11 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.3.1\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "إجراء"
@@ -44,7 +49,7 @@ msgstr "أضف هذا النطاق (الفرعي) لقائمتك السوداء 
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "أضف هذا النطاق (الفرعي) لقائمتك المسموحة المحلية."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "قائمة حظر إضافية"
 
@@ -52,7 +57,7 @@ msgstr "قائمة حظر إضافية"
 msgid "Additional Settings"
 msgstr "إعدادات إضافية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "وقت انتظار إضافي بالثواني قبل الشروع في تطبيق إعدادات أدبلوك."
 
@@ -72,15 +77,15 @@ msgstr "إعدادات متقدمة للتقارير"
 msgid "Answer"
 msgstr "إجابة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "مجلد النسخ الاحتياطي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "مجلد التخزين المؤقت الأساسي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -113,7 +118,7 @@ msgstr "نطاق محظور"
 msgid "Blocked Domains"
 msgstr "نطاقات محظورة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "نسخة احتياطية لقائمة الحظر"
 
@@ -129,7 +134,7 @@ msgstr "استعلام لقائمة الحظر..."
 msgid "Blocklist Sources"
 msgstr "مصادر قائمة الحظر"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -177,32 +182,32 @@ msgstr ""
 msgid "Count"
 msgstr "العدد"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -210,21 +215,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -233,39 +238,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -279,11 +284,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -291,7 +296,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -303,7 +308,7 @@ msgstr "مفعل"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -313,11 +318,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -327,11 +332,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -339,7 +352,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -358,7 +379,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -370,15 +391,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -388,7 +409,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -406,12 +427,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -419,7 +436,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -440,7 +457,7 @@ msgstr ""
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -452,23 +469,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -496,39 +513,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -561,13 +578,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -579,27 +596,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -619,23 +630,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -687,7 +698,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -701,7 +712,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -709,7 +720,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -718,7 +729,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -733,11 +744,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -745,14 +756,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/bg/adblock.po
+++ b/applications/luci-app-adblock/po/bg/adblock.po
@@ -4,6 +4,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -37,7 +42,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +50,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +70,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,7 +107,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -118,7 +123,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -157,32 +162,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -190,21 +195,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -213,39 +218,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -259,11 +264,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -271,7 +276,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -283,7 +288,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -293,11 +298,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -307,11 +312,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -319,7 +332,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -338,7 +359,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -350,15 +371,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -368,7 +389,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -386,12 +407,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -399,7 +416,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -420,7 +437,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -432,23 +449,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -476,39 +493,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -541,13 +558,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -559,27 +576,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -599,23 +610,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -667,7 +678,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -681,7 +692,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -698,7 +709,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -713,11 +724,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -725,14 +736,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/bn_BD/adblock.po
+++ b/applications/luci-app-adblock/po/bn_BD/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0.2\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +76,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,7 +113,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -124,7 +129,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,32 +168,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,11 +270,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,7 +294,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +318,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +338,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +365,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -374,7 +395,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -392,12 +413,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -405,7 +422,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -426,7 +443,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -438,23 +455,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,39 +499,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -547,13 +564,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -565,27 +582,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -605,23 +616,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -673,7 +684,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +698,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +706,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,7 +715,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -719,11 +730,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -731,14 +742,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ca/adblock.po
+++ b/applications/luci-app-adblock/po/ca/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Acció"
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Retard addicional en segons de l’activador abans que comenci el processament "
@@ -73,15 +78,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +115,7 @@ msgstr "Domini blocat"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,7 +131,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Fonts de la llista negra"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -165,32 +170,32 @@ msgstr ""
 msgid "Count"
 msgstr "Recompte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Directori del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Reinicialització de fitxers del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -221,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Notificació per correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Adreça de destinatari de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,11 +272,11 @@ msgstr "Edita la llista negra"
 msgid "Edit Whitelist"
 msgstr "Edita la llista blanca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -279,7 +284,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,7 +296,7 @@ msgstr "Activat"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,11 +320,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Purga la memòria cau del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -327,7 +340,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Força el DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -346,7 +367,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -358,15 +379,15 @@ msgstr "Darrera execució"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -376,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -394,20 +415,16 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Llista d’utilitats de baixada admeses i plenament preconfigurades."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Servei de prioritat baixa"
 
@@ -428,7 +445,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -440,23 +457,23 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -484,39 +501,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -549,13 +566,13 @@ msgstr ""
 msgid "Save"
 msgstr "Desa"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -567,27 +584,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -607,23 +618,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -675,7 +686,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -697,7 +708,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -706,7 +717,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
@@ -721,11 +732,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -733,15 +744,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/cs/adblock.po
+++ b/applications/luci-app-adblock/po/cs/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3.2-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akce"
@@ -43,7 +48,7 @@ msgstr "Přidejte tuto (sub)doménu na místní blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Přidat tuto (sub)doménu na místní whitelist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Další nastavení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatečné zpoždění v sekundách před začátkem zpracování blokování reklamy."
@@ -72,15 +77,15 @@ msgstr "Pokročilá nastavení hlášení"
 msgid "Answer"
 msgstr "Odpověd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Základní dočasný adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -113,7 +118,7 @@ msgstr "Blokované domény"
 msgid "Blocked Domains"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Záloha blokovacího seznamu"
 
@@ -129,7 +134,7 @@ msgstr "Dotaz na blokovací seznam..."
 msgid "Blocklist Sources"
 msgstr "Zdroje seznamů blokování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -168,7 +173,7 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -177,25 +182,25 @@ msgstr ""
 "chyb při stahování nebo po příštím spuštění."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Adresář DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Resetování souboru DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -203,21 +208,21 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -226,39 +231,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Parametry stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Fronta stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Oznámení e-mailem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Počet e-mailových oznámení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "E-mailový profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Adresa příjemce e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Adresa odesílatele e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Téma e-mailu"
 
@@ -272,11 +277,11 @@ msgstr "Upravit blacklist"
 msgid "Edit Whitelist"
 msgstr "Upravit whitelist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Povolit bezpečné vyhledávání (SafeSearch)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Povolit střední filtry SafeSearch pro youtube."
 
@@ -284,7 +289,7 @@ msgstr "Povolit střední filtry SafeSearch pro youtube."
 msgid "Enable the adblock service."
 msgstr "Povolit službu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -296,7 +301,7 @@ msgstr "Zapnuto"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -306,11 +311,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Stávající úlohy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -320,11 +325,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Vyprázdnit mezipaměť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -332,7 +345,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Vynutit lokální DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -351,7 +372,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informace"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -363,15 +384,15 @@ msgstr "Poslední spuštění"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -381,7 +402,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -399,21 +420,17 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Seznam podporovaných a plně předkonfigurovaných nástrojů pro stahování."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Služba s nízkou prioritou"
 
@@ -434,7 +451,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -446,23 +463,23 @@ msgstr "Dotaz"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adresa příjemce pro e-maily s upozorněním."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -490,39 +507,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Počet bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Velikost bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Adresář sestav"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Rozhraní sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -555,13 +572,13 @@ msgstr ""
 msgid "Save"
 msgstr "Uložit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -573,27 +590,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -613,23 +624,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Pozastavit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Cílový adresář pro vygenerovaný blokovací seznam 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -681,7 +692,7 @@ msgstr ""
 msgid "Time"
 msgstr "Čas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -695,7 +706,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -703,7 +714,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
@@ -712,7 +723,7 @@ msgstr "Prodleva spuštění"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
@@ -727,11 +738,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -739,15 +750,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/de/adblock.po
+++ b/applications/luci-app-adblock/po/de/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Aktion"
@@ -43,7 +48,7 @@ msgstr "Füge diese (Sub-)Domain zur lokalen Blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Füge diese (Sub-)Domain zur lokalen Whiteklist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Zusätzliche Jail-Sperrliste"
 
@@ -51,7 +56,7 @@ msgstr "Zusätzliche Jail-Sperrliste"
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Zusätzliche Verzögerung (in Sekunden) bis zur Verarbeitung durch den "
@@ -73,15 +78,15 @@ msgstr "Fortgeschrittene Berichtseinstellungen"
 msgid "Answer"
 msgstr "Antwort"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Basis-Temp-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -114,7 +119,7 @@ msgstr "Blockierte Domain"
 msgid "Blocked Domains"
 msgstr "Geblockte Domains"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Sperrliste Backup"
 
@@ -130,7 +135,7 @@ msgstr "Sperrlisten abfragen..."
 msgid "Blocklist Sources"
 msgstr "Blockierlisten-Quellen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -178,7 +183,7 @@ msgstr ""
 msgid "Count"
 msgstr "Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -187,25 +192,25 @@ msgstr ""
 "sofort ab dem Booten oder im Fall von Downloadfehlern zur Verfügung zu haben."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "DNS-Backend"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS-Datei zurücksetzen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-Report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "DNS-Restart-Timeout"
 
@@ -213,15 +218,15 @@ msgstr "DNS-Restart-Timeout"
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Deaktiviere DNS-Zulassen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Deaktiviere DNS-Restarts"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,7 +234,7 @@ msgstr ""
 "Deaktiviere das Triggern von Neustarts des DNS-Backends durch Adblock per "
 "Autoload/inotify-Funktionsaufrufe."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
 
@@ -238,39 +243,39 @@ msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
 msgid "Domain"
 msgstr "Domäne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Downloadparameter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Download-Warteschlange"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Email-Benachrichtigszähler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "E-Mail-Profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail-Empfänger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "E-Mail-Absender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "E-Mail-Thema"
 
@@ -284,11 +289,11 @@ msgstr "Blackliste bearbeiten"
 msgid "Edit Whitelist"
 msgstr "Whiteliste bearbeiten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Aktiviere SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
 
@@ -296,7 +301,7 @@ msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
 msgid "Enable the adblock service."
 msgstr "Aktiviere den Adblock-Dienst."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Aktivieren Sie die ausführliche Debug-Protokollierung bei "
@@ -310,7 +315,7 @@ msgstr "Aktiviert"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -320,11 +325,11 @@ msgstr "Erzwinge SafeSearch für Google, Bing, DuckDuckGo, Yandex und Pixabay."
 msgid "Existing job(s)"
 msgstr "Bestehende Job(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Externe DNS-Abfragedomain"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +341,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filterkriterien wie z.B. Datum, Domain oder Client (optional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "DNS-Cache leeren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 
@@ -348,7 +361,15 @@ msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 msgid "Force Local DNS"
 msgstr "Lokales DNS erzwingen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -370,7 +391,7 @@ msgstr "Zugriff auf adblock LuCI app erlauten"
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Jail-Verzeichnis"
 
@@ -382,15 +403,15 @@ msgstr "Letzter Lauf"
 msgid "Latest DNS Requests"
 msgstr "Letzte DNS-Abfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "SafeSearch einschränken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "SafeSearch auf bestimmte Anbieter einschränken."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Liste an verfügbaren Netzwerkschnittstellen die von tcpdump verwendet werden "
@@ -405,7 +426,7 @@ msgstr ""
 "triggern. Wähle \"unspecified\", um einen herkömmlichen Start-Timeout-"
 "Mechanismuss anstatt eines Netzwerk-Triggers zu verwenden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -434,22 +455,18 @@ msgstr ""
 "mehr RAM und zusätzlich eine Multicore-CPU, z.B entpsrechende x86- oder "
 "RaspberryPi-Geräte.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste der unterstützten und vollständig vorkonfigurierten Download-"
 "Hilfsprogramme."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Lokale DNS-Ports"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Protokollansicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Dienst mit niedriger Priorität"
 
@@ -470,7 +487,7 @@ msgstr "Aktuell noch keine Adblock-Logs vorhanden!"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "\"msmtp\"-Profil, das für Adblock-Benachrichtigunsmails verwendet wird."
@@ -483,7 +500,7 @@ msgstr "Abfrage"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Frage aktive Sperrlisten und Backups über eine spezifische Domain ab."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -491,19 +508,17 @@ msgstr ""
 "Erhöhe den Benachrichtigunszähler um Emails zu erhalten, wenn die Gesamtzahl "
 "der Blocklisten kleiner gleich diesem Schwellwert ist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Empfängeradresse für Adblock-Benachrichtigungs-E-Mails."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Leite alle DNS-Anfragen an die \"Lan\"-Zone auf den lokalen DNS-Resolver um, "
-"gilt sowohl für UDP und TCP-Protokolle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -534,39 +549,39 @@ msgstr "Aktualisiere Timer..."
 msgid "Refresh..."
 msgstr "Aktualisiere..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "SafeSearch abschwächen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Berichte Datenblock-Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Berichte Datenblock-Größe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Verzeichnis für Berichte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Berichte-Schnittstelle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Berichte Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "Berichte Datenblock-Nutzung durch tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Berichte von tcpdump verwendete Datenblockgröße in MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -602,7 +617,7 @@ msgstr "Run-Werkzeuge"
 msgid "Save"
 msgstr "Speichern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -610,7 +625,7 @@ msgstr ""
 "Sende relevante Adblock-Benachrichtigungen per Email. Hinweis: Hierzu muss "
 "das \"msmtp\"-Zusatzpaket installiert sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Absenderadresse für Adblock-Benachrichtigungsmails."
 
@@ -622,7 +637,7 @@ msgstr "(Er)Setze einen neuen Adblock-Job"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -630,23 +645,15 @@ msgstr ""
 "Größe der Download-Warteschlange für laufende Downloads (inkl. Platzbedarf "
 "für Sortieren, Zusammenführen)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "Quellen (Größe, Fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-"Leerzeichengetrennte Liste von DNS-relevanten Firewall-Ports, die zwingend "
-"lokal sein müssen."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Leerzeichengetrennte Liste an Ports die von tcpdump genutzt werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Spezielle Konfigurationseinstellungen für das gewählte Download-Programm."
@@ -667,7 +674,7 @@ msgstr "Status / Version"
 msgid "Suspend"
 msgstr "Anhalten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -676,7 +683,7 @@ msgstr ""
 "\" gesetzt, hier sollte besser ein USB-Stick oder anderer lokaler Speicher "
 "verwendet werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -685,11 +692,11 @@ msgstr ""
 "hier sollte besser ein USB-Stick oder anderer lokaler Speicher verwendet "
 "werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Zielverzeichnis für die erzeugte Sperrliste 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Zielverzeichnis für die erzeugte Jail-Sperrliste \"adb_list.jail\"."
 
@@ -751,7 +758,7 @@ msgstr ""
 msgid "Time"
 msgstr "Zeit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Timeout für erfolgreichen DNS-Backend-Startvorgang."
 
@@ -767,7 +774,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top-10 Statistiken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr "Betreff für Adblock-Benachrichtigungsmails."
 
@@ -775,7 +782,7 @@ msgstr "Betreff für Adblock-Benachrichtigungsmails."
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
@@ -784,7 +791,7 @@ msgstr "Verzögerung der Trigger-Bedingung"
 msgid "Unable to save changes: %s"
 msgstr "Konnte Änderungen nicht speichern: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
@@ -801,11 +808,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Whiteliste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -813,17 +820,34 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "Max. Größe des Result-Sets"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Lokale DNS-Ports"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Leite alle DNS-Anfragen an die \"Lan\"-Zone auf den lokalen DNS-Resolver "
+#~ "um, gilt sowohl für UDP und TCP-Protokolle."
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr ""
+#~ "Leerzeichengetrennte Liste von DNS-relevanten Firewall-Ports, die "
+#~ "zwingend lokal sein müssen."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "DNS Anforderungen (blockiert)"

--- a/applications/luci-app-adblock/po/el/adblock.po
+++ b/applications/luci-app-adblock/po/el/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +76,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,7 +113,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -124,7 +129,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Λίστα Μπλοκαρισμένων πηγών"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,32 +168,32 @@ msgstr ""
 msgid "Count"
 msgstr "Μέτρηση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "κατάλογος DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Επαναφορά αρχείου DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,11 +270,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,7 +294,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +318,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +338,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +365,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -374,7 +395,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -392,12 +413,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -405,7 +422,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -426,7 +443,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -438,23 +455,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,39 +499,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -547,13 +564,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -565,27 +582,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -605,23 +616,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -673,7 +684,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +698,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +706,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,7 +715,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -719,11 +730,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -731,15 +742,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/en/adblock.po
+++ b/applications/luci-app-adblock/po/en/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +76,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,7 +113,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -124,7 +129,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,32 +168,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,11 +270,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,7 +294,7 @@ msgstr "Enabled"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +318,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +338,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +365,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -374,7 +395,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -392,12 +413,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -405,7 +422,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -426,7 +443,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -438,23 +455,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,39 +499,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -547,13 +564,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -565,27 +582,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -605,23 +616,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -673,7 +684,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +698,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +706,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,7 +715,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -719,11 +730,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -731,14 +742,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -13,6 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Acción"
@@ -46,7 +51,7 @@ msgstr "Agregue este (sub) dominio a su lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Agregue este (sub) dominio a su lista blanca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Lista de bloqueo adicional de la cárcel"
 
@@ -54,7 +59,7 @@ msgstr "Lista de bloqueo adicional de la cárcel"
 msgid "Additional Settings"
 msgstr "Configuraciones adicionales"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
@@ -76,15 +81,15 @@ msgstr "Configuración avanzada de informes"
 msgid "Answer"
 msgstr "Responder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Directorio de temperatura base"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -117,7 +122,7 @@ msgstr "Dominio bloqueado"
 msgid "Blocked Domains"
 msgstr "Dominios bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Copia de seguridad de lista de bloqueo"
 
@@ -133,7 +138,7 @@ msgstr "Consulta de lista de bloqueo..."
 msgid "Blocklist Sources"
 msgstr "Fuentes de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -182,7 +187,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -191,25 +196,25 @@ msgstr ""
 "caso de errores de descarga o durante el inicio."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "Backend de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Directorio DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Restablecimiento de archivos DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Informe DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Tiempo de espera de reinicio de DNS"
 
@@ -217,15 +222,15 @@ msgstr "Tiempo de espera de reinicio de DNS"
 msgid "Date"
 msgstr "Fecha"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Desactivar Permitir DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Desactivar Reinicios de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -233,7 +238,7 @@ msgstr ""
 "Desactivar los reinicios activados por adblock para back-end dns con "
 "funciones de carga automática/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
 
@@ -242,39 +247,39 @@ msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Descargar parámetros"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Descargar Cola"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Notificación del E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Conteo de notificaciones por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Perfil de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario del correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente del correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Tema del correo electrónico"
 
@@ -288,11 +293,11 @@ msgstr "Editar lista negra"
 msgid "Edit Whitelist"
 msgstr "Editar lista blanca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Activar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activar filtros moderados de SafeSearch para YouTube."
 
@@ -300,7 +305,7 @@ msgstr "Activar filtros moderados de SafeSearch para YouTube."
 msgid "Enable the adblock service."
 msgstr "Activa el servicio Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activa el registro de depuración detallado en caso de errores de "
@@ -314,7 +319,7 @@ msgstr "Activado"
 msgid "End Timestamp"
 msgstr "Finalizar marca de tiempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -326,11 +331,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Trabajo(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Dominio de búsqueda de DNS externo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -343,11 +348,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterios de filtro como fecha, dominio o cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Vaciar caché de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 
@@ -355,7 +368,15 @@ msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 msgid "Force Local DNS"
 msgstr "Forzar DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -378,7 +399,7 @@ msgstr "Conceder acceso a la aplicación adblock de LuCI"
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Directorio de la cárcel"
 
@@ -390,15 +411,15 @@ msgstr "Último inicio"
 msgid "Latest DNS Requests"
 msgstr "Últimas solicitudes de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "Limitar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limitar SafeSearch a proveedores specíficos."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de dispositivos de red disponibles utilizados por tcpdump."
 
@@ -411,7 +432,7 @@ msgstr ""
 "Elija 'No especificado' para usar un tiempo de espera de inicio clásico en "
 "lugar de un disparador de red."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -440,21 +461,17 @@ msgstr ""
 "MByte,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) necesita más RAM y soporte "
 "multinúcleo, p. ej. x86 o dispositivos Raspberry.<br /><p></p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Puertos DNS locales"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Vista de registro"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Servicio con prioridad baja"
 
@@ -475,7 +492,7 @@ msgstr "¡Aún no hay registros relacionados con adblock!"
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil utilizado por 'msmtp' para notificaciones de E-Mails adblock."
 
@@ -489,7 +506,7 @@ msgstr ""
 "Consulta listas de bloqueo activas y copias de seguridad para un dominio "
 "específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -497,19 +514,17 @@ msgstr ""
 "Aumente el recuento de notificaciones para obtener correos electrónicos si "
 "el recuento general de la lista de bloqueo es menor o igual al límite dado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Dirección del receptor para la notificación de bloqueos electrónicos."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Redireccionar todas las consultas DNS desde la zona 'lan' al solucionador "
-"DNS local, se aplica al protocolo UDP y TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -540,39 +555,39 @@ msgstr "Actualizar temporizador..."
 msgid "Refresh..."
 msgstr "Actualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "Relajar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Informe de recuento de fragmentos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Tamaño del fragmento de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Directorio de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Interfaz de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Informar puertos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "Informe el recuento de fragmentos utilizado por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informe el tamaño del fragmento utilizado por tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -608,7 +623,7 @@ msgstr "Ejecutar utilidades"
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -616,7 +631,7 @@ msgstr ""
 "Enviar correos electrónicos de notificación relacionados con adblock. Tenga "
 "en cuenta: esto necesita una instalación adicional del paquete 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Dirección del remitente para los correos electrónicos de notificación de "
@@ -630,7 +645,7 @@ msgstr "Establecer/Reemplazar un nuevo trabajo de adblock"
 msgid "Settings"
 msgstr "Configuración"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -638,23 +653,15 @@ msgstr ""
 "Tamaño de la cola de descarga para el procesamiento de descarga (incluida la "
 "clasificación, fusión, etc.) en paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "Fuentes (tamaño, enfoque)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-"Lista separada por espacios de puertos de firewall relacionados con DNS que "
-"deben forzarse localmente."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de puertos separados por espacios utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opciones de configuración especiales para la utilidad de descarga "
@@ -676,7 +683,7 @@ msgstr "Estado / Versión"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -685,7 +692,7 @@ msgstr ""
 "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
 "otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -694,12 +701,12 @@ msgstr ""
 "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
 "otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo generada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo de cárcel generada 'adb_list."
@@ -765,7 +772,7 @@ msgstr ""
 msgid "Time"
 msgstr "Hora"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tiempo de espera para esperar un reinicio de backend de DNS exitoso."
 
@@ -781,7 +788,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 estadísticas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr "Tema para los correos electrónicos de notificación de adblock."
 
@@ -789,7 +796,7 @@ msgstr "Tema para los correos electrónicos de notificación de adblock."
 msgid "Total DNS Requests"
 msgstr "Solicitudes DNS Totales"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
@@ -798,7 +805,7 @@ msgstr "Retraso de disparo"
 msgid "Unable to save changes: %s"
 msgstr "No se pueden guardar los cambios: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
@@ -815,11 +822,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista blanca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -827,17 +834,34 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "máx. tamaño del conjunto de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "llamado (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "crudo (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Puertos DNS locales"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Redireccionar todas las consultas DNS desde la zona 'lan' al solucionador "
+#~ "DNS local, se aplica al protocolo UDP y TCP."
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr ""
+#~ "Lista separada por espacios de puertos de firewall relacionados con DNS "
+#~ "que deben forzarse localmente."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "Solicitudes DNS (bloqueadas)"

--- a/applications/luci-app-adblock/po/fi/adblock.po
+++ b/applications/luci-app-adblock/po/fi/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Toiminta"
@@ -43,7 +48,7 @@ msgstr "Lisää tämä (ali-)verkkonimi kieltolistallesi."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lisää tämä (ali-)verkkonimi sallittujen listallesi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ylimääräinen odotusaika sekunteina ennen adblock-käsittelyn aloittamista."
@@ -72,15 +77,15 @@ msgstr "Raportoinnin lisäasetukset"
 msgid "Answer"
 msgstr "Vastaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Varmuuskopiohakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Oletushakemisto väliaikaistiedostoille"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -113,7 +118,7 @@ msgstr "Estetty verkkonimi"
 msgid "Blocked Domains"
 msgstr "Estetyt verkkonimet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Kieltolistan varmuuskopio"
 
@@ -129,7 +134,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Estolistojen lähteet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -168,32 +173,32 @@ msgstr ""
 msgid "Count"
 msgstr "Määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "DNS-sovellus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS-tiedoston resetointi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 
@@ -201,15 +206,15 @@ msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 msgid "Date"
 msgstr "Päivä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Estä DNS:n salliminen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Estä DNS:n uudelleenkäynnistykset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -217,7 +222,7 @@ msgstr ""
 "Estä adblockin aiheuttamat DNS-sovelluksen uudelleenkäynnistykset autoload/"
 "inotify-funktioilla."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -226,39 +231,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Verkkonimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Latausparametrit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Latausjono"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Sähköposti-ilmoitus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Sähköposti-ilmoitusten määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Sähköpostiprofiili"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Sähköposti: vastaanottajan osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Sähköposti: lähettäjän osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Sähköposti: otsikko"
 
@@ -272,11 +277,11 @@ msgstr "Editoi estolistaa"
 msgid "Edit Whitelist"
 msgstr "Editoi sallittujen lista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -284,7 +289,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr "Ota Adblock-palvelu käyttöön."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Runsas lokisisältö toimintojen virheiden etsimistä varten."
 
@@ -296,7 +301,7 @@ msgstr "Käytössä"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -306,11 +311,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Nykyiset työt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -320,11 +325,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Suodatintekijät kuten päivä, verkkonimi tai asiakas (valinnainen)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Tyhjennä DNS-välimuisti"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Tyhjennä DNS-välimuisti ennen Adblock-sääntöjen käsittelyä."
 
@@ -332,7 +345,15 @@ msgstr "Tyhjennä DNS-välimuisti ennen Adblock-sääntöjen käsittelyä."
 msgid "Force Local DNS"
 msgstr "Pakota paikallinen DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -351,7 +372,7 @@ msgstr "Salli pääsy Adblock-asetuksiin"
 msgid "Information"
 msgstr "Tietoja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -363,15 +384,15 @@ msgstr "Viimeksi ajettu"
 msgid "Latest DNS Requests"
 msgstr "Viimeiset DNS-kyselyt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -381,7 +402,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -399,20 +420,16 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Tuetut ja valmiiksi asetetut lataustyökalut."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Paikalliset DNS-portit"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Lokinäkymä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Matala sovelluksen prioriteetti"
 
@@ -433,7 +450,7 @@ msgstr "Ei vielä Adblock-lokeja!"
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -445,25 +462,23 @@ msgstr "Kysely"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Vastaanottajan sähköpostiosoite Adblockin ilmoituksille."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Ohjaa kaikki LAN-vyöhykkeeltä tulevat DNS-kyselyt paikalliselle DNS-"
-"palvelimelle, sekä UDP- että TCP-protokollat."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -491,39 +506,39 @@ msgstr "Päivitysajastin..."
 msgid "Refresh..."
 msgstr "Päivitä..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Raporttipalojen määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Raporttipalojen koko"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Raporttihakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Raportoitava sovitin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Raportoitavat portit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -556,13 +571,13 @@ msgstr ""
 msgid "Save"
 msgstr "Tallenna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Lähettäjän osoite Adblockin sähköposti-ilmoituksille."
 
@@ -574,27 +589,21 @@ msgstr ""
 msgid "Settings"
 msgstr "Asetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "Lähteet (koko, fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -614,23 +623,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -682,7 +691,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -696,7 +705,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -704,7 +713,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -713,7 +722,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -728,11 +737,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -740,17 +749,27 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Paikalliset DNS-portit"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Ohjaa kaikki LAN-vyöhykkeeltä tulevat DNS-kyselyt paikalliselle DNS-"
+#~ "palvelimelle, sekä UDP- että TCP-protokollat."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "DNS-kyselyt (estetyt)"

--- a/applications/luci-app-adblock/po/fr/adblock.po
+++ b/applications/luci-app-adblock/po/fr/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Action"
@@ -43,7 +48,7 @@ msgstr "Ajout sous-domaine au réseau local blacklisté."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Ajout sous-domaine au réseau local whitelisté."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Additionnel Bannis Blocklisté"
 
@@ -51,7 +56,7 @@ msgstr "Additionnel Bannis Blocklisté"
 msgid "Additional Settings"
 msgstr "Paramètres additionnels"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Délai de déclenchement supplémentaire en secondes avant que le bloqueur de "
@@ -73,15 +78,15 @@ msgstr "Paramètres de rapport avancés"
 msgid "Answer"
 msgstr "Répondre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Répertoire Temporaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -114,7 +119,7 @@ msgstr "Domaines bloqués"
 msgid "Blocked Domains"
 msgstr "Domaines bloqués"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Sauvegarde de la liste de blocage"
 
@@ -130,7 +135,7 @@ msgstr "Demande Blocklist..."
 msgid "Blocklist Sources"
 msgstr "Sources des listes de blocage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -180,7 +185,7 @@ msgstr ""
 msgid "Count"
 msgstr "Compteur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -189,25 +194,25 @@ msgstr ""
 "utilisées en cas d'erreurs de téléchargement ou lors du démarrage."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "Backend du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Répertoire du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Réinitialiser le fichier de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Rapport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Délai de redémarrage DNS"
 
@@ -215,15 +220,15 @@ msgstr "Délai de redémarrage DNS"
 msgid "Date"
 msgstr "Date"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Désactiver l'autorisation DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Désactiver les redémarrages DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -231,7 +236,7 @@ msgstr ""
 "Désactiver les redémarrages déclenchés par adblock pour les backends dns "
 "avec des fonctions d'auto-chargement/notification."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
 
@@ -240,39 +245,39 @@ msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
 msgid "Domain"
 msgstr "Domaine"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Paramètres Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Queue de Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Notifications par e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Nombre de notifications par courrier électronique"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Email du profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Adresse e-mail du destinataire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Adresse électronique de l'expéditeur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Objet du courrier électronique"
 
@@ -286,11 +291,11 @@ msgstr "Modifier la liste noire"
 msgid "Edit Whitelist"
 msgstr "Modifier la liste blanche"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Activer Safesearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activez les filtres SafeSearch modérés pour youtube."
 
@@ -298,7 +303,7 @@ msgstr "Activez les filtres SafeSearch modérés pour youtube."
 msgid "Enable the adblock service."
 msgstr "Activer le service adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activez la journalisation verbale de débogage en cas d'erreurs de traitement."
@@ -311,7 +316,7 @@ msgstr "Activé"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -323,11 +328,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Travaux en cours"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Domaine de recherche DNS externe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -340,11 +345,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Critère filtre comme la date, domaine, client (option)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Vider le cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Videz également le cache DNS avant le traitement des adblocs."
 
@@ -352,7 +365,15 @@ msgstr "Videz également le cache DNS avant le traitement des adblocs."
 msgid "Force Local DNS"
 msgstr "Forcer le DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -375,7 +396,7 @@ msgstr "Donner tout accès à l'application LuCI adblock"
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Répertoire des bannis"
 
@@ -387,15 +408,15 @@ msgstr "Dernière exécution"
 msgid "Latest DNS Requests"
 msgstr "Dernière Requêtes DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "Limiter SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limitez SafeSearch à certains fournisseurs."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste des périphériques réseau disponibles utilisés par tcpdump."
 
@@ -408,7 +429,7 @@ msgstr ""
 "l'adblock. Choisissez \"non spécifié\" pour utiliser un délai de démarrage "
 "classique au lieu d'un déclencheur réseau."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -439,22 +460,18 @@ msgstr ""
 "besoin de plus de RAM et de support Multicore, par exemple des appareils x86 "
 "ou Raspberry.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste des utilitaires de téléchargement pris en charge et entièrement pré-"
 "configurés."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Ports DNS locaux"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Vue du journal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Service en priorité basse"
 
@@ -475,7 +492,7 @@ msgstr "Pas encore de journaux liés à l'adblock !"
 msgid "Overview"
 msgstr "Vue d’ensemble"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilisé par \"msmtp\" pour les e-mails de notification adblock."
 
@@ -489,7 +506,7 @@ msgstr ""
 "Recherchez des listes de blocage actives et des sauvegardes pour un domaine "
 "spécifique."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -498,7 +515,7 @@ msgstr ""
 "électroniques si le nombre total de blocages est inférieur ou égal à la "
 "limite donnée."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Adresse du destinataire pour les e-mails de notification du bloqueur de "
@@ -506,13 +523,11 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Rediriger toutes les requêtes DNS de la zone \"lan\" vers le résolveur DNS "
-"local, s'applique aux protocoles UDP et TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -544,39 +559,39 @@ msgstr "Rafraîchir l'horloge..."
 msgid "Refresh..."
 msgstr "Rafraichi..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "Relax SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Rapporter le nombre de morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Rapporter la taille des morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Rapporter le Répertoire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Rapporter l'Interface"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Rapport des Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "Signalez le nombre de morceaux utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Indiquez la taille des morceaux utilisés par tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -612,7 +627,7 @@ msgstr "Outils de travail"
 msgid "Save"
 msgstr "Enregistrer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -620,7 +635,7 @@ msgstr ""
 "Envoyer des e-mails de notification relatifs à l'adblock. Veuillez noter que "
 "l'installation du paquet \"msmtp\" supplémentaire est nécessaire."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Adresse de l'expéditeur des courriers électroniques de notification de "
@@ -634,7 +649,7 @@ msgstr "Définir/remplacer un nouveau travail d'adblock"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -642,23 +657,15 @@ msgstr ""
 "Taille de la file d'attente pour le traitement des téléchargements (y "
 "compris le tri, la fusion, etc.) en parallèle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "Sources (Taille, Focus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-"Liste séparée par espace des ports de pare-feu liés au DNS qui doivent être "
-"forcés localement."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Liste des ports utilisés par tcpdump, séparés par des espaces."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Options de configuration spéciales pour l'utilitaire de téléchargement "
@@ -680,7 +687,7 @@ msgstr "Statut / Version"
 msgid "Suspend"
 msgstr "Mettre en pause"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -688,7 +695,7 @@ msgstr ""
 "Répertoire cible pour les fichiers de rapports liés au DNS. La valeur par "
 "défaut est '/tmp', veuillez utiliser plutot une clé usb ou un disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -697,12 +704,12 @@ msgstr ""
 "défaut est '/tmp', veuillez utiliser de préférence une clé usb ou un autre "
 "disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Répertoire cible pour la liste de blocage générée \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Répertoire cible pour la liste de blocage générée \"adb_list.jail\"."
 
@@ -768,7 +775,7 @@ msgstr ""
 msgid "Time"
 msgstr "Heure"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Délai d'attente pour un redémarrage réussi du backend du DNS."
 
@@ -784,7 +791,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 Statistiques"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr "Objet pour les notifications par e-mails d'adblock."
 
@@ -792,7 +799,7 @@ msgstr "Objet pour les notifications par e-mails d'adblock."
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
@@ -801,7 +808,7 @@ msgstr "Délai de déclenchement"
 msgid "Unable to save changes: %s"
 msgstr "Sauvegarde Impossible : %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
@@ -818,11 +825,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Liste Blanche..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -830,17 +837,34 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "taille max. des résultats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Ports DNS locaux"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Rediriger toutes les requêtes DNS de la zone \"lan\" vers le résolveur "
+#~ "DNS local, s'applique aux protocoles UDP et TCP."
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr ""
+#~ "Liste séparée par espace des ports de pare-feu liés au DNS qui doivent "
+#~ "être forcés localement."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "Requêtes DNS (bloquées)"

--- a/applications/luci-app-adblock/po/he/adblock.po
+++ b/applications/luci-app-adblock/po/he/adblock.po
@@ -4,6 +4,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -37,7 +42,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +50,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +70,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,7 +107,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -118,7 +123,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -157,32 +162,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -190,21 +195,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -213,39 +218,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -259,11 +264,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -271,7 +276,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -283,7 +288,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -293,11 +298,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -307,11 +312,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -319,7 +332,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -338,7 +359,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -350,15 +371,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -368,7 +389,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -386,12 +407,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -399,7 +416,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -420,7 +437,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -432,23 +449,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -476,39 +493,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -541,13 +558,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -559,27 +576,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -599,23 +610,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -667,7 +678,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -681,7 +692,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -698,7 +709,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -713,11 +724,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -725,14 +736,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hi/adblock.po
+++ b/applications/luci-app-adblock/po/hi/adblock.po
@@ -4,6 +4,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -37,7 +42,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -45,7 +50,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -65,15 +70,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,7 +107,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -118,7 +123,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -157,32 +162,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -190,21 +195,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -213,39 +218,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -259,11 +264,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -271,7 +276,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -283,7 +288,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -293,11 +298,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -307,11 +312,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -319,7 +332,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -338,7 +359,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -350,15 +371,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -368,7 +389,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -386,12 +407,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -399,7 +416,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -420,7 +437,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -432,23 +449,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -476,39 +493,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -541,13 +558,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -559,27 +576,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -599,23 +610,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -667,7 +678,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -681,7 +692,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -698,7 +709,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -713,11 +724,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -725,14 +736,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hu/adblock.po
+++ b/applications/luci-app-adblock/po/hu/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Művelet"
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "További aktiválókésleltetés másodpercben, mielőtt a reklámblokkolás "
@@ -73,15 +78,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Válasz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +115,7 @@ msgstr "Blokkolt tartomány"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,7 +131,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Blokkolási lista forrásai"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -165,32 +170,32 @@ msgstr ""
 msgid "Count"
 msgstr "Darabszám"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS könyvtár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS fájlvisszaállítás"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -221,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Tartomány"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "E-mail értesítés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-mail fogadócím"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,11 +272,11 @@ msgstr "Feketelista szerkesztése"
 msgid "Edit Whitelist"
 msgstr "Fehérlista szerkesztése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -279,7 +284,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,7 +296,7 @@ msgstr "Engedélyezve"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,11 +320,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "DNS gyorsítótár kiürítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -327,7 +340,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Helyi DNS kényszerítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -346,7 +367,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -358,15 +379,15 @@ msgstr "Utolsó futás"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -376,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -394,21 +415,17 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "A támogatott és teljesen előre beállított letöltési segédprogramok listája."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Alacsony prioritású szolgáltatás"
 
@@ -429,7 +446,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -441,23 +458,23 @@ msgstr "Lekérdezés"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Fogadó címe a reklámblokkoló értesítési e-mailekhez."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -485,39 +502,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Darabok számának jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Darabok méretének jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Könyvtár jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Csatoló jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -550,13 +567,13 @@ msgstr ""
 msgid "Save"
 msgstr "Mentés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -568,27 +585,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -608,23 +619,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Célkönyvtár az előállított „adb_list.overall” blokkolási listához."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -678,7 +689,7 @@ msgstr ""
 msgid "Time"
 msgstr "Idő"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -692,7 +703,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -700,7 +711,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
@@ -709,7 +720,7 @@ msgstr "Aktiváló késleltetése"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
@@ -724,11 +735,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,15 +747,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -13,6 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Action"
@@ -46,7 +51,7 @@ msgstr "Aggiungi questo (sotto)dominio alla tua lista nera locale."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Aggiungi questo (sotto)dominio alla tua lista bianca locale."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -54,7 +59,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Impostazioni aggiuntive"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Tempo addizionale in secondi di attesa prima che adblock si avvii."
 
@@ -74,15 +79,15 @@ msgstr "Impostazioni avanzate dei report"
 msgid "Answer"
 msgstr "Risposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Directory del Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,7 +116,7 @@ msgstr "Domini bloccati"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -127,7 +132,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Fonti lista di Blocco"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -162,9 +167,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 "Configurazione del pacchetto adblock per bloccare pubblicità/domini "
-"fraudolenti usando il DNS. Per informazioni aggiuntive <a href=\"https"
-"://github.com/openwrt/packages/blob/master/net/adblock/files/README.md\" "
-"target=\"_blank\" rel=\"noreferrer noopener\" >consulta la documentazione</a>"
+"fraudolenti usando il DNS. Per informazioni aggiuntive <a href=\"https://"
+"github.com/openwrt/packages/blob/master/net/adblock/files/README.md\" target="
+"\"_blank\" rel=\"noreferrer noopener\" >consulta la documentazione</a>"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
@@ -172,7 +177,7 @@ msgstr ""
 msgid "Count"
 msgstr "Numero"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -181,25 +186,25 @@ msgstr ""
 "nell'evenienza di errori nello scaricamento o all'avvio."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "Backend DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Directory DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Reset File DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Report del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Tempo di riavvio del DNS"
 
@@ -207,21 +212,21 @@ msgstr "Tempo di riavvio del DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -230,39 +235,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Notifica E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail destinatario"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -276,11 +281,11 @@ msgstr "Modifica Lista Nera"
 msgid "Edit Whitelist"
 msgstr "Modifica Lista Bianca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -288,7 +293,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -300,7 +305,7 @@ msgstr "Abilitato"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -310,11 +315,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -324,11 +329,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Pulisci Cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -336,7 +349,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Forza DNS Locale"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -355,7 +376,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -367,15 +388,15 @@ msgstr "Ultimo Avvio"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -385,7 +406,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -403,21 +424,17 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Elenco delle utility di download supportate e completamente preconfigurate."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Serviio a bassa priorità"
 
@@ -438,7 +455,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riassunto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -450,24 +467,24 @@ msgstr "Interrogazione"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Indirizzo del destinatario per e-mail di notifica di blocco degli annunci."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -495,39 +512,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Directory dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -560,13 +577,13 @@ msgstr ""
 msgid "Save"
 msgstr "Salva"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -578,27 +595,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -618,23 +629,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Sospendi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Directory per la lista di blocco generata 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -687,7 +698,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -701,7 +712,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -709,7 +720,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Ritardo Innesco"
 
@@ -718,7 +729,7 @@ msgstr "Ritardo Innesco"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Registro di Debug Dettagliato"
 
@@ -733,11 +744,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -745,15 +756,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -13,6 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "アクション"
@@ -46,7 +51,7 @@ msgstr "この(サブ)ドメインをローカルのブラックリストに追�
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "この(サブ)ドメインをローカルのホワイトリストに追加します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "追加のJailブロックリスト"
 
@@ -54,7 +59,7 @@ msgstr "追加のJailブロックリスト"
 msgid "Additional Settings"
 msgstr "追加設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Adblock の処理が開始されるまでの、追加の遅延時間（秒）です。"
 
@@ -74,15 +79,15 @@ msgstr "リポートの詳細設定"
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "ベースとなるテンポラリディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -114,7 +119,7 @@ msgstr "ブロックされたドメイン"
 msgid "Blocked Domains"
 msgstr "ブロックされたドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "ブロックリストのバックアップ"
 
@@ -130,7 +135,7 @@ msgstr "ブロックリストのクエリ..."
 msgid "Blocklist Sources"
 msgstr "ブロックリスト提供元"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -178,7 +183,7 @@ msgstr ""
 msgid "Count"
 msgstr "カウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -187,25 +192,25 @@ msgstr ""
 "時に使用されます。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "DNSバックエンド"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS ファイル リセット"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNSレポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "DNS再起動タイムアウト"
 
@@ -213,15 +218,15 @@ msgstr "DNS再起動タイムアウト"
 msgid "Date"
 msgstr "日付"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "DNS許可を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "DNS再起動を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,7 +234,7 @@ msgstr ""
 "autoload/inotify機能を使用してDNSバックエンドのadblockの再起動トリガーを無効"
 "にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "セレクティブDNSホワイトリスティングを無効化(RPZパススルー)。"
 
@@ -238,39 +243,39 @@ msgstr "セレクティブDNSホワイトリスティングを無効化(RPZパ�
 msgid "Domain"
 msgstr "ドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "パラメータをダウンロード"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "ダウンロードキュー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "ダウンロードユーティリティ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Eメール通知数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
@@ -284,11 +289,11 @@ msgstr "ブラックリストの編集"
 msgid "Edit Whitelist"
 msgstr "ホワイトリストの編集"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "セーフサーチを有効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "youtube用の適度なセーフサーチフィルタを有効にします。"
 
@@ -296,7 +301,7 @@ msgstr "youtube用の適度なセーフサーチフィルタを有効にしま�
 msgid "Enable the adblock service."
 msgstr "adblockサービスを有効にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "エラーが発生した際に詳細なデバッグロギングを有効にします。"
 
@@ -308,7 +313,7 @@ msgstr "有効"
 msgid "End Timestamp"
 msgstr "終了タイムスタンプ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -320,11 +325,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "既存の仕事"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "外部DNSルックアップドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,11 +341,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "日付、ドメイン、クライアントなどのフィルター基準(オプション)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "DNS キャッシュのクリア"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "adblockが正常に動くようにするため、事前にDNSキャッシュをクリアします。"
 
@@ -348,7 +361,15 @@ msgstr "adblockが正常に動くようにするため、事前にDNSキャッ�
 msgid "Force Local DNS"
 msgstr "ローカル DNS の強制"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -370,7 +391,7 @@ msgstr "LuCIアプリのadblockへのアクセスを許可"
 msgid "Information"
 msgstr "情報"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Jailディレクトリ"
 
@@ -382,15 +403,15 @@ msgstr "最終実行"
 msgid "Latest DNS Requests"
 msgstr "最新のDNSリクエスト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "セーフサーチを制限"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "セーフサーチを特定のプロバイダに制限します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdumpが使用する利用可能なネットワークデバイス一覧です。"
 
@@ -402,7 +423,7 @@ msgstr ""
 "adblockの開始をトリガーできるネットワークインターフェース一覧です。未指定を選"
 "択するとトリガーの代わりに従来のスタートアップタイムアウトを使用します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -422,20 +443,16 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "サポートされ、かつ設定済のダウンロード ユーティリティの一覧です。"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "ローカルDNSポート"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "ログビュー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "優先度が低いサービス"
 
@@ -456,7 +473,7 @@ msgstr "まだadblolck関連のログがありません！"
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp'をadblock通知Eメールに使用するプロファイル。"
 
@@ -468,7 +485,7 @@ msgstr "検索"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "特定のドメインのアクティブなブロックリストとバックアップを検索します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -476,19 +493,17 @@ msgstr ""
 "通知数を上げて、ブロックリスト全体の数が指定された制限以下の場合に電子メール"
 "を取得します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知メールの受信アドレスです。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"'lan'ゾーンからすべてのDNSクエリをローカルDNSリゾルバにリダイレクトし、UDPと"
-"TCPプロトコルに適用します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -519,39 +534,39 @@ msgstr "タイマーをリフレッシュ..."
 msgid "Refresh..."
 msgstr "リフレッシュ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "リラックスセーフサーチ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "レポート チャンクカウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "レポート チャンクサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "レポート インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "レポートポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "tcpdumpによって使用されるレポートチャンク数。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "tcpdumpがメガバイト単位で使用するレポートチャンクサイズ。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -587,7 +602,7 @@ msgstr "実行ユーティリティー"
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -595,7 +610,7 @@ msgstr ""
 "adblock関連の通知Eメールを送信します。注意: これは追加の'msmtp'パッケージのイ"
 "ンストールが必要です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "adblockの通知Eメール送信者アドレス。"
 
@@ -607,7 +622,7 @@ msgstr "新しいadblockジョブの設定/置き換え"
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -615,22 +630,15 @@ msgstr ""
 "ダウンロード処理(並べ替え、統合など)のダウンロードキューのサイズを並列で指定"
 "します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "ソース(サイズ、フォーカス)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-"スペースで区切られた、ローカルのみの、DNS関連のファイアウォールポートリスト。"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdumpが使用するポートの、スペースで区切られたリスト。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr "選択したダウンロードユーティリティーの特別な設定オプション。"
 
@@ -650,7 +658,7 @@ msgstr "ステータス / バージョン"
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -658,7 +666,7 @@ msgstr ""
 "DNS関連のレポートファイルのターゲットディレクトリです。デフォルトは'/tmp'で"
 "す。可能ならばUSBメモリまたは別のローカルディスクを使用してください。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -667,11 +675,11 @@ msgstr ""
 "トは'/tmp'です。可能ならばUSBメモリまたは別のローカルディスクを使用してくださ"
 "い。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成されたブロックリスト 'adb_list.overall' の保存先ディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "生成されたjailブロックリスト'adb_list.jail'のターゲットディレクトリです。"
@@ -732,7 +740,7 @@ msgstr ""
 msgid "Time"
 msgstr "時刻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "DNSバックエンドの再起動が成功するまでのタイムアウト。"
 
@@ -748,7 +756,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "上位10項目"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr "adblockの通知Eメールのトピック。"
 
@@ -756,7 +764,7 @@ msgstr "adblockの通知Eメールのトピック。"
 msgid "Total DNS Requests"
 msgstr "DNSリクエスト合計"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
@@ -765,7 +773,7 @@ msgstr "トリガ遅延"
 msgid "Unable to save changes: %s"
 msgstr "変更を保存できませんでした: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
@@ -782,11 +790,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "ホワイトリスト..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -794,17 +802,34 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "ローカルDNSポート"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "'lan'ゾーンからすべてのDNSクエリをローカルDNSリゾルバにリダイレクトし、UDP"
+#~ "とTCPプロトコルに適用します。"
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr ""
+#~ "スペースで区切られた、ローカルのみの、DNS関連のファイアウォールポートリス"
+#~ "ト。"
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "DNSリクエスト(ブロック)"

--- a/applications/luci-app-adblock/po/ko/adblock.po
+++ b/applications/luci-app-adblock/po/ko/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "액션"
@@ -43,7 +48,7 @@ msgstr "이 (서브)도메인을 로컬 블랙리스트에 추가."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "이 (서브)도메인을 로컬 화이트리스트에 추가."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "추가 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +76,15 @@ msgstr "고급 리포트 설정"
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +115,7 @@ msgstr "차단된 도메인"
 msgid "Blocked Domains"
 msgstr "차단된 도메인들"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "차단목록 백업"
 
@@ -126,7 +131,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -165,32 +170,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -221,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,11 +272,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -279,7 +284,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,7 +296,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,11 +320,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -327,7 +340,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -346,7 +367,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -358,15 +379,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -376,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -394,12 +415,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -407,7 +424,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -428,7 +445,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -440,23 +457,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -484,39 +501,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -549,13 +566,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -567,27 +584,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -607,23 +618,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -675,7 +686,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -697,7 +708,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -706,7 +717,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -721,11 +732,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -733,14 +744,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/mr/adblock.po
+++ b/applications/luci-app-adblock/po/mr/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -71,15 +76,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,7 +113,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -124,7 +129,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,32 +168,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,11 +270,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,7 +294,7 @@ msgstr "सक्षम केले"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +318,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +338,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +365,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -374,7 +395,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -392,12 +413,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -405,7 +422,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -426,7 +443,7 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -438,23 +455,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,39 +499,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -547,13 +564,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -565,27 +582,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -605,23 +616,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -673,7 +684,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +698,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +706,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,7 +715,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -719,11 +730,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -731,15 +742,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ms/adblock.po
+++ b/applications/luci-app-adblock/po/ms/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Tindakan"
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Terdapat kelewatan picu dalam saat sebelum proses adblock bermula."
 
@@ -71,15 +76,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Jawapan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,7 +113,7 @@ msgstr "Kawasan Liputan Yang telah disekat"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -124,7 +129,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Punca Senarai Sekatan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,32 +168,32 @@ msgstr ""
 msgid "Count"
 msgstr "Kiraan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Direktori DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Reset fail DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,21 +201,21 @@ msgstr ""
 msgid "Date"
 msgstr "Tarikh"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -219,39 +224,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,11 +270,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -277,7 +282,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -289,7 +294,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,11 +318,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -325,7 +338,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -344,7 +365,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -374,7 +395,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -392,12 +413,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -405,7 +422,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -426,7 +443,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -438,23 +455,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,39 +499,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -547,13 +564,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -565,27 +582,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -605,23 +616,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -673,7 +684,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +698,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +706,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,7 +715,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -719,11 +730,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -731,15 +742,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/nb_NO/adblock.po
+++ b/applications/luci-app-adblock/po/nb_NO/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Handling"
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligere utløserforsinkelse i sekunder før behandling av "
@@ -73,15 +78,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +115,7 @@ msgstr "Blokkert domene"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,7 +131,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Blokklistekilder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -165,32 +170,32 @@ msgstr ""
 msgid "Count"
 msgstr "Antall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS-mappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS-filtilbakestilling"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dato"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -221,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "E-postmerknad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagersadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,11 +272,11 @@ msgstr "Rediger svarteliste"
 msgid "Edit Whitelist"
 msgstr "Rediger hvitliste"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -279,7 +284,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,7 +296,7 @@ msgstr "Aktivert"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,11 +320,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Tøm DNS-hurtiglageret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -327,7 +340,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Tving lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -346,7 +367,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -358,15 +379,15 @@ msgstr "Sist kjørt"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -376,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -394,12 +415,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -407,7 +424,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -428,7 +445,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -440,23 +457,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -484,39 +501,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -549,13 +566,13 @@ msgstr ""
 msgid "Save"
 msgstr "Lagre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -567,27 +584,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -607,23 +618,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -675,7 +686,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -697,7 +708,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -706,7 +717,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -721,11 +732,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -733,15 +744,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/pl/adblock.po
+++ b/applications/luci-app-adblock/po/pl/adblock.po
@@ -11,6 +11,11 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akcja"
@@ -44,7 +49,7 @@ msgstr "Dodaj tę (sub-)domenę do Twojej lokalnej czarnej listy."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Dodaj tę (pod-)domenę do Twojej lokalnej białej listy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Dodatkowa lista blokująca"
 
@@ -52,7 +57,7 @@ msgstr "Dodatkowa lista blokująca"
 msgid "Additional Settings"
 msgstr "Ustawienia dodatkowe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalacza w sekundach przed rozpoczęciem przetwarzania "
@@ -74,15 +79,15 @@ msgstr "Ustawienia raportowania"
 msgid "Answer"
 msgstr "Odpowiedź"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Podstawowy katalog tymczasowy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -115,7 +120,7 @@ msgstr "Zablokowana domena"
 msgid "Blocked Domains"
 msgstr "Zablokowane domeny"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Kopia zapasowa list blokujących"
 
@@ -131,7 +136,7 @@ msgstr "Zapytanie..."
 msgid "Blocklist Sources"
 msgstr "Źródła list"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -180,7 +185,7 @@ msgstr ""
 msgid "Count"
 msgstr "Licznik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -189,25 +194,25 @@ msgstr ""
 "błędów pobierania lub podczas startu."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "Zaplecze DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Katalog DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Resetuj plik DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Limit czasu restartu DNS"
 
@@ -215,15 +220,15 @@ msgstr "Limit czasu restartu DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Wyłącz pozwolenie na DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Wyłącz restart DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -231,7 +236,7 @@ msgstr ""
 "Wyłącz wyzwalane restarty adblocka dla zaplecza DNS z funkcjami Autoload/"
 "Inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
 
@@ -240,39 +245,39 @@ msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
 msgid "Domain"
 msgstr "Domena"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Kolejka pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Powiadomienie e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Licznik powiadomień e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Profil e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Adres e-mail odbiorcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Adres e-mail nadawcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Temat e-mail"
 
@@ -286,11 +291,11 @@ msgstr "Czarna lista"
 msgid "Edit Whitelist"
 msgstr "Biała lista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Włącz SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
 
@@ -298,7 +303,7 @@ msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
 msgid "Enable the adblock service."
 msgstr "Włącz usługę adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Włącz pełne rejestrowanie debugowania w przypadku błędów przetwarzania."
@@ -311,7 +316,7 @@ msgstr "Włączone"
 msgid "End Timestamp"
 msgstr "Sygnatura czasowa zakończenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -323,11 +328,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Istniejące zadania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Zewnętrzna domena wyszukiwania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -340,11 +345,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Kryteria filtrowania takie jak data, domena lub klient (opcjonalnie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Opróżnij pamięć podręczną DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 
@@ -352,7 +365,15 @@ msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 msgid "Force Local DNS"
 msgstr "Wymuś lokalny DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -374,7 +395,7 @@ msgstr "Udziel dostępu LuCI do aplikacji adblock"
 msgid "Information"
 msgstr "Informacje"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Katalog więzienia"
 
@@ -386,15 +407,15 @@ msgstr "Ostatnie uruchomienie"
 msgid "Latest DNS Requests"
 msgstr "Ostatnie zapytania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "Limit SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limit SafeSearch dla certyfikowanych dostawców."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dostępnych urządzeń sieciowych używanych przez tcpdump."
 
@@ -407,7 +428,7 @@ msgstr ""
 "'nieokreślone', aby użyć klasycznego limitu czasu uruchamiania zamiast "
 "wyzwalacza sieciowego."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -437,21 +458,17 @@ msgstr ""
 "wielordzeniowej, np. urządzenia x86 lub urządzenia typu raspberry.<br /> "
 "<p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista obsługiwanych i wstępnie skonfigurowanych narzędzi do pobierania."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Lokalne porty DNS"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Widok dziennika"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Usługa niskopriorytetowa"
 
@@ -472,7 +489,7 @@ msgstr "Brak dzienników związanych z adblockiem!"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil używany przez 'msmtp' do powiadamiania o blokadzie e-mail."
 
@@ -486,7 +503,7 @@ msgstr ""
 "Wysyłaj zapytania do aktywnych list blokowania i kopii zapasowych dla "
 "określonej domeny."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -494,19 +511,17 @@ msgstr ""
 "Zwiększ liczbę powiadomień, aby otrzymywać wiadomości e-mail jeśli ogólna "
 "liczba blokowanych list jest mniejsza lub równa podanemu limitowi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adres odbiorcy dla powiadomień e-mail adblocka."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Przekieruj wszystkie zapytania DNS ze strefy LAN do lokalnego programu "
-"obsługi DNS, dotyczy protokołu UDP i TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -536,39 +551,39 @@ msgstr "Odśwież zegar..."
 msgid "Refresh..."
 msgstr "Odświeżanie..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "Odpoczynek SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Zgłoś liczbę fragmentów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Zgłoś wielkość porcji"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Katalog raportów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Interfejs raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Porty raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "Raportuj liczbę fragmentów używaną przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Raportuj wielkość fragmentów używaną przez tcpdump w MB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -603,7 +618,7 @@ msgstr "Uruchomione narzędzia"
 msgid "Save"
 msgstr "Zapisz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -611,7 +626,7 @@ msgstr ""
 "Wysyłaj powiadomienia e-mail związane z adblock. Uwaga: wymaga to dodatkowej "
 "instalacji pakietu 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adres nadawcy dla powiadomień e-mailowych adblocka."
 
@@ -623,7 +638,7 @@ msgstr "Ustaw/Zmień nowe zadanie Adblock"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -631,23 +646,15 @@ msgstr ""
 "Rozmiar kolejki pobierania do przetwarzania plików (w tym sortowanie, "
 "łączenie itp.) równolegle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "Źródła (wielkość, skupienie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-"Rozdzielona spacjami lista portów zapory związanych z DNS, które należy "
-"wymusić lokalnie."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Rozdzielona spacjami lista portów używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr "Specjalne opcje konfiguracji dla wybranego narzędzia do pobierania."
 
@@ -667,7 +674,7 @@ msgstr "Status/Wersja"
 msgid "Suspend"
 msgstr "Zawieś"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -675,7 +682,7 @@ msgstr ""
 "Katalog docelowy dla plików raportowania. Domyślnie jest to '/ tmp', "
 "najlepiej użyj pamięci USB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -683,12 +690,12 @@ msgstr ""
 "Katalog docelowy dla kopii zapasowej list. Domyślnie jest to '/tmp', użyj "
 "najlepiej pamięci USB lub innego dysku."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy blokowania 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy zablokowanych 'adb_list.jail'."
@@ -752,7 +759,7 @@ msgstr ""
 msgid "Time"
 msgstr "Czas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Limit czasu oczekiwania na pomyślne ponowne uruchomienie zaplecza DNS."
 
@@ -768,7 +775,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr "Temat dla powiadomień e-mail adblocka."
 
@@ -776,7 +783,7 @@ msgstr "Temat dla powiadomień e-mail adblocka."
 msgid "Total DNS Requests"
 msgstr "Łączna liczba żądań DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
@@ -785,7 +792,7 @@ msgstr "Opóźnienie wyzwalacza"
 msgid "Unable to save changes: %s"
 msgstr "Nie można zapisać zmian: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
@@ -802,11 +809,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Biała lista ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -814,17 +821,34 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "maks. rozmiar zestawu wyników"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Lokalne porty DNS"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Przekieruj wszystkie zapytania DNS ze strefy LAN do lokalnego programu "
+#~ "obsługi DNS, dotyczy protokołu UDP i TCP."
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr ""
+#~ "Rozdzielona spacjami lista portów zapory związanych z DNS, które należy "
+#~ "wymusić lokalnie."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "Żądania DNS (zablokowane)"

--- a/applications/luci-app-adblock/po/pt/adblock.po
+++ b/applications/luci-app-adblock/po/pt/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Ação"
@@ -43,7 +48,7 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Priosional"
 
@@ -51,7 +56,7 @@ msgstr "Lista de Bloqueio Priosional"
 msgid "Additional Settings"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso adicional do gatilho em segundos antes do processamento do adblock "
@@ -73,15 +78,15 @@ msgstr "Configurações Avançadas do Relatório"
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -115,7 +120,7 @@ msgstr "Domínio Bloqueado"
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -131,7 +136,7 @@ msgstr "Pesquisando a Lista de Bloqueio..."
 msgid "Blocklist Sources"
 msgstr "Origem da Blocklist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -180,7 +185,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -189,25 +194,25 @@ msgstr ""
 "usados em caso de erros de descarregamento ou durante a inicialização."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Repor o ficheiro DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -215,15 +220,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -231,7 +236,7 @@ msgstr ""
 "Desativar o adblock que causar a reinicialização das funções autoload/"
 "inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desativa a lista branca seletiva do DNS (passagem pelo RPZ)."
 
@@ -240,39 +245,39 @@ msgstr "Desativa a lista branca seletiva do DNS (passagem pelo RPZ)."
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Parâmetros de Descarregamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Fila de Descarregamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Ferramenta para Descarregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Perfil de e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de e-mail do destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Endereço de e-mail do remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Assunto do e-mail"
 
@@ -286,11 +291,11 @@ msgstr "Editar Lista Negra"
 msgid "Edit Whitelist"
 msgstr "Editar lista de permissões"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Ativar os filtros SafeSearch de forma moderada para o Youtube."
 
@@ -298,7 +303,7 @@ msgstr "Ativar os filtros SafeSearch de forma moderada para o Youtube."
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registo de depuração detalhado para casos de todos os erros de "
@@ -312,7 +317,7 @@ msgstr "Ativado"
 msgid "End Timestamp"
 msgstr "Carimbo de tempo final"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -324,11 +329,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -341,11 +346,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Limpar o cache de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também limpar o Cache do DNS antes do adblock."
 
@@ -353,7 +366,15 @@ msgstr "Também limpar o Cache do DNS antes do adblock."
 msgid "Force Local DNS"
 msgstr "Forçar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -376,7 +397,7 @@ msgstr "Conceder acesso à app LuCI adblock"
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
@@ -388,15 +409,15 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "Limite do SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limite o SafeSearch a determinados provedores."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de aparelhos da rede disponíveis que foram usados pelo tcpdump."
 
@@ -409,7 +430,7 @@ msgstr ""
 "'não especificado' para usar um tempo de inicialização clássico em vez de um "
 "gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -439,22 +460,18 @@ msgstr ""
 "> &#8226;&#xa0;<b>XXL</b> (200k-) precisa de mais suporte a RAM e Multicore, "
 "por exemplo. x86 ou aparelhos raspberry.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de ferramentas de descarregamento suportadas e completamente pré-"
 "configuradas."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Portas DNS Locais"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Vista do registo log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -475,7 +492,7 @@ msgstr "Ainda não há registos relacionados ao adblock!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil dos e-mails de notificação do adblock utilizado por 'msmtp'."
 
@@ -489,7 +506,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -497,19 +514,17 @@ msgstr ""
 "Aumente a contagem de notificações para receber e-mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Endereço do destinatário para e-mails de notificação do adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Redirecione todas as consultas de DNS da zona 'lan' para o resolvedor de DNS "
-"local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -540,39 +555,39 @@ msgstr "Atualizando o Temporizador..."
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "Alivie o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Relatar Contagem de Porções"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Tamanho de Porções de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Interface de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -608,7 +623,7 @@ msgstr "Executar Utilitários"
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -616,7 +631,7 @@ msgstr ""
 "Envie e-mails de notificação relacionados ao adblock. Note que: a instalação "
 "adicional do pacote 'msmtp' é necessária."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Endereço E-Mail do remetente para as notificações do adblock."
 
@@ -628,7 +643,7 @@ msgstr "Definir/Substituir um novo trabalho de adblock"
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -636,23 +651,15 @@ msgstr ""
 "Tamanho da fila de descarregamento para o processamento de descarregamento "
 "(incl. classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-"Lista separada por espaço das portas de firewall relacionadas ao DNS que "
-"devem ser impostas localmente."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de descarregamento "
@@ -674,7 +681,7 @@ msgstr "Condição geral / versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -683,7 +690,7 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
 "outro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -692,12 +699,12 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou outro "
 "disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Diretório de destino para a lista de blocos 'adb_list.overall' gerada ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
@@ -761,7 +768,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -777,7 +784,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos e-mails que serão usados nas notificações do adblock."
@@ -786,7 +793,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr "Total de solicitações de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
@@ -795,7 +802,7 @@ msgstr "Atraso do Gatilho"
 msgid "Unable to save changes: %s"
 msgstr "Impossível gravar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
@@ -812,11 +819,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -824,17 +831,34 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Portas DNS Locais"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Redirecione todas as consultas de DNS da zona 'lan' para o resolvedor de "
+#~ "DNS local, aplica-se ao protocolo UDP e TCP."
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr ""
+#~ "Lista separada por espaço das portas de firewall relacionadas ao DNS que "
+#~ "devem ser impostas localmente."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "Solicitações do DNS (bloqueadas)"

--- a/applications/luci-app-adblock/po/pt_BR/adblock.po
+++ b/applications/luci-app-adblock/po/pt_BR/adblock.po
@@ -13,6 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Ação"
@@ -46,7 +51,7 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Adicional"
 
@@ -54,7 +59,7 @@ msgstr "Lista de Bloqueio Adicional"
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso de gatilho adicional em segundos antes do processamento do adblock "
@@ -76,15 +81,15 @@ msgstr "Configurações Avançadas do Relatório"
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -118,7 +123,7 @@ msgstr "Domínios Bloqueados"
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -134,7 +139,7 @@ msgstr "Pesquisando a Lista de Bloqueio..."
 msgid "Blocklist Sources"
 msgstr "Fontes de listas de bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -183,7 +188,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -192,25 +197,25 @@ msgstr ""
 "usados em caso de erros de download ou durante a inicialização."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Zerar Arquivo de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -218,15 +223,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Dia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -234,7 +239,7 @@ msgstr ""
 "Desative o bloqueador de anúncios que causar a reinicialização das funções "
 "autoload/inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
 
@@ -243,39 +248,39 @@ msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Fila de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -289,11 +294,11 @@ msgstr "Editar a Lista Negra"
 msgid "Edit Whitelist"
 msgstr "Editar a Lista Branca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
 
@@ -301,7 +306,7 @@ msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço de bloqueio de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
@@ -315,7 +320,7 @@ msgstr "Ativado"
 msgid "End Timestamp"
 msgstr "Fim da marca temporal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -327,11 +332,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -344,11 +349,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Limpar a Cache do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 
@@ -356,7 +369,15 @@ msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 msgid "Force Local DNS"
 msgstr "Usar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -379,7 +400,7 @@ msgstr "Conceda acesso ao aplicativo LuCI adblock"
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
@@ -391,15 +412,15 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "Limite do SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limite o SafeSearch a determinados fornecedores."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Lista de dispositivos da rede disponíveis que foram usados pelo tcpdump."
@@ -413,7 +434,7 @@ msgstr ""
 "Escolha 'não especificado' para usar um tempo de inicialização clássico em "
 "vez de um gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -444,20 +465,16 @@ msgstr ""
 "mais suporte a RAM e Multicore, por exemplo. x86 ou dispositivos raspberry."
 "<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Portas DNS Locais"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Exibir o Registro Log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -478,7 +495,7 @@ msgstr "Ainda não há registros relacionados ao bloqueio de anúncio!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Perfil dos E-Mails de notificação do bloqueio de anúncio utilizado por "
@@ -494,7 +511,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -502,7 +519,7 @@ msgstr ""
 "Aumente a contagem de notificações para receber E-Mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Endereço do E-Mail do destinatário para o recebimento das notificações do "
@@ -510,13 +527,11 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Redirecione todas as consultas de DNS da zona 'lan' para o resolvedor de DNS "
-"local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -548,39 +563,39 @@ msgstr "Atualizando o Temporizador..."
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "Alivie o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Contagem de Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Tamanho dos Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Interface do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -616,7 +631,7 @@ msgstr "Executar Utilitários"
 msgid "Save"
 msgstr "Salvar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -624,7 +639,7 @@ msgstr ""
 "Envie E-Mails de notificação relacionados ao bloqueio de anúncios. Note que: "
 "é necessário a instalação adicional do pacote 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Endereço E-Mail do remetente para as notificações do bloqueador de anúncios."
@@ -637,7 +652,7 @@ msgstr "Definir/Substituir um novo trabalho de bloqueio de anúncios"
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -645,23 +660,15 @@ msgstr ""
 "Tamanho da fila de download para o processamento de download (incl. "
 "classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-"Lista separada por espaço das portas de firewall relacionadas ao DNS que "
-"devem ser impostas localmente."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de download selecionado."
@@ -682,7 +689,7 @@ msgstr "Condição Geral / Versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -691,7 +698,7 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
 "outro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -700,11 +707,11 @@ msgstr ""
 "diretório predefinido é '/tmp', use preferencialmente um pendrive ou outro "
 "disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Caminho do diretório para a lista nega gerada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
@@ -769,7 +776,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -785,7 +792,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos E-Mais que serão usados nas notificações do bloqueador "
@@ -795,7 +802,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr "Total das solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
@@ -804,7 +811,7 @@ msgstr "Gatilho de Atraso"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
@@ -821,11 +828,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -833,17 +840,34 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Portas DNS Locais"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Redirecione todas as consultas de DNS da zona 'lan' para o resolvedor de "
+#~ "DNS local, aplica-se ao protocolo UDP e TCP."
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr ""
+#~ "Lista separada por espaço das portas de firewall relacionadas ao DNS que "
+#~ "devem ser impostas localmente."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "Solicitações do DNS (bloqueadas)"

--- a/applications/luci-app-adblock/po/ro/adblock.po
+++ b/applications/luci-app-adblock/po/ro/adblock.po
@@ -11,6 +11,11 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Actiune"
@@ -44,7 +49,7 @@ msgstr "Adăugați acest (sub) domeniu în lista locală de interzise."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adăugați acest (sub) domeniu la lista locală de admise."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +57,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Setări Suplimentare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Întârziere adițională înainte ca procesarea adblock-ului să înceapă (în "
@@ -74,15 +79,15 @@ msgstr "Setări Avansate Raport"
 msgid "Answer"
 msgstr "Răspuns"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Director Temporar de Bază"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -115,7 +120,7 @@ msgstr "Domeniu blocat"
 msgid "Blocked Domains"
 msgstr "Domenii Blocate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Copie de Rezervă Pentru Lista de Blocate"
 
@@ -131,7 +136,7 @@ msgstr "Interogare Lista de Blocare..."
 msgid "Blocklist Sources"
 msgstr "Surse de blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -178,7 +183,7 @@ msgstr ""
 msgid "Count"
 msgstr "Număr"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -187,25 +192,25 @@ msgstr ""
 "utilizate în cazul erorilor de descărcare sau în timpul pornirii."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Director DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Timp Repornire DNS"
 
@@ -213,15 +218,15 @@ msgstr "Timp Repornire DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Dezactivare Permite DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Dezactivare Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,7 +234,7 @@ msgstr ""
 "Dezactivează repornirile declanșate de adblock pentru backend-urile dns cu "
 "funcții de autoîncărcare /notificare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
 
@@ -238,39 +243,39 @@ msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
 msgid "Domain"
 msgstr "Domeniu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Descărcare Parametri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Coadă de Descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Notificare e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Număr de Notificări pe E-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Profil E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "Adresa E-Mail Expeditor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Subiect E-Mail"
 
@@ -284,11 +289,11 @@ msgstr "Editare listă neagră"
 msgid "Edit Whitelist"
 msgstr "Editare listă albă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Activare Căutare Sigură"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activare filtre moderate SafeSearch pentru YouTube."
 
@@ -296,7 +301,7 @@ msgstr "Activare filtre moderate SafeSearch pentru YouTube."
 msgid "Enable the adblock service."
 msgstr "Activare serviciu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activare înregistrare detaliată de depanare în cazul unor erori de procesare."
@@ -309,7 +314,7 @@ msgstr "Activat"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -321,11 +326,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Activitate(ăți) existentă(e)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Domeniul de căutare DNS extern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -338,11 +343,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterii de filtrare precum dată, domeniu sau client (opțional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Eliberează cache-ul DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 
@@ -350,7 +363,15 @@ msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 msgid "Force Local DNS"
 msgstr "Forţează DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -373,7 +394,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Director Închisoare"
 
@@ -385,15 +406,15 @@ msgstr "Ultima rulare"
 msgid "Latest DNS Requests"
 msgstr "Ultimele Cereri DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dispozitivelor de rețea utilizate de tcpdump."
 
@@ -406,7 +427,7 @@ msgstr ""
 "Alegeți „nespecificat” pentru a utiliza un interval de timp de pornire "
 "clasic în loc de declanșarea rețelei."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -435,20 +456,16 @@ msgstr ""
 "&#xa0;<b>XXL</b> (200k-) au nevoie de dispozitive cu mai mult RAM și suport "
 "Multicore, ex. x86 sau raspberry.<br /> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Porturi DNS Locale"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Vizualizare Jurnal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -469,7 +486,7 @@ msgstr "Nu există încă jurnale adblock!"
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilizat de „msmtp” pentru e-mailurile de notificare adblock."
 
@@ -483,7 +500,7 @@ msgstr ""
 "Interogare listă de blocări active și copii de rezervă pentru un anumit "
 "domeniu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -491,19 +508,17 @@ msgstr ""
 "Creșteți numărul de notificări pentru a primi e-mailuri dacă numărul total "
 "de blocări este mai mic sau egal cu limita dată."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Redirecționare toate interogările DNS din zona „lan” către procesatorul DNS "
-"local, se aplică protocolului UDP și TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -534,39 +549,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -599,13 +614,13 @@ msgstr ""
 msgid "Save"
 msgstr "Salvează"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -617,27 +632,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -657,23 +666,23 @@ msgstr ""
 msgid "Suspend"
 msgstr "Suspendă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -725,7 +734,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -739,7 +748,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -747,7 +756,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
@@ -756,7 +765,7 @@ msgstr "Intârzierea declanșării"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -771,11 +780,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -783,17 +792,27 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Porturi DNS Locale"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Redirecționare toate interogările DNS din zona „lan” către procesatorul "
+#~ "DNS local, se aplică protocolului UDP și TCP."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "Cereri DNS (blocate)"

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -16,6 +16,11 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Действие"
@@ -49,7 +54,7 @@ msgstr "Добавить (под-)домен в ваш локальный чер
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Добавить (под-)домен в ваш локальный белый список."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Дополнительный тюремный блоклист"
 
@@ -57,7 +62,7 @@ msgstr "Дополнительный тюремный блоклист"
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Дополнительная задержка в секундах до начала работы Adblock."
 
@@ -77,15 +82,15 @@ msgstr "Расширенные настройки отчетов"
 msgid "Answer"
 msgstr "Ответ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Базовый каталог временных файлов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -118,7 +123,7 @@ msgstr "Заблокированные домены"
 msgid "Blocked Domains"
 msgstr "Заблокированные домены"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Бэкап черного списка"
 
@@ -135,7 +140,7 @@ msgstr "Запросы к черному списку..."
 msgid "Blocklist Sources"
 msgstr "Источники черных списков"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 #, fuzzy
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
@@ -185,7 +190,7 @@ msgstr ""
 msgid "Count"
 msgstr "Количество"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -194,25 +199,25 @@ msgstr ""
 "загрузкой или во время запуска."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "DNS-серверная часть"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "Папка DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Сброс файла DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Отчет DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "Таймаут перезапуска DNS"
 
@@ -220,15 +225,15 @@ msgstr "Таймаут перезапуска DNS"
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "Отключить DNS ответы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "Отключить перезагрузки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -236,7 +241,7 @@ msgstr ""
 "Отключить триггеры, запускаемые adblock, для dns backends с функциями "
 "автозагрузки/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 #, fuzzy
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Запретить избирательное применение белого списка DNS (сквозное RPZ)."
@@ -246,39 +251,39 @@ msgstr "Запретить избирательное применение бе�
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "Параметры загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "Очередь загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Утилита для скачивания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Уведомление электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "Счётчик e-mail уведомлений"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail адрес получателя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "E-Mail адрес отправителя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "Тема"
 
@@ -292,11 +297,11 @@ msgstr "Редактировать Черный список"
 msgid "Edit Whitelist"
 msgstr "Редактировать Белый список"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "Включить Безопасный Поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Включите умеренные фильтры Безопастного Поиска для youtube."
 
@@ -304,7 +309,7 @@ msgstr "Включите умеренные фильтры Безопастно�
 msgid "Enable the adblock service."
 msgstr "Включить сервис AdBlock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Включить подробный отчёт при возникновении ошибок."
 
@@ -316,7 +321,7 @@ msgstr "Включено"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -328,11 +333,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Существующая работа(ы)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Внешний домен DNS Lookup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -345,11 +350,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Критерии фильтрации, такие как дата, домен или клиент (необязательно)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Очистка кэша DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Очистите кэш DNS до обработки adblock."
 
@@ -357,7 +370,15 @@ msgstr "Очистите кэш DNS до обработки adblock."
 msgid "Force Local DNS"
 msgstr "Локальный DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -376,7 +397,7 @@ msgstr "Предоставить доступ к приложению LuCI AdBlo
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "Директория Jail"
 
@@ -388,15 +409,15 @@ msgstr "Последний запуск"
 msgid "Latest DNS Requests"
 msgstr "Последние DNS запросы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "Список доступных сетевых устройств используемых tcpdump."
 
@@ -408,7 +429,7 @@ msgstr ""
 "Список сетевых интерфейсов для запуска adblock по их доступности. Выберите "
 "'не определено' для запуска по таймауту."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -428,22 +449,18 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Список поддерживаемых и полностью предварительно настроенных утилит для "
 "скачивания."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "Локальные порты DNS"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "Просмотр журнала"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Низкий приоритет службы"
 
@@ -464,7 +481,7 @@ msgstr "Ещё нет журналов, связанных с adblock!"
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -477,25 +494,23 @@ msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 "Запросить активные списки блоков и резервные копии для определенного домена."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Адрес получателя для уведомлений по электронной почте."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"Перенаправить все DNS запросы из 'lan' зоны на локальный DNS резолвер. "
-"Применимо к UDP и TCP протоколам."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -523,39 +538,39 @@ msgstr "Обновить таймер..."
 msgid "Refresh..."
 msgstr "Обновить..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "Количество фрагментов отчета"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "Размер фрагментов отчета"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "Папка для отчетов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "Отчет интерфейса"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "Порты отчетов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -588,7 +603,7 @@ msgstr "Запуск Утилиты"
 msgid "Save"
 msgstr "Сохранить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -596,7 +611,7 @@ msgstr ""
 "Отправлять на e-mail уведомления касающиеся adblock. Замечание: требуется "
 "установка дополнительного пакета \"msmtp\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "E-Mails адрес отправителя для уведомления adblock ."
 
@@ -608,27 +623,21 @@ msgstr ""
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Разделенный пробелами список портов используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr "Специальные конфигурационные опции для выбранной утилиты загрузки."
 
@@ -648,7 +657,7 @@ msgstr "Статус / Версия"
 msgid "Suspend"
 msgstr "Приостановить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -656,7 +665,7 @@ msgstr ""
 "Каталог для отчетов связанных с DNS. '/tmp' по умолчанию, предпочтительно "
 "использовать USB или другой локальный диск."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -664,11 +673,11 @@ msgstr ""
 "Каталог для бэкапов блок-списков . '/tmp' по умолчанию, предпочтительно "
 "использовать USB или другой локальный диск."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Папка для созданного списка блокировки 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -722,7 +731,7 @@ msgstr ""
 msgid "Time"
 msgstr "Время"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Тайм-аут ожидания успешного перезапуска серверной части DNS."
 
@@ -737,7 +746,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Топ-10 статистики"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr "Тема электронных писем уведомлений adblock."
 
@@ -745,7 +754,7 @@ msgstr "Тема электронных писем уведомлений adbloc
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
@@ -754,7 +763,7 @@ msgstr "Задержка запуска"
 msgid "Unable to save changes: %s"
 msgstr "Невозможно сохранить изменения: %ы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
@@ -771,11 +780,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Белый список..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -783,17 +792,27 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "Локальные порты DNS"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "Перенаправить все DNS запросы из 'lan' зоны на локальный DNS резолвер. "
+#~ "Применимо к UDP и TCP протоколам."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "DNS запросы (заблокированы)"

--- a/applications/luci-app-adblock/po/sk/adblock.po
+++ b/applications/luci-app-adblock/po/sk/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akcia"
@@ -43,7 +48,7 @@ msgstr "Pridať túto (sub-) doménu medzi lokálne zakázané domény."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Pridať túto (sub-) doménu medzi lokálne povolené domény."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Ďalšie nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatočné oneskorenie v sekundách pred začiatkom spracovania blokovania "
@@ -74,15 +79,15 @@ msgstr "Pokročilé nastavenia"
 msgid "Answer"
 msgstr "Odpoveď"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Základný Temp priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -113,7 +118,7 @@ msgstr "Blokovaná doména"
 msgid "Blocked Domains"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Záloha zoznamu blokovaných domén"
 
@@ -129,7 +134,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Zdroje zoznamov blokovaní"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -168,32 +173,32 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS adresár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Inicializácia DNS súboru"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -201,21 +206,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -224,39 +229,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "Upozornenie e-mailom"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "Adresa príjemcu e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,11 +275,11 @@ msgstr "Upraviť čiernu listinu"
 msgid "Edit Whitelist"
 msgstr "Upraviť bielu listinu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -282,7 +287,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -294,7 +299,7 @@ msgstr "Povolené"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -304,11 +309,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,11 +323,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Vyprázdniť medzipamäť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -330,7 +343,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -349,7 +370,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informácie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -361,15 +382,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -379,7 +400,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -397,12 +418,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -410,7 +427,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -431,7 +448,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -443,23 +460,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -487,39 +504,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -552,13 +569,13 @@ msgstr ""
 msgid "Save"
 msgstr "Uložiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -570,27 +587,21 @@ msgstr ""
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -610,23 +621,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -678,7 +689,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -692,7 +703,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -700,7 +711,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -709,7 +720,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -724,11 +735,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,15 +747,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Åtgärd"
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Fler inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligare trigger fördröjning i sekunder innan Adblock-bearbetningen "
@@ -73,15 +78,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,7 +115,7 @@ msgstr "Blockerad domän"
 msgid "Blocked Domains"
 msgstr "Blockerade domäner"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,7 +131,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Källor för blockeringslistor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -165,32 +170,32 @@ msgstr ""
 msgid "Count"
 msgstr "Räkna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS-mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS-filåterställning"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -221,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Domän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagaradress"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,11 +272,11 @@ msgstr "Redigera svartlista"
 msgid "Edit Whitelist"
 msgstr "Redigera vitlista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -279,7 +284,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,7 +296,7 @@ msgstr "Aktiverad"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,11 +320,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "Töm DNS-cache"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -327,7 +340,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr "Tvinga lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -346,7 +367,7 @@ msgstr ""
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -358,15 +379,15 @@ msgstr "Kördes senast"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -376,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -394,20 +415,16 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "Lågprioriterad tjänst"
 
@@ -428,7 +445,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Översikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -440,23 +457,23 @@ msgstr "Fråga"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -484,39 +501,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -549,13 +566,13 @@ msgstr ""
 msgid "Save"
 msgstr "Spara"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -567,27 +584,21 @@ msgstr ""
 msgid "Settings"
 msgstr "Inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -607,23 +618,23 @@ msgstr "Status / Version"
 msgid "Suspend"
 msgstr "Stäng av"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -675,7 +686,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -697,7 +708,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -706,7 +717,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -721,11 +732,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -733,15 +744,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -1,6 +1,11 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
@@ -34,7 +39,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -42,7 +47,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -62,15 +67,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -99,7 +104,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -115,7 +120,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -154,32 +159,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -187,21 +192,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -210,39 +215,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -256,11 +261,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -268,7 +273,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -280,7 +285,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -290,11 +295,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -304,11 +309,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -316,7 +329,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -335,7 +356,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -347,15 +368,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -365,7 +386,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -383,12 +404,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -396,7 +413,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -417,7 +434,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -429,23 +446,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -473,39 +490,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -538,13 +555,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -556,27 +573,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -596,23 +607,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -664,7 +675,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -678,7 +689,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -686,7 +697,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -695,7 +706,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -710,11 +721,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -722,14 +733,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/tr/adblock.po
+++ b/applications/luci-app-adblock/po/tr/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Eylem"
@@ -43,7 +48,7 @@ msgstr "Bu (alt-)alan adını yerel kara listenize ekleyin."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Bu (alt)alan adını yerel izin verilen listenize ekleyin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "Ek \"Hapis\" Engelleme listesi"
 
@@ -51,7 +56,7 @@ msgstr "Ek \"Hapis\" Engelleme listesi"
 msgid "Additional Settings"
 msgstr "Ek Ayarlar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Reklam engelleme işlemi başlamadan önce saniye cinsinden gecikme süresi."
@@ -72,15 +77,15 @@ msgstr "Gelişmiş Rapor Ayarları"
 msgid "Answer"
 msgstr "Cevap"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Yedekleme Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "Geçici dosyalar icin temel Dizin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -113,7 +118,7 @@ msgstr "Engellenmiş Alan Adı"
 msgid "Blocked Domains"
 msgstr "Engellenen Alan Adları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "Engelleme Listesi Yedekleme"
 
@@ -129,7 +134,7 @@ msgstr "Engelleme Listesi Sorgusu..."
 msgid "Blocklist Sources"
 msgstr "Engelleme Listesi Kaynakları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -179,7 +184,7 @@ msgstr ""
 msgid "Count"
 msgstr "Adet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -188,25 +193,25 @@ msgstr ""
 "başlatma sırasında kullanılacaktır."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "DNS Arka Uç"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS Dosya Sıfırlama"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS Raporu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 
@@ -214,15 +219,15 @@ msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 msgid "Date"
 msgstr "Tarih"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "DNS İzin Vermeyi Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "DNS Yeniden Başlatmalarını Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -230,7 +235,7 @@ msgstr ""
 "Adblock tarafından tetiklenen autoload/inotify fonksiyonları ile dns arka uç "
 "yeniden başlatmasını devre dışı bırakın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Seçilebilir DNS beyaz listesini (RPZ geçişi) devre dışı bırakın."
 
@@ -239,39 +244,39 @@ msgstr "Seçilebilir DNS beyaz listesini (RPZ geçişi) devre dışı bırakın.
 msgid "Domain"
 msgstr "Alan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "İndirme Parametreleri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "İndirme Kuyruğu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "İndirme Aracı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "E-Mail Bildirimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "E-Mail Bildirim Sayısı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "E-Mail Profili"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Alıcı Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Gönderen Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "E-Mail Konusu"
 
@@ -285,11 +290,11 @@ msgstr "Karalisteyi Düzenle"
 msgid "Edit Whitelist"
 msgstr "Beyazlisteyi Düzenle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "GüvenliArama'yı Etkinleştir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Youtube için hafif GüvenliArama'yı etkinleştir."
 
@@ -297,7 +302,7 @@ msgstr "Youtube için hafif GüvenliArama'yı etkinleştir."
 msgid "Enable the adblock service."
 msgstr "Adblock servisini etkinleştir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Herhangi bir işleme hatası durumunda ayrıntılı hata ayıklama günlüğünü "
@@ -311,7 +316,7 @@ msgstr "Etkin"
 msgid "End Timestamp"
 msgstr "Zaman damgasını bitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -323,11 +328,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Mevcut iş(ler)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "Harici DNS Arama Alanı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -340,11 +345,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Tarih, alan, client gibi filtre özellikleri (opsiyonel)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "DNS Önbelleğini Temizle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Adblock işleminden önce de DNS Önbelleğini temizle."
 
@@ -352,7 +365,15 @@ msgstr "Adblock işleminden önce de DNS Önbelleğini temizle."
 msgid "Force Local DNS"
 msgstr "Yerel DNS zorla"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -375,7 +396,7 @@ msgstr "LuCI uygulaması adblock'a izin verin"
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -387,15 +408,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -405,7 +426,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -423,12 +444,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -436,7 +453,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -457,7 +474,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -469,23 +486,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -513,39 +530,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -578,13 +595,13 @@ msgstr ""
 msgid "Save"
 msgstr "Kaydet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -596,27 +613,21 @@ msgstr ""
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -636,23 +647,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -704,7 +715,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -718,7 +729,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -726,7 +737,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -735,7 +746,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -750,11 +761,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -762,15 +773,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/uk/adblock.po
+++ b/applications/luci-app-adblock/po/uk/adblock.po
@@ -11,6 +11,11 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3.2-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Дія"
@@ -44,7 +49,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -52,7 +57,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
@@ -72,15 +77,15 @@ msgstr ""
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -109,7 +114,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,7 +130,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -164,32 +169,32 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -197,21 +202,21 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -220,39 +225,39 @@ msgstr ""
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -266,11 +271,11 @@ msgstr "Редагувати чорний список"
 msgid "Edit Whitelist"
 msgstr "Редагувати білий список"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -278,7 +283,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -290,7 +295,7 @@ msgstr "Увімкнено"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -300,11 +305,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -314,11 +319,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -326,7 +339,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -345,7 +366,7 @@ msgstr ""
 msgid "Information"
 msgstr "Інформація"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -357,15 +378,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -375,7 +396,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -393,12 +414,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -406,7 +423,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -427,7 +444,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -439,23 +456,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -483,39 +500,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -548,13 +565,13 @@ msgstr ""
 msgid "Save"
 msgstr "Зберегти"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -566,27 +583,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -606,23 +617,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -674,7 +685,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -688,7 +699,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -696,7 +707,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr ""
 
@@ -705,7 +716,7 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -720,11 +731,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -732,15 +743,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/vi/adblock.po
+++ b/applications/luci-app-adblock/po/vi/adblock.po
@@ -10,6 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Hành động"
@@ -43,7 +48,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Kích hoạt độ trễ trong vài giây trước khi bắt đầu tiến trình chặn quảng cáo."
@@ -72,15 +77,15 @@ msgstr ""
 msgid "Answer"
 msgstr "Phản hồi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -109,7 +114,7 @@ msgstr "Tên miền bị chặn"
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,7 +130,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Bộ lọc"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -164,33 +169,33 @@ msgstr ""
 msgid "Count"
 msgstr "Bộ đếm"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 #, fuzzy
 msgid "DNS Directory"
 msgstr "Thư mục DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "Đặt lại tệp DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,21 +203,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ngày"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
@@ -221,39 +226,39 @@ msgstr ""
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,11 +272,11 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
@@ -279,7 +284,7 @@ msgstr ""
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -291,7 +296,7 @@ msgstr "Bật"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,11 +320,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -327,7 +340,15 @@ msgstr ""
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -346,7 +367,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr ""
 
@@ -358,15 +379,15 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -376,7 +397,7 @@ msgid ""
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -394,12 +415,8 @@ msgid ""
 "support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
 msgstr ""
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
@@ -407,7 +424,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr ""
 
@@ -428,7 +445,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -440,23 +457,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -484,39 +501,39 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -549,13 +566,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -567,27 +584,21 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -607,23 +618,23 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -675,7 +686,7 @@ msgstr ""
 msgid "Time"
 msgstr "Thời gian"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -689,7 +700,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -697,7 +708,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
@@ -706,7 +717,7 @@ msgstr "Kích hoạt độ trễ"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 #, fuzzy
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
@@ -722,11 +733,11 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -734,15 +745,15 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/zh_Hans/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hans/adblock.po
@@ -17,6 +17,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "动作"
@@ -50,7 +55,7 @@ msgstr "添加此域名到本地黑名单。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "添加此域名到本地白名单。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "其它被屏蔽列表"
 
@@ -58,7 +63,7 @@ msgstr "其它被屏蔽列表"
 msgid "Additional Settings"
 msgstr "其它设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "事件触发启动前的延时（秒）。"
 
@@ -78,15 +83,15 @@ msgstr "高级报告设置"
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "备份目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "基础临时目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -115,7 +120,7 @@ msgstr "已拦截的域名"
 msgid "Blocked Domains"
 msgstr "已拦截域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "黑名单列表的备份"
 
@@ -131,7 +136,7 @@ msgstr "黑名单查询..."
 msgid "Blocklist Sources"
 msgstr "拦截列表来源"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -175,32 +180,32 @@ msgstr ""
 msgid "Count"
 msgstr "计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "创建压缩的阻止列表备份，将在下载错误或启动期间使用它们。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "DNS后端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS 目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS 文件重置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS报告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "DNS重新启动超时"
 
@@ -208,21 +213,21 @@ msgstr "DNS重新启动超时"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "禁用DNS允许"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "禁用DNS重新启动"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "禁用具有自动加载/ inotify功能的dns后端的adblock触发的重启。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "禁止选择性DNS白名单(RPZ通过)."
 
@@ -231,39 +236,39 @@ msgstr "禁止选择性DNS白名单(RPZ通过)."
 msgid "Domain"
 msgstr "域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "下载队列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "E-Mail 通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "电子邮件通知计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "电子邮件资料"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "收件人电子邮件地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "发件人电子邮件地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -277,11 +282,11 @@ msgstr "编辑黑名单"
 msgid "Edit Whitelist"
 msgstr "编辑白名单"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "启用安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "为YouTube启用适度的安全搜索过滤器."
 
@@ -289,7 +294,7 @@ msgstr "为YouTube启用适度的安全搜索过滤器."
 msgid "Enable the adblock service."
 msgstr "启用广告屏蔽服务."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "启用详细调试日志记录以防出现任何处理错误。"
 
@@ -301,7 +306,7 @@ msgstr "已启用"
 msgid "End Timestamp"
 msgstr "结束时间戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -311,11 +316,11 @@ msgstr "强制执行Google，Bing，Duckduckgo，Yandex，youtube和Google的Saf
 msgid "Existing job(s)"
 msgstr "现有的工作(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "外部DNS查找域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -327,11 +332,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "过滤条件，例如日期，域或客户（可选）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 缓存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "还要在处理adblock之前刷新DNS缓存。"
 
@@ -339,7 +352,15 @@ msgstr "还要在处理adblock之前刷新DNS缓存。"
 msgid "Force Local DNS"
 msgstr "强制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -360,7 +381,7 @@ msgstr "授予对LuCI应用程序adblock的访问权限"
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "黑名单目录"
 
@@ -372,15 +393,15 @@ msgstr "最后运行"
 msgid "Latest DNS Requests"
 msgstr "最新的DNS请求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "限定安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "限定特定搜索引擎的安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump使用的可用网络设备列表."
 
@@ -392,7 +413,7 @@ msgstr ""
 "触发adblock启动的可用网络接口列表.选择“未指定”以使用传统的启动超时而不是网络"
 "触发器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -418,20 +439,16 @@ msgstr ""
 "<b> XXL </b>（200k-）需要更多的RAM和多核支持，例如x86或树莓派设备。<br /> <p>"
 "＆＃xa0; </p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支持和完全预配置的下载工具列表。"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "本地DNS端口"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "日志视图"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "低优先级服务"
 
@@ -452,7 +469,7 @@ msgstr "尚无与adblock相关的日志！"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp' 用于adblock通知电子邮件的配置文件。"
 
@@ -464,25 +481,24 @@ msgstr "查询"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查询特定域的活动阻止列表和备份."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 "如果总体阻止列表总数小于或等于给定的限制，请提高通知数量，以获取电子邮件."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知 E-Mail 的收件人地址。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"将所有 DNS 查询从“lan”区域重定向到本地解析器，包括 udp、tcp 协议的端口 ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -512,39 +528,39 @@ msgstr "刷新时间..."
 msgid "Refresh..."
 msgstr "刷新..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "放宽安全搜寻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "报告区块计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "报告区块大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "报告接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "报告端口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "报告 tcpdump 所使用的区块数量。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "报告 tcpdump 所使用的区块大小 (以 MByte 显示)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
@@ -579,13 +595,13 @@ msgstr "运行工具"
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr "发送 AdBlock 相关的通知邮件。请留意：此功能需要安装 \"msmtp\"。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "AdBlock 通知邮件的发送地址。"
 
@@ -597,27 +613,21 @@ msgstr "设置/替换新 AdBlock 任务"
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr "并行下载处理 (分类、合并等) 的下载队列大小。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump使用的端口列表，用空格分隔端口。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -637,23 +647,23 @@ msgstr "状态/版本"
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
@@ -705,7 +715,7 @@ msgstr ""
 msgid "Time"
 msgstr "时间"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -719,7 +729,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -727,7 +737,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr "DNS 请求总数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "触发延迟"
 
@@ -736,7 +746,7 @@ msgstr "触发延迟"
 msgid "Unable to save changes: %s"
 msgstr "无法保存更改：%s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
@@ -751,11 +761,11 @@ msgstr "白名单更改已保存。刷新您的广告阻止列表，以使更改
 msgid "Whitelist..."
 msgstr "白名单..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -763,17 +773,26 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "原始（/ tmp）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "本地DNS端口"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "将所有 DNS 查询从“lan”区域重定向到本地解析器，包括 udp、tcp 协议的端口 ."
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "DNS请求（已阻止）"

--- a/applications/luci-app-adblock/po/zh_Hant/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hant/adblock.po
@@ -16,6 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "- unspecified -"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "動作"
@@ -49,7 +54,7 @@ msgstr "加入此網域到本地黑名單。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "加入此網域到本地白名單。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "Additional Jail Blocklist"
 msgstr "其它被封鎖清單"
 
@@ -57,7 +62,7 @@ msgstr "其它被封鎖清單"
 msgid "Additional Settings"
 msgstr "其它設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "事件觸發啟動前的延時 (秒)。"
 
@@ -77,15 +82,15 @@ msgstr "進階報告設定"
 msgid "Answer"
 msgstr "回覆"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Base Temp Directory"
 msgstr "基礎臨時目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -115,7 +120,7 @@ msgstr "已封鎖的網域"
 msgid "Blocked Domains"
 msgstr "封鎖網域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid "Blocklist Backup"
 msgstr "黑名單清單的備份"
 
@@ -131,7 +136,7 @@ msgstr "黑名單查詢..."
 msgid "Blocklist Sources"
 msgstr "封鎖清單來源"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -177,32 +182,32 @@ msgstr ""
 msgid "Count"
 msgstr "次數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:360
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:372
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "建立壓縮的封鎖清單備份，將在下載錯誤或啟動期間使用它們。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid "DNS Backend"
 msgstr "DNS 後端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "DNS Directory"
 msgstr "DNS 目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "DNS File Reset"
 msgstr "DNS 檔案重設"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS 報告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "DNS Restart Timeout"
 msgstr "DNS 重新啟動逾時"
 
@@ -210,21 +215,21 @@ msgstr "DNS 重新啟動逾時"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable DNS Allow"
 msgstr "停用 DNS 允許"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid "Disable DNS Restarts"
 msgstr "停用 DNS 重新啟動"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:439
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "停用具有 自動載入/inotify 功能的 DNS 後端的 adblock 觸發重新啟動。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:413
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "停用選擇性 DNS 白名單 (RPZ 通過)。"
 
@@ -233,39 +238,39 @@ msgstr "停用選擇性 DNS 白名單 (RPZ 通過)。"
 msgid "Domain"
 msgstr "網域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Download Parameters"
 msgstr "下載參數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid "Download Queue"
 msgstr "下載佇列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "Download Utility"
 msgstr "下載公用程式"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid "E-Mail Notification"
 msgstr "E-Mail 通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid "E-Mail Notification Count"
 msgstr "E-Mail 通知計數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "E-Mail Profile"
 msgstr "E-Mail 設定檔"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail 收件人位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "E-Mail Sender Address"
 msgstr "E-Mail 寄件者位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "E-Mail Topic"
 msgstr "E-Mail 主旨"
 
@@ -279,11 +284,11 @@ msgstr "編輯黑名單"
 msgid "Edit Whitelist"
 msgstr "編輯白名單"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid "Enable SafeSearch"
 msgstr "啟用安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "啟用適用於 YouTube 的中等安全搜尋篩選器。"
 
@@ -291,7 +296,7 @@ msgstr "啟用適用於 YouTube 的中等安全搜尋篩選器。"
 msgid "Enable the adblock service."
 msgstr "啟用 adblock 服務。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "啟用詳細偵錯日誌記錄，以防出現任何處理錯誤。"
 
@@ -303,7 +308,7 @@ msgstr "已啟用"
 msgid "End Timestamp"
 msgstr "結束時間戳記"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -314,11 +319,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "現有的工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "External DNS Lookup Domain"
 msgstr "外部 DNS 查詢網域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -330,11 +335,19 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "篩選器條件，例如日期、網域或用戶端 (可選)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Firewall ports that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Firewall source zones that should be forced locally."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 快取"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "還要在處理 Adblock 之前更新 DNS 快取。"
 
@@ -342,7 +355,15 @@ msgstr "還要在處理 Adblock 之前更新 DNS 快取。"
 msgid "Force Local DNS"
 msgstr "強制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+msgid "Forced Ports"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:329
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -363,7 +384,7 @@ msgstr "授予對 LuCI 應用程式 adblock 的存取權限"
 msgid "Information"
 msgstr "資訊"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Jail Directory"
 msgstr "黑名單目錄"
 
@@ -375,15 +396,15 @@ msgstr "最後執行"
 msgid "Latest DNS Requests"
 msgstr "最新的 DNS 要求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch"
 msgstr "限制安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:316
 msgid "Limit SafeSearch to certain providers."
 msgstr "限定特定搜尋引擎的安全搜尋。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump 使用的可用網路裝置清單。"
 
@@ -395,7 +416,7 @@ msgstr ""
 "觸發 adblock 啟動的可用網路介面清單。選擇「未指定」以使用傳統的啟動逾時而不是"
 "網路觸發器。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -421,20 +442,16 @@ msgstr ""
 "<b>XXL</b> (200k-) 需要更多的 RAM 和多核心支援，例如 x86 或樹莓派裝置。<br /"
 "> <p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:382
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "已支援並完整預先設定的下載公用程式清單。"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid "Local DNS Ports"
-msgstr "本地 DNS 連接埠"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
 msgid "Log View"
 msgstr "日誌檢視"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid "Low Priority Service"
 msgstr "低優先順序服務"
 
@@ -455,7 +472,7 @@ msgstr "尚無與 adblock 相關的日誌！"
 msgid "Overview"
 msgstr "總覽"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "「msmtp」用於 adblock 通知 E-Mail 的設定檔。"
 
@@ -467,26 +484,24 @@ msgstr "查詢"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查詢特定網域的作用中封鎖清單和備份。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:471
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:485
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 "如果總體封鎖清單總數小於或等於給定的限制，請提高通知數量，以取得 E-Mail。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:337
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知 E-Mail 的收件人位址。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid ""
-"Redirect all DNS queries from 'lan' zone to the local DNS resolver, applies "
-"to UDP and TCP protocol."
+"Redirect all DNS queries from specified zones to the local DNS resolver, "
+"applies to UDP and TCP protocol."
 msgstr ""
-"將所有 DNS 查詢從「lan」區域重新導向到本地 DNS 解析程式，包括 UDP 及 TCP 協定"
-"的連接埠 。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:348
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -516,44 +531,46 @@ msgstr "更新計時器..."
 msgid "Refresh..."
 msgstr "更新..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:325
 msgid "Relax SafeSearch"
 msgstr "寬鬆安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report Chunk Count"
 msgstr "報告區塊計數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report Chunk Size"
 msgstr "報告區塊大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Report Directory"
 msgstr "報告目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Report Interface"
 msgstr "報告介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Report Ports"
 msgstr "報告連接埠"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Report chunk count used by tcpdump."
 msgstr "報告 tcpdump 使用的區塊計數。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "報告 tcpdump 使用的區塊大小 (MByte)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
 "Please note: This option starts a small ubus/adblock monitor in the "
 "background."
-msgstr "在 DNS 後端載入後重置黑名單 'adb_list.overall'。請留意：此選項將在背景啓動小型 ubus/adblock 監視。"
+msgstr ""
+"在 DNS 後端載入後重置黑名單 'adb_list.overall'。請留意：此選項將在背景啓動小"
+"型 ubus/adblock 監視。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
@@ -581,13 +598,13 @@ msgstr "執行公用程式"
 msgid "Save"
 msgstr "儲存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr "寄送 adblock 相關的通知 E-Mail。請注意：這需要額外安裝「msmtp」套件。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:459
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Sender address for adblock notification E-Mails."
 msgstr "adblock 通知 E-Mail 的寄件者位址。"
 
@@ -599,27 +616,21 @@ msgstr "設定/取代新的 adblock 工作"
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:358
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr "下載佇列的大小，用於下載處理程序 (包括排序、合併等)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sources (Size, Focus)"
 msgstr "來源 (大小、焦點)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
-msgid ""
-"Space separated list of DNS-related firewall ports which should be forced "
-"locally."
-msgstr "與 DNS 相關的防火牆連接埠，應在本地強制 (以空格分隔字串)。"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump 使用的連接埠 (以空格分隔字串)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
 msgid "Special config options for the selected download utility."
 msgstr "選取的下載公用程式的特殊設定選項。"
 
@@ -639,7 +650,7 @@ msgstr "狀態 / 版本"
 msgid "Suspend"
 msgstr "暫停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid ""
 "Target directory for DNS related report files. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
@@ -647,18 +658,18 @@ msgstr ""
 "與 DNS 相關的報告檔案的目標目錄。預設為「/tmp」，請最好使用 USD 隨身碟或其他"
 "本地磁碟。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:364
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:376
 msgid ""
 "Target directory for blocklist backups. Default is '/tmp', please use "
 "preferably an usb stick or another local disk."
 msgstr ""
 "封鎖清單備份的目標目錄。預設為「/tmp」，請最好使用 USD 隨身碟或其他本地磁碟。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:392
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:406
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "產生封鎖清單「adb_list.overall」的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -714,7 +725,7 @@ msgstr "這顯示了上次產生的 DNS 報告，按下更新按鈕取得目前�
 msgid "Time"
 msgstr "時間"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:396
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:410
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "逾時以等待 DNS 後端成功重新啟動。"
 
@@ -728,7 +739,7 @@ msgstr "若要使 adblock 清單保持為最新，應為這些清單設定自動
 msgid "Top 10 Statistics"
 msgstr "十大統計"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
 msgid "Topic for adblock notification E-Mails."
 msgstr "adblock 通知 E-Mail 的主旨。"
 
@@ -736,7 +747,7 @@ msgstr "adblock 通知 E-Mail 的主旨。"
 msgid "Total DNS Requests"
 msgstr "DNS 請求總數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:353
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
@@ -745,7 +756,7 @@ msgstr "觸發延遲"
 msgid "Unable to save changes: %s"
 msgstr "無法儲存變更：%s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:333
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:345
 msgid "Verbose Debug Logging"
 msgstr "詳細偵錯記錄"
 
@@ -760,11 +771,11 @@ msgstr "白名單變更已儲存。更新 Adblock 清單以使變更生效。"
 msgid "Whitelist..."
 msgstr "白名單..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:388
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -772,17 +783,32 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "最大結果數量"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:387
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:386
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Local DNS Ports"
+#~ msgstr "本地 DNS 連接埠"
+
+#~ msgid ""
+#~ "Redirect all DNS queries from 'lan' zone to the local DNS resolver, "
+#~ "applies to UDP and TCP protocol."
+#~ msgstr ""
+#~ "將所有 DNS 查詢從「lan」區域重新導向到本地 DNS 解析程式，包括 UDP 及 TCP "
+#~ "協定的連接埠 。"
+
+#~ msgid ""
+#~ "Space separated list of DNS-related firewall ports which should be forced "
+#~ "locally."
+#~ msgstr "與 DNS 相關的防火牆連接埠，應在本地強制 (以空格分隔字串)。"
 
 #~ msgid "DNS Requests (blocked)"
 #~ msgstr "DNS 要求 (已封鎖)"


### PR DESCRIPTION
* made DNS redirect code more flexible
* fix dns backend detection in TurrisOS
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>