### PR TITLE
luci-app-wireguard: select qrencode optional dependency

### DIFF
--- a/applications/luci-app-wireguard/Makefile
+++ b/applications/luci-app-wireguard/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=WireGuard Status
-LUCI_DEPENDS:=+wireguard-tools +kmod-wireguard +luci-proto-wireguard
+LUCI_DEPENDS:=+wireguard-tools +kmod-wireguard +luci-proto-wireguard +qrencode
 LUCI_PKGARCH:=all
 
 include ../../luci.mk


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas@nbembedded.com>

Partial fix for https://github.com/openwrt/luci/issues/4475