### PR TITLE
luci-app-ddns: fix wget-ssl path

### DIFF
--- a/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
+++ b/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
@@ -187,7 +187,7 @@ local methods = {
 
 			local function has_wgetssl()
 				if cache['has_wgetssl'] then return cache['has_wgetssl'] end
-				local res = (sys.call( [[command -v wget-ssl >/dev/null 2>&1]] ) == 0)
+				local res = has_wget() and (sys.call( [[wget --version | grep -qF +https >/dev/null 2>&1]] ) == 0)
 				cache['has_wgetssl'] = res
 				return res
 			end


### PR DESCRIPTION
Description: Fix path of wget-ssl due to https://github.com/openwrt/packages/pull/14257
See also https://github.com/openwrt/packages/pull/14510