### PR TITLE
luci-app-attendedsysupgrade: remove depends uhttpd-mod-ubus

### DIFF
--- a/applications/luci-app-attendedsysupgrade/Makefile
+++ b/applications/luci-app-attendedsysupgrade/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for attended sysupgrades
-LUCI_DEPENDS:=+luci-base +uhttpd-mod-ubus +attendedsysupgrade-common +cgi-io
+LUCI_DEPENDS:=+luci-base +attendedsysupgrade-common +cgi-io
 
 include ../../luci.mk
 

--- a/applications/luci-app-attendedsysupgrade/root/etc/uci-defaults/40_luci-attendedsysupgrade
+++ b/applications/luci-app-attendedsysupgrade/root/etc/uci-defaults/40_luci-attendedsysupgrade
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-/etc/init.d/uhttpd restart
-/etc/init.d/rpcd reload
-
-return 0


### PR DESCRIPTION
Remove depenedency uhttpd-mod-ubus which is not required.
User may want to work with nginx rather uhttpd.
