### PR TITLE
Clean up trailing whitespace in 'modules'

### DIFF
--- a/modules/luci-base/luasrc/ccache.lua
+++ b/modules/luci-base/luasrc/ccache.lua
@@ -61,7 +61,7 @@ function cache_enable(cachepath, mode)
 	package.loaders[2] = function(mod)
 		local encoded = cachepath .. "/" .. _encode_filename(mod)
 		local modcons = _load_sane(encoded)
-		
+
 		if modcons then
 			return modcons
 		end

--- a/modules/luci-base/luasrc/sgi/cgi.lua
+++ b/modules/luci-base/luasrc/sgi/cgi.lua
@@ -35,11 +35,11 @@ function run()
 		limitsource(io.stdin, tonumber(luci.sys.getenv("CONTENT_LENGTH"))),
 		ltn12.sink.file(io.stderr)
 	)
-	
+
 	local x = coroutine.create(luci.dispatcher.httpdispatch)
 	local hcache = ""
 	local active = true
-	
+
 	while coroutine.status(x) ~= "dead" do
 		local res, id, data1, data2 = coroutine.resume(x, r)
 

--- a/modules/luci-base/luasrc/template.lua
+++ b/modules/luci-base/luasrc/template.lua
@@ -53,7 +53,7 @@ function Template.__init__(self, name, template)
 
 	-- Create a new namespace for this template
 	self.viewns = context.viewns
-	
+
 	-- If we have a cached template, skip compiling and loading
 	if not self.template then
 
@@ -84,13 +84,13 @@ end
 -- Renders a template
 function Template.render(self, scope)
 	scope = scope or getfenv(2)
-	
+
 	-- Put our predefined objects in the scope of the template
 	setfenv(self.template, setmetatable({}, {__index =
 		function(tbl, key)
 			return rawget(tbl, key) or self.viewns[key] or scope[key]
 		end}))
-	
+
 	-- Now finally render the thing
 	local stat, err = util.copcall(self.template)
 	if not stat then

--- a/modules/luci-compat/luasrc/model/network/proto_vpnc.lua
+++ b/modules/luci-compat/luasrc/model/network/proto_vpnc.lua
@@ -43,4 +43,3 @@ function proto.contains_interface(self, ifc)
 end
 
 netmod:register_pattern_virtual("^vpn%-%w")
-

--- a/modules/luci-compat/luasrc/tools/webadmin.lua
+++ b/modules/luci-compat/luasrc/tools/webadmin.lua
@@ -14,8 +14,8 @@ function byte_format(byte)
 		if byte > 1024 and i < 5 then
 			byte = byte / 1024
 		else
-			return string.format("%.2f %s", byte, suff[i]) 
-		end 
+			return string.format("%.2f %s", byte, suff[i])
+		end
 	end
 end
 
@@ -24,23 +24,23 @@ function date_format(secs)
 	local mins = 0
 	local hour = 0
 	local days = 0
-	
+
 	secs = math.floor(secs)
 	if secs > 60 then
 		mins = math.floor(secs / 60)
 		secs = secs % 60
 	end
-	
+
 	if mins > 60 then
 		hour = math.floor(mins / 60)
 		mins = mins % 60
 	end
-	
+
 	if hour > 24 then
 		days = math.floor(hour / 24)
 		hour = hour % 24
 	end
-	
+
 	if days > 0 then
 		return string.format("%.0fd %02.0fh %02.0fmin %02.0fs", days, hour, mins, secs)
 	else
@@ -70,15 +70,15 @@ end
 
 function firewall_find_zone(name)
 	local find
