### PR TITLE
luci-theme-openwrt-2000: Add doctype to header

### DIFF
--- a/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
+++ b/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
@@ -17,7 +17,7 @@
 
 	http.prepare_content("text/html; charset=UTF-8")
 -%>
-
+<!DOCTYPE html>
 <html lang="<%=luci.i18n.context.lang%>">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
Without a doctype, the browser is put into quirks mode. In quirks mode, Webkit (Safari on macOS and iOS) ignores `display: block;` for `<td>` elements which causes the firewall page (among others) to display improperly.

**Without doctype:**
<img width="517" alt="image" src="https://user-images.githubusercontent.com/204106/106952398-afa8df00-66f6-11eb-9683-5e348d1582f4.png">

**With doctype:**
<img width="516" alt="image" src="https://user-images.githubusercontent.com/204106/106952520-d36c2500-66f6-11eb-9cf7-dc577c5a38ba.png">