### PR TITLE
luci-app-sqm: Use CAKE as default qdisc

### DIFF
--- a/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
+++ b/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
@@ -95,7 +95,7 @@ return view.extend({
 		for (var i=0; i < qdiscs.length; i++) {
 			o.value(qdiscs[i].name);
 		}
-		o.default = "fq_codel";
+		o.default = "cake";
 		o.rmempty = false;
 
 		var qos_desc = "";
@@ -108,7 +108,7 @@ return view.extend({
 			else
 				qos_desc += "No help text</p>";
 		}
-		o.default = "simple.qos";
+		o.default = "piece_of_cake.qos";
 		o.rmempty = false;
 		o.description = qos_desc;
 


### PR DESCRIPTION
The sqm-scripts package depends on kmod-sched-cake, meaning CAKE is always
available in normal installs. So we might as well just make CAKE the
default config in SQM configs.