-	
-	luci.model.uci.cursor():foreach("firewall", "zone", 
+
+	luci.model.uci.cursor():foreach("firewall", "zone",
 		function (section)
 			if section.name == name then
 				find = section[".name"]
 			end
 		end
 	)
-	
+
 	return find
 end
 

--- a/modules/luci-mod-admin-mini/luasrc/controller/mini/index.lua
+++ b/modules/luci-mod-admin-mini/luasrc/controller/mini/index.lua
@@ -10,14 +10,14 @@ function index()
 		root.target = alias("mini")
 		root.index = true
 	end
-	
+
 	entry({"about"}, template("about"))
-	
+
 	local page   = entry({"mini"}, alias("mini", "index"), _("Essentials"), 10)
 	page.sysauth = "root"
 	page.sysauth_authenticator = "htmlauth"
 	page.index = true
-	
+
 	entry({"mini", "index"}, alias("mini", "index", "index"), _("Overview"), 10).index = true
 	entry({"mini", "index", "index"}, form("mini/index"), _("General"), 1).ignoreindex = true
 	entry({"mini", "index", "luci"}, cbi("mini/luci", {autoapply=true}), _("Settings"), 10)

--- a/modules/luci-mod-admin-mini/luasrc/controller/mini/system.lua
+++ b/modules/luci-mod-admin-mini/luasrc/controller/mini/system.lua
@@ -17,8 +17,8 @@ function action_backup()
 	local reset_avail = os.execute([[grep '"rootfs_data"' /proc/mtd >/dev/null 2>&1]]) == 0
 	local restore_cmd = "gunzip | tar -xC/ >/dev/null 2>&1"
 	local backup_cmd  = "tar -c %s | gzip 2>/dev/null"
-	
-	local restore_fpi 
+
+	local restore_fpi
 	luci.http.setfilehandler(
 		function(meta, chunk, eof)
 			if not restore_fpi then
@@ -32,11 +32,11 @@ function action_backup()
 			end
 		end
 	)
-		  
+
 	local upload = luci.http.formvalue("archive")
 	local backup = luci.http.formvalue("backup")
 	local reset  = reset_avail and luci.http.formvalue("reset")
-	
+
 	if upload and #upload > 0 then
 		luci.template.render("mini/applyreboot")
 		luci.sys.reboot()
@@ -66,7 +66,7 @@ function action_upgrade()
 	require("luci.model.uci")
 
 	local tmpfile = "/tmp/firmware.img"
-	
+
 	local function image_supported()
 		-- XXX: yay...
 		return ( 0 == os.execute(
@@ -76,11 +76,11 @@ function action_upgrade()
 				% tmpfile
 		) )
 	end
-	
+
 	local function image_checksum()
 		return (luci.sys.exec("md5sum %q" % tmpfile):match("^([^%s]+)"))
 	end
-	
+
 	local function storage_size()
 		local size = 0
 		if nixio.fs.access("/proc/mtd") then
@@ -128,9 +128,9 @@ function action_upgrade()
 	local has_support  = image_supported()
 	local has_platform = nixio.fs.access("/lib/upgrade/platform.sh")
 	local has_upload   = luci.http.formvalue("image")
-	
+
 	-- This does the actual flashing which is invoked inside an iframe
-	-- so don't produce meaningful errors here because the the 
+	-- so don't produce meaningful errors here because the the
 	-- previous pages should arrange the stuff as required.
 	if step == 4 then
 		if has_platform and has_image and has_support then
@@ -163,7 +163,7 @@ function action_upgrade()
 		if has_image then
 			nixio.fs.unlink(tmpfile)
 		end
-			
+
 		luci.template.render("mini/upgrade", {
 			step=1,
 			bad_image=(has_image and not has_support or false),
@@ -180,14 +180,14 @@ function action_upgrade()
 			flashsize=storage_size(),
 			keepconfig=(keep_avail and luci.http.formvalue("keepcfg") == "1")
 		} )
-	
+
 	-- Step 3: load iframe which calls the actual flash procedure
 	elseif step == 3 then
 		luci.template.render("mini/upgrade", {
 			step=3,
 			keepconfig=(keep_avail and luci.http.formvalue("keepcfg") == "1")
 		} )
-	end	
+	end
 end
 
 function _keep_pattern()

--- a/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/dhcp.lua
+++ b/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/dhcp.lua
@@ -30,15 +30,15 @@ limit:depends("ignore", "0")
 
 function limit.cfgvalue(self, section)
 	local value = Value.cfgvalue(self, section)
-	
+
 	if value then
 		return tonumber(value) + 1
-	end 
+	end
 end
 
 function limit.write(self, section, value)
 	value = tonumber(value) - 1
-	return Value.write(self, section, value) 
+	return Value.write(self, section, value)
 end
 
 limit.rmempty = true
@@ -53,7 +53,7 @@ uci:foreach("dhcp", "dnsmasq",
  function(section)
  	leasefn = section.leasefile
  end
-) 
+)
 local leasefp = leasefn and fs.access(leasefn) and io.lines(leasefn)
 if leasefp then
 	leases = {}

