### PR TITLE
[RFC] luci-mod-system: drop kmod-ledtrig-* dependency

### DIFF
--- a/modules/luci-mod-system/Makefile
+++ b/modules/luci-mod-system/Makefile
@@ -7,11 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Administration - Global System Settings
-LUCI_DEPENDS:=+luci-base \
-	+kmod-ledtrig-default-on \
-	+kmod-ledtrig-heartbeat \
-	+kmod-ledtrig-netdev \
-	+kmod-ledtrig-timer
+LUCI_DEPENDS:=+luci-base
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
~The kmod packages were dropped from OpenWrt,~
~and the led triggers are now kernel built-in.~
...Not yet, but it will be.

This is the counterpart of openwrt/openwrt#3754.