### PR TITLE
luci-mod-status: use the new ubus dsl metrics

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
@@ -2,40 +2,39 @@
 'require baseclass';
 'require rpc';
 
-var callLuciDSLStatus = rpc.declare({
-	object: 'luci-rpc',
-	method: 'getDSLStatus',
+var callDSLMetrics = rpc.declare({
+	object: 'dsl',
+	method: 'metrics',
 	expect: { '': {} }
 });
 
 function renderbox(dsl) {
 	return E('div', { class: 'ifacebox' }, [
-		E('div', { class: 'ifacebox-head center ' + ((dsl.line_state === 'UP') ? 'active' : '') },
+		E('div', { class: 'ifacebox-head center ' + (dsl.up ? 'active' : '') },
 			E('strong', _('DSL Status'))),
 		E('div', { class: 'ifacebox-body left' }, [
 			L.itemlist(E('span'), [
-				_('Line State'), '%s [0x%x]'.format(dsl.line_state, dsl.line_state_detail),
-				_('Line Mode'), dsl.line_mode_s || '-',
-				_('Line Uptime'), '%t'.format(dsl.line_uptime),
-				_('Annex'), dsl.annex_s || '-',
-				_('Profile'), dsl.profile_s || '-',
-				_('Data Rate'), '%1000.3mb/s / %1000.3mb/s'.format(dsl.data_rate_down, dsl.data_rate_up),
-				_('Max. Attainable Data Rate (ATTNDR)'), '%1000.3mb/s / %1000.3mb/s'.format(dsl.max_data_rate_down, dsl.max_data_rate_up),
-				_('Latency'), '%.2f ms / %.2f ms'.format(dsl.latency_down / 1000, dsl.latency_up / 1000),
-				_('Line Attenuation (LATN)'), '%.1f dB / %.1f dB'.format(dsl.line_attenuation_down, dsl.line_attenuation_up),
-				_('Signal Attenuation (SATN)'), '%.1f dB / %.1f dB'.format(dsl.signal_attenuation_down, dsl.signal_attenuation_up),
-				_('Noise Margin (SNR)'), '%.1f dB / %.1f dB'.format(dsl.noise_margin_down, dsl.noise_margin_up),
-				_('Aggregate Transmit Power (ACTATP)'), '%.1f dB / %.1f dB'.format(dsl.actatp_down, dsl.actatp_up),
-				_('Forward Error Correction Seconds (FECS)'), '%d / %d'.format(dsl.errors_fecs_near, dsl.errors_fecs_far),
-				_('Errored seconds (ES)'), '%d / %d'.format(dsl.errors_es_near, dsl.errors_es_far),
-				_('Severely Errored Seconds (SES)'), '%d / %d'.format(dsl.errors_ses_near, dsl.errors_ses_far),
-				_('Loss of Signal Seconds (LOSS)'), '%d / %d'.format(dsl.errors_loss_near, dsl.errors_loss_far),
-				_('Unavailable Seconds (UAS)'), '%d / %d'.format(dsl.errors_uas_near, dsl.errors_uas_far),
-				_('Header Error Code Errors (HEC)'), '%d / %d'.format(dsl.errors_hec_near, dsl.errors_hec_far),
-				_('Non Pre-emptive CRC errors (CRC_P)'), '%d / %d'.format(dsl.errors_crc_p_near, dsl.errors_crc_p_far),
-				_('Pre-emptive CRC errors (CRCP_P)'), '%d / %d'.format(dsl.errors_crcp_p_near, dsl.errors_crcp_p_far),
-				_('ATU-C System Vendor ID'), dsl.atuc_vendor_id,
-				_('Power Management Mode'), dsl.power_mode_s
+				_('Line State'), dsl.state || '-',
+				_('Line Mode'), dsl.mode || '-',
+				_('Line Uptime'), '%t'.format(dsl.uptime),
+				_('Annex'), dsl.annex || '-',
+				_('Data Rate'), '%1000.3mb/s / %1000.3mb/s'.format(dsl.downstream.data_rate, dsl.upstream.data_rate),
+				_('Max. Attainable Data Rate (ATTNDR)'), '%1000.3mb/s / %1000.3mb/s'.format(dsl.downstream.attndr, dsl.upstream.attndr),
+				_('Latency'), '%.2f ms / %.2f ms'.format(dsl.downstream.interleave_delay / 1000, dsl.upstream.interleave_delay / 1000),
+				_('Line Attenuation (LATN)'), '%.1f dB / %.1f dB'.format(dsl.downstream.latn, dsl.upstream.latn),
+				_('Signal Attenuation (SATN)'), '%.1f dB / %.1f dB'.format(dsl.downstream.satn, dsl.upstream.satn),
+				_('Noise Margin (SNR)'), '%.1f dB / %.1f dB'.format(dsl.downstream.snr, dsl.upstream.snr),
+				_('Aggregate Transmit Power (ACTATP)'), '%.1f dB / %.1f dB'.format(dsl.downstream.actatp, dsl.upstream.actatp),
+				_('Forward Error Correction Seconds (FECS)'), '%d / %d'.format(dsl.errors.near.fecs, dsl.errors.far.fecs),
+				_('Errored seconds (ES)'), '%d / %d'.format(dsl.errors.near.es, dsl.errors.far.es),
+				_('Severely Errored Seconds (SES)'), '%d / %d'.format(dsl.errors.near.ses, dsl.errors.far.ses),
+				_('Loss of Signal Seconds (LOSS)'), '%d / %d'.format(dsl.errors.near.loss, dsl.errors.far.loss),
+				_('Unavailable Seconds (UAS)'), '%d / %d'.format(dsl.errors.near.uas, dsl.errors.far.uas),
+				_('Header Error Code Errors (HEC)'), '%d / %d'.format(dsl.errors.near.hec, dsl.errors.far.hec),
+				_('Non Pre-emptive CRC errors (CRC_P)'), '%d / %d'.format(dsl.errors.near.crc_p, dsl.errors.far.crc_p),
+				_('Pre-emptive CRC errors (CRCP_P)'), '%d / %d'.format(dsl.errors.near.crcp_p, dsl.errors.far.crcp_p),
+				_('ATU-C System Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id,
+				_('Power Management Mode'), dsl.power_state
 			])
 		])
 	]);
@@ -45,11 +44,11 @@ return baseclass.extend({
 	title: _('DSL'),
 
 	load: function() {
-		return L.resolveDefault(callLuciDSLStatus(), {});
+		return L.resolveDefault(callDSLMetrics(), {});
 	},
 
 	render: function(dsl) {
-		if (!dsl.line_state)
+		if (!dsl.state)
 			return null;
 
 		return E('div', { 'id': 'dsl_status_table', 'class': 'network-status-table' }, renderbox(dsl));

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -120,7 +120,7 @@
 		"description": "Grant access to DSL status display",
 		"read": {
 			"ubus": {
-				"luci-rpc": [ "getDSLStatus" ]
+				"dsl": [ "metrics" ]
 			}
 		}
 	},


### PR DESCRIPTION
This is significantly faster.

This is the luci feed part of: http://patchwork.ozlabs.org/project/openwrt/list/?series=220557
That needs to be merged first before this can go in