### PR TITLE
luci-base: luci.js: fix `LuCI.request.poll.add()` exception handling

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -982,12 +982,13 @@
 						if (!Poll.active())
 							return;
 
+						var res_json = null;
 						try {
-							callback(res, res.json(), res.duration);
+							res_json = res.json();
 						}
-						catch (err) {
-							callback(res, null, res.duration);
-						}
+						catch (err) {}
+
+						callback(res, res_json, res.duration);
 					});
 				};
 


### PR DESCRIPTION
The try/catch is meant for the `res.json()` call and should only apply to that. As it was before, an exception inside the poll callback would cause the callback to be reinvoked without the JSON parameter, which is an odd behaviour. Moreover, it makes it hard to debug because it is completely hidden from the browser console. We now differentiate between exceptions thrown due to bad JSON in `responseText` from exceptions generated inside the callback itself, which are let through for browser console logging.
