### PR TITLE
luci-base: update placeholder for IPv4 gateway on proto static

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/protocol/static.js
+++ b/modules/luci-base/htdocs/luci-static/resources/protocol/static.js
@@ -136,7 +136,7 @@ return network.registerProtocol('static', {
 			return network.getWANNetworks().then(L.bind(function(wans) {
 				if (wans.length == 1) {
 					var gwaddr = wans[0].getGatewayAddr();
-					this.placeholder = gwaddr ? '%s (%s)'.format(gwaddr, wans[0].getName()) : '';
+					this.placeholder = gwaddr ? '%s %s (%s)'.format(_('Add IPv4 gateway…'), gwaddr, wans[0].getName()) : _('Add IPv4 gateway…');
 				}
 
 				return form.Value.prototype.render.apply(this, [ option_index, section_id, in_table ]);


### PR DESCRIPTION
The problem is that when switching from the dhcp proto to the static
proto, the IPv4 gateway is already filled in as a placeholder but not
preselected. With some themes (luci-theme-openwrt-2020) it is not well
visible that this is only a suggestion and is not a preselection.

By adding 'Add IPv4 gateway...' to the placeholder, it is more cleaner
that it is only a suggestion.