### PR TITLE
luci-theme-bootstrap: fix text wrapping in buttons

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1294,6 +1294,7 @@ body.modal-overlay-active #modal_overlay {
 	border-bottom-color: #bbb;
 	border-radius: 4px;
 	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+	white-space: pre;
 }
 
 .btn:focus,


### PR DESCRIPTION
* should fix #4647

Signed-off-by: Dirk Brenken <dev@brenken.org>