### PR TITLE
luci-app-openvpn: add hint for comp_lzo and compress issue

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -162,7 +162,7 @@ local knownParams = {
 		{ ListValue,
 			"compress",
 			{ "lzo", "lz4", "stub-v2"},
-			translate("Enable a compression algorithm") },
+			translate("Security recommendation: It is recommended to not enable compression and set this parameter to `stub-v2`") },
 	} },
 
 	{ "networking", translate("Networking"), {

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -254,7 +254,7 @@ local knownParams = {
 		{ ListValue,
 			"comp_lzo",
 			{ "yes", "no", "adaptive" },
-			translate("Use fast LZO compression") },
+			translate("Security recommendation: It is recommended to not enable compression and set this parameter to `no`")},
 		{ Flag,
 			"comp_noadapt",
 			0,

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -161,7 +161,7 @@ local knownParams = {
 			translate("Policy level over usage of external programs and scripts") },
 		{ ListValue,
 			"compress",
-			{ "lzo", "lz4" },
+			{ "lzo", "lz4", "stub-v2"},
 			translate("Enable a compression algorithm") },
 	} },
 

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
@@ -42,7 +42,7 @@ local basicParams = {
 	{ ListValue,
 		"comp_lzo",
 		{"yes","no","adaptive"},
-		translate("Use fast LZO compression") },
+		translate("Security recommendation: It is recommended to not enable compression and set this parameter to `no`")},
 	{ Value,
 		"keepalive",
 		"10 60",

--- a/applications/luci-app-openvpn/po/ar/openvpn.po
+++ b/applications/luci-app-openvpn/po/ar/openvpn.po
@@ -54,7 +54,8 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:193
 msgid "Allow remote to change its IP or port"
-msgstr "السماح للسيرفر البعيد بتغيير عنوان بروتوكول الإنترنت أو المنفذ الخاص به"
+msgstr ""
+"السماح للسيرفر البعيد بتغيير عنوان بروتوكول الإنترنت أو المنفذ الخاص به"
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:457
 msgid "Allowed maximum of connected clients"
@@ -247,10 +248,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:648
 msgid "Enable TLS and assume server role"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
@@ -567,6 +564,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -767,11 +777,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/bg/openvpn.po
+++ b/applications/luci-app-openvpn/po/bg/openvpn.po
@@ -248,10 +248,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -566,6 +562,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -766,11 +775,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/bn_BD/openvpn.po
+++ b/applications/luci-app-openvpn/po/bn_BD/openvpn.po
@@ -247,10 +247,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -565,6 +561,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -765,11 +774,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/ca/openvpn.po
+++ b/applications/luci-app-openvpn/po/ca/openvpn.po
@@ -251,10 +251,6 @@ msgstr "Activa el TLS i assumeix el rol de client"
 msgid "Enable TLS and assume server role"
 msgstr "Activa el TLS i assumeix el rol de servidor"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Activa la fragmentació de datagrames interna"
@@ -569,6 +565,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -772,11 +781,6 @@ msgstr ""
 msgid "Upload ovpn file"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Utilitza compressió ràpida LZO"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -819,6 +823,9 @@ msgstr "temps d'espera màxim d'inactivitat tun/tap"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "sí (%i)"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Utilitza compressió ràpida LZO"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/cs/openvpn.po
+++ b/applications/luci-app-openvpn/po/cs/openvpn.po
@@ -250,10 +250,6 @@ msgstr "Povolit TLS a převzít roli klienta"
 msgid "Enable TLS and assume server role"
 msgstr "Povolit TLS a převzít roli serveru"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Povolit kompresní algoritmus"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Povolit interní fragmentaci datagramů"
@@ -576,6 +572,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Sekce pro úpravu konfiguračního souboru OVPN (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Vybrat šablonu …"
@@ -780,11 +789,6 @@ msgstr "Nahrát"
 msgid "Upload ovpn file"
 msgstr "Nahrát OVPN soubor"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Používat rychlou kompresi LZO"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -827,6 +831,12 @@ msgstr "časový limit nečinnosti TUN/TAP"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "ano (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Povolit kompresní algoritmus"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Používat rychlou kompresi LZO"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/de/openvpn.po
+++ b/applications/luci-app-openvpn/po/de/openvpn.po
@@ -250,10 +250,6 @@ msgstr "TLS im Client-Betriebsmodus aktivieren"
 msgid "Enable TLS and assume server role"
 msgstr "TLS im Server-Betriebsmodus aktivieren"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Kompressionsalgorithmus aktivieren"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Datenpakete bei Bedarf fragmentieren"
@@ -579,6 +575,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Abschnitt zum Ändern der OVPN-Konfigurationsdatei (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Vorlage auswählen ..."
@@ -787,11 +796,6 @@ msgstr "Upload"
 msgid "Upload ovpn file"
 msgstr "Hochladen der OVPN-Datei"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Schnelle LZO-Kompression benutzen"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -834,6 +838,12 @@ msgstr "Inaktivitäts-Timeout für TUN/TAP Schnittstellen"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "Gestartet (%s)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Kompressionsalgorithmus aktivieren"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Schnelle LZO-Kompression benutzen"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/el/openvpn.po
+++ b/applications/luci-app-openvpn/po/el/openvpn.po
@@ -250,10 +250,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -569,6 +565,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -769,11 +778,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/en/openvpn.po
+++ b/applications/luci-app-openvpn/po/en/openvpn.po
@@ -248,10 +248,6 @@ msgstr "Enable TLS and assume client role"
 msgid "Enable TLS and assume server role"
 msgstr "Enable TLS and assume server role"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Enable internal datagram fragmentation"
@@ -566,6 +562,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -768,11 +777,6 @@ msgstr ""
 msgid "Upload ovpn file"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Use fast LZO compression"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -815,6 +819,9 @@ msgstr "tun/tap inactivity timeout"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "yes (%i)"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Use fast LZO compression"
 
 #~ msgid "Daemonize after initialization"
 #~ msgstr "Daemonize after initialization"

--- a/applications/luci-app-openvpn/po/es/openvpn.po
+++ b/applications/luci-app-openvpn/po/es/openvpn.po
@@ -249,10 +249,6 @@ msgstr "Activar TLS y asumir el rol de cliente"
 msgid "Enable TLS and assume server role"
 msgstr "Activar TLS y asumir el rol del servidor"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Activar un algoritmo de compresión"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Activar la fragmentación interna del datagrama"
@@ -578,6 +574,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Sección para modificar el archivo de configuración OVPN (% )"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Seleccionar plantilla..."
@@ -785,11 +794,6 @@ msgstr "Cargar"
 msgid "Upload ovpn file"
 msgstr "Subir archivo ovpn"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Compresión rápida LZO"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -832,6 +836,12 @@ msgstr "Espera de inactividad tun/tap"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "sí (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Activar un algoritmo de compresión"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Compresión rápida LZO"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/fa/openvpn.po
+++ b/applications/luci-app-openvpn/po/fa/openvpn.po
@@ -250,10 +250,6 @@ msgstr "فعالسازی TLS و قبول نقش کلاینت"
 msgid "Enable TLS and assume server role"
 msgstr "فعالسازی TLS و قبول نقش سرور"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "فعالسازی الگوریتم فشرده سازی"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "فعالسازی چند قطعه کردن دیتاگرام داخلی"
@@ -574,6 +570,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -776,11 +785,6 @@ msgstr ""
 msgid "Upload ovpn file"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -823,6 +827,9 @@ msgstr ""
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr ""
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "فعالسازی الگوریتم فشرده سازی"
 
 #~ msgid "Daemonize after initialization"
 #~ msgstr "Daemonize after initialization"

--- a/applications/luci-app-openvpn/po/fi/openvpn.po
+++ b/applications/luci-app-openvpn/po/fi/openvpn.po
@@ -248,10 +248,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -566,6 +562,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -766,11 +775,6 @@ msgstr "Lähetä"
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/fr/openvpn.po
+++ b/applications/luci-app-openvpn/po/fr/openvpn.po
@@ -259,10 +259,6 @@ msgstr "Activer le TLS et prendre le rôle du client"
 msgid "Enable TLS and assume server role"
 msgstr "Activer le TLS et prendre le rôle du serveur"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Activer un algorithme de compression"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Autoriser la fragmentation des datagrammes en interne"
@@ -591,6 +587,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Section pour modifier le fichier de configuration de l'OVPN (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Sélectionner un modèle ..."
@@ -798,11 +807,6 @@ msgstr "Téléverser"
 msgid "Upload ovpn file"
 msgstr "Téléverser un fichier ovpn"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Utiliser la compression LZO rapide"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -845,6 +849,12 @@ msgstr "Délai d'inactivité tun/tap"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "oui (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Activer un algorithme de compression"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Utiliser la compression LZO rapide"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/he/openvpn.po
+++ b/applications/luci-app-openvpn/po/he/openvpn.po
@@ -246,10 +246,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -564,6 +560,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -764,11 +773,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/hi/openvpn.po
+++ b/applications/luci-app-openvpn/po/hi/openvpn.po
@@ -248,10 +248,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -566,6 +562,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -766,11 +775,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/hu/openvpn.po
+++ b/applications/luci-app-openvpn/po/hu/openvpn.po
@@ -250,10 +250,6 @@ msgstr "TLS engedélyezése és ügyfélszerep feltételezése"
 msgid "Enable TLS and assume server role"
 msgstr "TLS engedélyezése és kiszolgálószerep feltételezése"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Tömörítési algoritmus engedélyezése"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Belső adatcsomag-darabolás engedélyezése"
@@ -581,6 +577,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Egy szakasz az OVPN beállítófájl módosításához (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Sablon kiválasztása…"
@@ -786,11 +795,6 @@ msgstr "Feltöltés"
 msgid "Upload ovpn file"
 msgstr "OVPN fájl feltöltése"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Gyors LZO-tömörítés használata"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -833,6 +837,12 @@ msgstr "TUN/TAP tétlenségi időkorlát"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "igen (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Tömörítési algoritmus engedélyezése"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Gyors LZO-tömörítés használata"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/it/openvpn.po
+++ b/applications/luci-app-openvpn/po/it/openvpn.po
@@ -248,10 +248,6 @@ msgstr "Abilita TLS e usa il ruolo client"
 msgid "Enable TLS and assume server role"
 msgstr "Abilita TLS e usa il ruolo server"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Abilita frammentazione interna dei datagram"
@@ -568,6 +564,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -768,11 +777,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/ja/openvpn.po
+++ b/applications/luci-app-openvpn/po/ja/openvpn.po
@@ -248,10 +248,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "圧縮アルゴリズムを有効にする"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -566,6 +562,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "テンプレートを選択..."
@@ -768,11 +777,6 @@ msgstr "アップロード"
 msgid "Upload ovpn file"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "高速LZO圧縮機能を使用する"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -815,6 +819,12 @@ msgstr ""
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "はい (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "圧縮アルゴリズムを有効にする"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "高速LZO圧縮機能を使用する"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/ko/openvpn.po
+++ b/applications/luci-app-openvpn/po/ko/openvpn.po
@@ -248,10 +248,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -566,6 +562,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -766,11 +775,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/mr/openvpn.po
+++ b/applications/luci-app-openvpn/po/mr/openvpn.po
@@ -248,10 +248,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -566,6 +562,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -766,11 +775,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/ms/openvpn.po
+++ b/applications/luci-app-openvpn/po/ms/openvpn.po
@@ -246,10 +246,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -564,6 +560,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -764,11 +773,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/nb_NO/openvpn.po
+++ b/applications/luci-app-openvpn/po/nb_NO/openvpn.po
@@ -246,10 +246,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -564,6 +560,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -764,11 +773,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/pl/openvpn.po
+++ b/applications/luci-app-openvpn/po/pl/openvpn.po
@@ -250,10 +250,6 @@ msgstr "Włącz TLS i przyjmij rolę klienta"
 msgid "Enable TLS and assume server role"
 msgstr "Włącz TLS i przyjmij rolę serwera"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Włącz algorytm kompresji"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Włącz wewnętrzną fragmentację datagramu"
@@ -578,6 +574,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Sekcja modyfikacji pliku konfiguracyjnego OVPN (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Wybierz szablon ..."
@@ -785,11 +794,6 @@ msgstr "Wyślij"
 msgid "Upload ovpn file"
 msgstr "Prześlij plik ovpn"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Użyj szybkiej kompresji LZO"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -832,6 +836,12 @@ msgstr "czas bezczynności TUN/TAP"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "tak (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Włącz algorytm kompresji"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Użyj szybkiej kompresji LZO"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/pt/openvpn.po
+++ b/applications/luci-app-openvpn/po/pt/openvpn.po
@@ -251,10 +251,6 @@ msgstr "Activar TLS e assumir papel de cliente"
 msgid "Enable TLS and assume server role"
 msgstr "Activar TLS e assumir papel de servidor"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Ativar um algoritmo de compressão"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Activar a fragmentação interna de datagramas"
@@ -580,6 +576,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Secção para modificar o ficheiro de configuração OVPN (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Selecionar modelo ..."
@@ -786,11 +795,6 @@ msgstr "Enviar"
 msgid "Upload ovpn file"
 msgstr "Enviar ficheiro ovpn"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Usar compressão LZO rápida"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -833,6 +837,12 @@ msgstr "Timeout de inactividade tun/tap"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "sim (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Ativar um algoritmo de compressão"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Usar compressão LZO rápida"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/pt_BR/openvpn.po
+++ b/applications/luci-app-openvpn/po/pt_BR/openvpn.po
@@ -250,10 +250,6 @@ msgstr "Ativar TLS e assumir papel de cliente"
 msgid "Enable TLS and assume server role"
 msgstr "Ativar TLS e assumir papel de servidor"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Ativar um algoritmo de compressão"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Ativar a fragmentação interna de datagramas"
@@ -576,6 +572,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Seção para modificar o arquivo de configuração OVPN (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Escolha um modelo ..."
@@ -784,11 +793,6 @@ msgstr "Envio"
 msgid "Upload ovpn file"
 msgstr "Enviar arquivo ovpn"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Usar compressão LZO rápida"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -831,6 +835,12 @@ msgstr "Tempo limite de inatividade tun/tap"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "sim (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Ativar um algoritmo de compressão"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Usar compressão LZO rápida"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/ro/openvpn.po
+++ b/applications/luci-app-openvpn/po/ro/openvpn.po
@@ -247,10 +247,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -565,6 +561,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -765,11 +774,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/ru/openvpn.po
+++ b/applications/luci-app-openvpn/po/ru/openvpn.po
@@ -281,10 +281,6 @@ msgstr "Включить TLS и выступить в роли клиента в
 msgid "Enable TLS and assume server role"
 msgstr "Включить в режиме сервера протокол TLS"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Включить алгоритм сжатия"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -637,6 +633,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "Раздел для изменения конфигурационного OVPN файла (%s)"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "Выберите шаблон..."
@@ -852,11 +861,6 @@ msgstr "Загрузка"
 msgid "Upload ovpn file"
 msgstr "Загрузка OVPN файла"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Использовать быстрое сжатие 'lzo'"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -899,6 +903,12 @@ msgstr "Промежуток времени простоя tun/tap"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "да (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Включить алгоритм сжатия"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Использовать быстрое сжатие 'lzo'"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/sk/openvpn.po
+++ b/applications/luci-app-openvpn/po/sk/openvpn.po
@@ -246,10 +246,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -564,6 +560,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -764,11 +773,6 @@ msgstr "Odovzdať"
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/sv/openvpn.po
+++ b/applications/luci-app-openvpn/po/sv/openvpn.po
@@ -246,10 +246,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -564,6 +560,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -764,11 +773,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/templates/openvpn.pot
+++ b/applications/luci-app-openvpn/po/templates/openvpn.pot
@@ -235,10 +235,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -553,6 +549,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -753,11 +762,6 @@ msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/tr/openvpn.po
+++ b/applications/luci-app-openvpn/po/tr/openvpn.po
@@ -246,10 +246,6 @@ msgstr ""
 msgid "Enable TLS and assume server role"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr ""
@@ -564,6 +560,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -764,11 +773,6 @@ msgstr "Yükleme"
 
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
-msgstr ""
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
 msgstr ""
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510

--- a/applications/luci-app-openvpn/po/uk/openvpn.po
+++ b/applications/luci-app-openvpn/po/uk/openvpn.po
@@ -247,10 +247,6 @@ msgstr "Увімкнути TLS та удавати себе клієнтом"
 msgid "Enable TLS and assume server role"
 msgstr "Увімкнути TLS та удавати себе сервером"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "Увімкнути алгоритм стиснення"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Увімкнути внутрішню фрагментацію datagram"
@@ -565,6 +561,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -767,11 +776,6 @@ msgstr "Відвантажити"
 msgid "Upload ovpn file"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -814,6 +818,9 @@ msgstr ""
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "так (%i)"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "Увімкнути алгоритм стиснення"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/vi/openvpn.po
+++ b/applications/luci-app-openvpn/po/vi/openvpn.po
@@ -250,10 +250,6 @@ msgstr "Kích hoạt TLS và giả định vải trò của client"
 msgid "Enable TLS and assume server role"
 msgstr "Kích hoạt TLS và giả định vải trò của server"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr ""
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "Kích hoạt internal datagram fragmentation"
@@ -568,6 +564,19 @@ msgstr ""
 msgid "Section to modify the OVPN config file (%s)"
 msgstr ""
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr ""
@@ -770,11 +779,6 @@ msgstr ""
 msgid "Upload ovpn file"
 msgstr ""
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "Dùng LZO nén nhanh"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -817,6 +821,9 @@ msgstr "tun/tap timeout không có hành động"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "Có (%i)"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "Dùng LZO nén nhanh"
 
 #~ msgid "Daemonize after initialization"
 #~ msgstr "Daemonize sau khi khởi tạo"

--- a/applications/luci-app-openvpn/po/zh_Hans/openvpn.po
+++ b/applications/luci-app-openvpn/po/zh_Hans/openvpn.po
@@ -251,10 +251,6 @@ msgstr "允许 TLS 并伪装为客户端"
 msgid "Enable TLS and assume server role"
 msgstr "允许 TLS 并伪装为服务器"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "启用压缩算法"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "允许内部数据报分片"
@@ -570,6 +566,19 @@ msgstr "在此区域编辑“auth-user-pass”文件的内容（%s）"
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "在此区域修改 OVPN 配置文件（%s）"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "选择模板…"
@@ -772,11 +781,6 @@ msgstr "上传"
 msgid "Upload ovpn file"
 msgstr "上传 opvn 文件"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "使用快速 LZO 压缩"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:103
@@ -819,6 +823,12 @@ msgstr "tun/tap 休眠超时"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "是（%i）"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "启用压缩算法"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "使用快速 LZO 压缩"
 
 #~ msgid "%s"
 #~ msgstr "%s"

--- a/applications/luci-app-openvpn/po/zh_Hant/openvpn.po
+++ b/applications/luci-app-openvpn/po/zh_Hant/openvpn.po
@@ -251,10 +251,6 @@ msgstr "允許 TLS 並偽裝為客戶端"
 msgid "Enable TLS and assume server role"
 msgstr "允許 TLS 並偽裝為伺服器"
 
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
-msgid "Enable a compression algorithm"
-msgstr "啟用壓縮演算法"
-
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:278
 msgid "Enable internal datagram fragmentation"
 msgstr "允許內部資料報分片"
@@ -293,7 +289,9 @@ msgstr "在伺服器模式下執行新的客戶端連線，當客戶端仍然是
 msgid ""
 "Executed in server mode whenever an IPv4 address/route or MAC address is "
 "added to OpenVPN's internal routing table"
-msgstr "只要將每個 IPv4位址/路由或 MAC位址新增到 OpenVPN 的內部路由表中, 就在伺服器模式下執行"
+msgstr ""
+"只要將每個 IPv4位址/路由或 MAC位址新增到 OpenVPN 的內部路由表中, 就在伺服器模"
+"式下執行"
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:744
 msgid "Exit on TLS negotiation failure"
@@ -569,6 +567,19 @@ msgstr "本節添加帶有您的憑據（％s）的可選“ auth-user-pass”�
 msgid "Section to modify the OVPN config file (%s)"
 msgstr "節錄OVPN設置文件（％s）的部分"
 
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `no`"
+msgstr ""
+
+#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:165
+msgid ""
+"Security recommendation: It is recommended to not enable compression and set "
+"this parameter to `stub-v2`"
+msgstr ""
+
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:85
 msgid "Select template ..."
 msgstr "選擇模板..."
@@ -748,7 +759,8 @@ msgstr "最低支援的 TLS 版本"
 msgid ""
 "The size of the OVPN config file (%s) is too large for online editing in "
 "LuCI (&ge; 100 KB)."
-msgstr "OVPN設置文件(％s)的尺寸太大，無法在LuCI中進行在線編輯（＆ge; 100 KB）。"
+msgstr ""
+"OVPN設置文件(％s)的尺寸太大，無法在LuCI中進行在線編輯（＆ge; 100 KB）。"
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:792
 msgid "This completely disables cipher negotiation"
@@ -770,11 +782,6 @@ msgstr "上傳"
 #: applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm:104
 msgid "Upload ovpn file"
 msgstr "上傳ovpn文件"
-
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:257
-#: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:45
-msgid "Use fast LZO compression"
-msgstr "使用快速 LZO 壓縮"
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:510
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua:97
@@ -818,6 +825,12 @@ msgstr "tun/tap 休眠超時"
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua:111
 msgid "yes (%i)"
 msgstr "是（%i）"
+
+#~ msgid "Enable a compression algorithm"
+#~ msgstr "啟用壓縮演算法"
+
+#~ msgid "Use fast LZO compression"
+#~ msgstr "使用快速 LZO 壓縮"
 
 #~ msgid "%s"
 #~ msgstr "%s"


### PR DESCRIPTION
The compress and comp_lzo are not recommended.
See https://community.openvpn.net/openvpn/wiki/VORACLE

So add a hint to the LuCI for this issue.
Also add the option `stub-v2` .

Since commit https://github.com/openwrt/packages/commit/e4376793b4e093089543cb1bad64eef34ed25eca lzo was set to default no on openwrt builds. The question is now should we also remove this from LuCI?