### PR TITLE
luci-proto-modemmanager: add support for specifying signal refresh rate

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -121,6 +121,9 @@ return network.registerProtocol('modemmanager', {
 		o.placeholder = dev ? (dev.getMTU() || '1500') : '1500';
 		o.datatype    = 'max(9200)';
 		
+		o = s.taboption('general', form.Value, 'signalrate', _('Signal Refresh Rate'), _("In seconds"));
+		o.datatype = 'uinteger';
+		
 		s.taboption('general', form.Value, 'metric', _('Gateway metric'));
 
 	}


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas@nbembedded.com>

LuCI support for signal refresh rate support added in PR https://github.com/openwrt/packages/pull/13009