### PR TITLE
luci-app-statistics: fix config of ipstatistics

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/ipstatistics.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/ipstatistics.js
@@ -7,10 +7,7 @@ return baseclass.extend({
 	title: _('IP-Statistics Plugin Configuration'),
 	description: _('The ipstatistics plugin collects IPv4 and IPv6 statistics to compare them.'),
 
-	addFormOptions: function(s) {
-		var o;
-
-		o = s.option(form.Flag, 'enable', _('Enable this plugin'));
-		o.default = '0';
+	configSummary: function(section) {
+		return _('Monitoring IP-Statistics');
 	}
 });


### PR DESCRIPTION
The config view did not return a configSummary resulting in an error:
  plugin.form.configSummary is not a function

This commit fixes the error.