--- a/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/passwd.lua
+++ b/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/passwd.lua
@@ -19,13 +19,13 @@ end
 function f.handle(self, state, data)
 	if state == FORM_VALID then
 		local stat = luci.sys.user.setpasswd("root", data.pw1) == 0
-		
+
 		if stat then
 			f.message = translate("Password successfully changed")
 		else
 			f.errmessage = translate("Unknown Error")
 		end
-		
+
 		data.pw1 = nil
 		data.pw2 = nil
 	end

--- a/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/wifi.lua
+++ b/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/wifi.lua
@@ -242,7 +242,7 @@ if hwtype == "mac80211" then
 		encr.description = translate(
 			"WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP " ..
 			"and ad-hoc mode) to be installed."
-		)		
+		)
 	else
 		encr.description = translate(
 			"WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP " ..

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -284,7 +284,7 @@ return view.extend({
 
 		o = s.taboption('general', form.DynamicList, 'address', _('Addresses'),
 			_('List of domains to force to an IP address.'));
-		
+
 		o.optional = true;
 		o.placeholder = '/router.local/192.168.0.1';
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -895,7 +895,7 @@ return view.extend({
 
 					o = ss.taboption('advanced', CBIWifiCountryValue, 'country', _('Country Code'));
 					o.wifiNetwork = radioNet;
- 
+
 					o = ss.taboption('advanced', form.ListValue, 'cell_density', _('Coverage cell density'), _('Configures data rates based on the coverage cell density. Normal configures basic rates to 6, 12, 24 Mbps if legacy 802.11b rates are not used else to 5.5, 11 Mbps. High configures basic rates to 12, 24 Mbps if legacy 802.11b rates are not used else to the 11 Mbps rate. Very High configures 24 Mbps as the basic rate. Supported rates lower than the minimum basic rate are not offered.'));
 					o.value('0', _('Disabled'));
 					o.value('1', _('Normal'));

--- a/modules/luci-mod-rpc/luasrc/jsonrpc.lua
+++ b/modules/luci-mod-rpc/luasrc/jsonrpc.lua
@@ -7,7 +7,7 @@ require "luci.json"
 
 function resolve(mod, method)
 	local path = luci.util.split(method, ".")
-	
+
 	for j=1, #path-1 do
 		if not type(mod) == "table" then
 			break
@@ -29,7 +29,7 @@ function handle(tbl, rawsource, ...)
 	local json = decoder:get()
 	local response
 	local success = false
-	
+
 	if stat then
 		if type(json.method) == "string"
 		 and (not json.params or type(json.params) == "table") then
@@ -56,23 +56,23 @@ end
 function reply(jsonrpc, id, res, err)
 	require "luci.json"
 	id = id or luci.json.null
-	
+
 	-- 1.0 compatibility
 	if jsonrpc ~= "2.0" then
 		jsonrpc = nil
 		res = res or luci.json.null
 		err = err or luci.json.null
 	end
-	
+
 	return {id=id, result=res, error=err, jsonrpc=jsonrpc}
 end
 
 function proxy(method, ...)
 	local res = {luci.util.copcall(method, ...)}
 	local stat = table.remove(res, 1)
-	
+
 	if not stat then
-		return nil, {code=-32602, message="Invalid params.", data=table.remove(res, 1)} 
+		return nil, {code=-32602, message="Invalid params.", data=table.remove(res, 1)}
 	else
 		if #res <= 1 then
 			return res[1] or luci.json.null

--- a/modules/luci-mod-rpc/luasrc/jsonrpcbind/uci.lua
+++ b/modules/luci-mod-rpc/luasrc/jsonrpcbind/uci.lua
@@ -29,19 +29,19 @@ function commit(config)
 end
 
 function delete(config, ...)
-	uci:load(config) 
-	return uci:delete(config, ...) and uci:save(config) 
+	uci:load(config)
+	return uci:delete(config, ...) and uci:save(config)
 end
 
 function delete_all(config, ...)
 	uci:load(config)
-	return uci:delete_all(config, ...) and uci:save(config) 
+	return uci:delete_all(config, ...) and uci:save(config)
 end
 
 function foreach(config, stype)
 	uci:load(config)
 	local sections = {}
-	
+
 	return uci:foreach(config, stype, function(section)
 		table.insert(sections, section)
 	end) and sections
@@ -80,4 +80,3 @@ function tset(config, ...)
 	uci:load(config)
 	return uci:tset(config, ...) and uci:save(config)
 end
-

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -388,7 +388,7 @@ return view.extend({
 					tab: tab,
 				};
 
-				this.radios[ifname+freq] = { 
+				this.radios[ifname+freq] = {
 					dev: wifiDevs[ifname].dev,
 					graph: graph_data,
 					table: table,

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
@@ -29,14 +29,14 @@ return baseclass.extend({
 		    ht = rt.ht, vht = rt.vht,
 			mhz = rt.mhz, nss = rt.nss,
 			mcs = rt.mcs, sgi = rt.short_gi;
-	
+
 		if (ht || vht) {
 			if (vht) s += ', VHT-MCS\xa0%d'.format(mcs);
 			if (nss) s += ', VHT-NSS\xa0%d'.format(nss);
 			if (ht)  s += ', MCS\xa0%s'.format(mcs);
 			if (sgi) s += ', ' + _('Short GI').replace(/ /g, '\xa0');
 		}
-	
+
 		return s;
 	},
 
@@ -99,12 +99,12 @@ return baseclass.extend({
 		    freq = null,
 		    rate = null,
 		    badges = [];
-	
+
 		for (var i = 0; i < networks.length; i++) {
 			var net = networks[i],
 			    is_assoc = (net.getBSSID() != '00:00:00:00:00:00' && net.getChannel() && !net.isDisabled()),
 			    quality = net.getSignalPercent();
-	
+
 			var icon;
 			if (net.isDisabled())
 				icon = L.resource('icons/signal-none.png');
@@ -134,7 +134,7 @@ return baseclass.extend({
 					}, [ _('Start WPS') ])
 				}
 			}
-	
+
 			var badge = renderBadge(
 				icon,
 				'%s: %d dBm / %s: %d%%'.format(_('Signal'), net.getSignal(), _('Quality'), quality),
@@ -147,14 +147,14 @@ return baseclass.extend({
 				_('WPS status'), this.WPSTranslateTbl[net.wps_status],
 				'', WPS_button
 			);
-	
+
 			badges.push(badge);
-	
+
 			chan = (chan != null) ? chan : net.getChannel();
 			freq = (freq != null) ? freq : net.getFrequency();
 			rate = (rate != null) ? rate : net.getBitRate();
 		}
-	
+
 		return E('div', { class: 'ifacebox' }, [
 			E('div', { class: 'ifacebox-head center ' + (radio.isUp() ? 'active' : '') },
 				E('strong', radio.getName())),
@@ -340,7 +340,7 @@ return baseclass.extend({
 							}).render()
 						)
 					}
-					else { 
+					else {
 						row.push(E('button', {
 							'class': 'cbi-button cbi-button-remove',
 							'click': L.bind(this.handleDelClient, this, networks[i], bss.mac)

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
@@ -215,4 +215,3 @@ return view.extend({
 	handleSave: null,
 	handleReset: null
 });
-


### PR DESCRIPTION
Whitespace and indent cleanup of 'modules' folder.

- Remove trailing whitespace
- Ensure one and only one final newline at the end of file
- Fix indentation
