### PR TITLE
[18.06] luci-app-https-dns-proxy: DSCP tagging support

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,6 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=13
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ca.dnscrypt.dns1.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ca.dnscrypt.dns1.lua
@@ -1,0 +1,8 @@
+return{
+	name="DnsCryptCa-DNS1",
+	label=_("DNSCrypt.ca (DNS1)"),
+	resolver_url="https://dns1.dnscrypt.ca:453/dns-query",
+	bootstrap_dns="45.76.37.222,185.112.145.13,93.95.226.53,2001:19f0:5001:185a:5400:ff:fe50:56d5",
+	help_link="https://dnscrypt.ca/",
+	help_link_text="dnscrypt.ca"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ca.dnscrypt.dns2.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ca.dnscrypt.dns2.lua
@@ -1,0 +1,8 @@
+return{
+	name="DnsCryptCa-DNS2",
+	label=_("DNSCrypt.ca (DNS2)"),
+	resolver_url="https://dns2.dnscrypt.ca:453/dns-query",
+	bootstrap_dns="45.76.37.222,185.112.145.13,93.95.226.53,2001:19f0:5001:185a:5400:ff:fe50:56d5",
+	help_link="https://dnscrypt.ca/",
+	help_link_text="dnscrypt.ca"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -186,6 +186,10 @@ lp = s3:option(Value, "listen_port", translate("Listen port"))
 lp.datatype = "port"
 lp.value    = n + 5053
 
+dscp = s3:option(Value, "dscp_codepoint", translate("DSCP Codepoint"))
+dscp.datatype = "range(0,63)"
+dscp.rmempty  = true
+
 ps = s3:option(Value, "proxy_server", translate("Proxy server"))
 ps.rmempty  = true
 

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -69,8 +69,20 @@ msgstr ""
 msgid "DNS.SB"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ca.dnscrypt.dns1.lua:3
+msgid "DNSCrypt.ca (DNS1)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ca.dnscrypt.dns2.lua:3
+msgid "DNSCrypt.ca (DNS2)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/pub.doh.lua:3
 msgid "DNSPod.cn Public DNS"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:189
+msgid "DSCP Codepoint"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua:3
@@ -144,7 +156,7 @@ msgstr ""
 msgid "OpenDNS (Family Shield)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:189
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:193
 msgid "Proxy server"
 msgstr ""
 


### PR DESCRIPTION
This implements support for editing DSCP codepoints/tagging in WebUI.

Signed-off-by: Stan Grishin <stangri@melmac.net>