### PR TITLE
[19.07] luci-app-https-dns-proxy: add nextdns.io and quad 101 providers

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "NextDNS.io",
+	label = _("NextDNS.io"),
+	resolver_url = "https://dns.nextdns.io/",
+	bootstrap_dns = "45.90.28.49,45.90.30.49",
+	help_link = " https://my.nextdns.io",
+	help_link_text = "NextDNS.io"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/tw.twnic.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/tw.twnic.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "Quad 101 (Taiwan)",
+	label = _("Quad 101 (Taiwan)"),
+	resolver_url = "https://dns.twnic.tw/dns-query",
+	bootstrap_dns = "101.101.101.101,101.102.103.104,2001:de4::101,2001:de4::102",
+	help_link = "https://blog.twnic.tw/2018/12/28/1803/",
+	help_link_text = "Quad 101 (Taiwan)"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -169,7 +169,7 @@ prov.write = function(self, section, value)
 	uci:save(packageName)
 end
 
-la = s3:option(Value, "listen_addr", translate("Listen address"))
+la = s3:option(Value, "listen_addr", translate("Listen Address"))
 la.datatype    = "host"
 la.placeholder = "127.0.0.1"
 la.rmempty     = true
@@ -182,7 +182,7 @@ uci:foreach(packageName, packageName, function(s)
 		n = n + 1
 end)
 
-lp = s3:option(Value, "listen_port", translate("Listen port"))
+lp = s3:option(Value, "listen_port", translate("Listen Port"))
 lp.datatype = "port"
 lp.value    = n + 5053
 
@@ -190,7 +190,7 @@ dscp = s3:option(Value, "dscp_codepoint", translate("DSCP Codepoint"))
 dscp.datatype = "range(0,63)"
 dscp.rmempty  = true
 
-ps = s3:option(Value, "proxy_server", translate("Proxy server"))
+ps = s3:option(Value, "proxy_server", translate("Proxy Server"))
 ps.rmempty  = true
 
 return m

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -109,6 +109,10 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/root/usr/share/rpcd/acl.d/luci-app-https-dns-proxy.json:3
+msgid "Grant UCI and file access for luci-app-https-dns-proxy"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:126
 msgid ""
 "If update DNSMASQ config is selected, when you add/remove any instances "
@@ -129,15 +133,19 @@ msgid "LibreDNS (No Ads)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:172
-msgid "Listen address"
+msgid "Listen Address"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:185
-msgid "Listen port"
+msgid "Listen Port"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/js.htm:52
 msgid "Loading"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua:3
+msgid "NextDNS.io"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua:3
@@ -153,7 +161,11 @@ msgid "OpenDNS (Family Shield)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:193
-msgid "Proxy server"
+msgid "Proxy Server"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/tw.twnic.dns.lua:3
+msgid "Quad 101 (Taiwan)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua:3


### PR DESCRIPTION
NextDNS.io is tested by me, the Quad 101 contribution and testing is by the forum member: https://forum.openwrt.org/t/dns-https-proxy-and-quad-101-recommend/87761.

Signed-off-by: Stan Grishin <stangri@melmac.net>