### PR TITLE
[19.07] luci-app-https-dns-proxy: WebUI for dnsmasq config update, quad9 bootstrap IPv6

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
@@ -8,18 +8,20 @@ end
 
 function https_dns_proxy_action(name)
 	local packageName = "https-dns-proxy"
+	local http = require "luci.http"
+	local sys = require "luci.sys"
+	local util = require "luci.util"
 	if name == "start" then
-		luci.sys.init.start(packageName)
+		sys.init.start(packageName)
 	elseif name == "action" then
-		luci.util.exec("/etc/init.d/" .. packageName .. " reload >/dev/null 2>&1")
-		luci.util.exec("/etc/init.d/dnsmasq restart >/dev/null 2>&1")
+		util.exec("/etc/init.d/" .. packageName .. " reload >/dev/null 2>&1")
 	elseif name == "stop" then
-		luci.sys.init.stop(packageName)
+		sys.init.stop(packageName)
 	elseif name == "enable" then
-		luci.sys.init.enable(packageName)
+		sys.init.enable(packageName)
 	elseif name == "disable" then
-		luci.sys.init.disable(packageName)
+		sys.init.disable(packageName)
 	end
-	luci.http.prepare_content("text/plain")
-	luci.http.write("0")
+	http.prepare_content("text/plain")
+	http.write("0")
 end

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
@@ -2,7 +2,7 @@ return {
 	name = "Quad9-Recommended",
 	label = _("Quad 9 (Recommended)"),
 	resolver_url = "https://dns.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.9,149.112.112.112",
+	bootstrap_dns = "9.9.9.9,149.112.112.112,2620:fe::fe,2620:fe::9",
 	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
 	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
@@ -2,7 +2,7 @@ return {
 	name = "Quad9-Unsecured",
 	label = _("Quad 9 (Unsecured)"),
 	resolver_url = "https://dns10.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.10,149.112.112.10",
+	bootstrap_dns = "9.9.9.10,149.112.112.10,2620:fe::10,2620:fe::fe:10",
 	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
 	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
@@ -2,7 +2,7 @@ return {
 	name = "Quad9-ECS",
 	label = _("Quad 9 (Secured with ECS Support)"),
 	resolver_url = "https://dns11.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.11,149.112.112.11",
+	bootstrap_dns = "9.9.9.11,149.112.112.11,2620:fe::11,2620:fe::fe:11",
 	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
 	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
@@ -2,7 +2,7 @@ return {
 	name = "Quad9-Secured",
 	label = _("Quad 9 (Secured)"),
 	resolver_url = "https://dns9.quad9.net/dns-query",
-	bootstrap_dns = "9.9.9.9,149.112.112.9",
+	bootstrap_dns = "9.9.9.9,149.112.112.9,2620:fe::fe,2620:fe::9",
 	help_link = "https://www.quad9.net/doh-quad9-dns-servers/",
 	help_link_text = "Quad9.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -6,6 +6,7 @@ local i18n = require "luci.i18n"
 local uci = require("luci.model.uci").cursor()
 
 local packageName = "https-dns-proxy"
+local readmeURL = "https://docs.openwrt.melmac.net/" .. packageName .. "/"
 local providers_dir = "/usr/lib/lua/luci/" .. packageName .. "/providers/"
 local helperText = ""
 
@@ -24,7 +25,7 @@ function getPackageVersion()
 end
 
 function createHelperText()
-	local initText = "<br />" .. translate("For more information on different options check") .. " "
+	local initText = translate("For more information on different options check") .. " "
 	for filename in fs.dir(providers_dir) do
 		local p_func = loadfile(providers_dir .. filename)
 		setfenv(p_func, { _ = i18n.translate })
@@ -122,9 +123,20 @@ else
 	buttons.template = packageName .. "/buttons"
 end
 
+c = m:section(NamedSection, "config", "https-dns-proxy", translate("Configuration"), translatef("If update DNSMASQ config is selected, when you add/remove any instances below, they will be used to override the 'DNS forwardings' section of %sDHCP and DNS%s (%smore information%s).", "<a href=\"" .. dispatcher.build_url("admin/network/dhcp") .. "\">", "</a>", "<a href=\"" .. readmeURL .. "#default-settings" .. "\" target=\"_blank\">", "</a>"))
+d1 = c:option(ListValue, "update_dnsmasq_config", translate("Update DNSMASQ Config on Start/Stop"))
+d1:value('*', translate("Update all configs"))
+local dnsmasq_num = 0
+uci:foreach("dhcp", "dnsmasq", function(s)
+d1:value(tostring(dnsmasq_num), translatef("Update %s config", "dhcp.@dnsmasq[" .. tostring(dnsmasq_num) .. "]"))
+dnsmasq_num = dnsmasq_num + 1
+end)
+d1:value('-', translate("Do not update configs"))
+d1.default = '*'
+
 createHelperText()
 s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), 
-	translatef("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of %sDHCP and DNS%s.", "<a href=\"" .. dispatcher.build_url("admin/network/dhcp") .. "\">", "</a>") .. helperText)
+	helperText)
 s3.template = "cbi/tblsection"
 s3.sortable  = false
 s3.anonymous = true

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:72
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:73
 msgid "%s is not installed or not found"
 msgstr ""
 
@@ -53,11 +53,15 @@ msgstr ""
 msgid "Cloudflare (Security Protection)"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:126
+msgid "Configuration"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
 msgid "DNS HTTPS Proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:106
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:107
 msgid "DNS HTTPS Proxy Settings"
 msgstr ""
 
@@ -77,11 +81,15 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:134
+msgid "Do not update configs"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:54
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:27
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:28
 msgid "For more information on different options check"
 msgstr ""
 
@@ -89,7 +97,18 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/root/usr/share/rpcd/acl.d/luci-app-https-dns-proxy.json:3
+msgid "Grant UCI and file access for luci-app-https-dns-proxy"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:126
+msgid ""
+"If update DNSMASQ config is selected, when you add/remove any instances "
+"below, they will be used to override the 'DNS forwardings' section of %sDHCP "
+"and DNS%s (%smore information%s)."
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:138
 msgid "Instances"
 msgstr ""
 
@@ -101,11 +120,11 @@ msgstr ""
 msgid "LibreDNS (No Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:160
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:172
 msgid "Listen address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:173
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:185
 msgid "Listen port"
 msgstr ""
 
@@ -125,7 +144,7 @@ msgstr ""
 msgid "OpenDNS (Family Shield)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:177
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:189
 msgid "Proxy server"
 msgstr ""
 
@@ -149,19 +168,19 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:133
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:145
 msgid "Resolver"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:98
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:99
 msgid "Running: %s DoH at %s:%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:110
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:111
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:108
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:109
 msgid "Service Status [%s %s]"
 msgstr ""
 
@@ -173,25 +192,31 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:76
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:77
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:63
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:64
 msgid "Unknown Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
-msgid ""
-"When you add/remove any instances below, they will be used to override the "
-"'DNS forwardings' section of %sDHCP and DNS%s."
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:131
+msgid "Update %s config"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:48
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
+msgid "Update DNSMASQ Config on Start/Stop"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:128
+msgid "Update all configs"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:49
 msgid "and"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:78
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:79
 msgid "disabled"
 msgstr ""
 

--- a/applications/luci-app-https-dns-proxy/root/usr/share/rpcd/acl.d/luci-app-https-dns-proxy.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/rpcd/acl.d/luci-app-https-dns-proxy.json
@@ -12,9 +12,6 @@
 				"/usr/lib/lua/luci/https-dns-proxy/providers/*": [
 					"read"
 				],
-				"/etc/init.d/dnsmasq *": [
-					"exec"
-				],
 				"/etc/init.d/https-dns-proxy *": [
 					"exec"
 				]


### PR DESCRIPTION
compiled/tested for rampis/er-x/19.07.5

Signed-off-by: Stan Grishin <stangri@melmac.net>