### PR TITLE
luci-base: add new member 'hidden' to DummyValue

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -3929,11 +3929,21 @@ var CBIDummyValue = CBIValue.extend(/** @lends LuCI.form.DummyValue.prototype */
 	 * @default null
 	 */
 
+    /**
+	 * Render the UCI option value as hidden using the HTML display: none style property.
+	 *
+	 * By default, the value is displayed
+	 *
+	 * @name LuCI.form.DummyValue.prototype#hidden
+	 * @type boolean
+	 * @default null
+	 */
+
 	/** @private */
 	renderWidget: function(section_id, option_index, cfgvalue) {
 		var value = (cfgvalue != null) ? cfgvalue : this.default,
 		    hiddenEl = new ui.Hiddenfield(value, { id: this.cbid(section_id) }),
-		    outputEl = E('div');
+		    outputEl = E('div', { 'style': this.hidden ? 'display:none' : null });
 
 		if (this.href && !((this.readonly != null) ? this.readonly : this.map.readonly))
 			outputEl.appendChild(E('a', { 'href': this.href }));


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas@nbembedded.com>

I needed to make a DummyValue completely hidden, but the only way to do that was by using `rawhtml` and setting that UCI value to some HTML.  Bad smell.  So I added a new member called `hidden` to `DummyValue` to allow us to do this quite nicely from anywhere.  I hope this can be accepted in a MR after some review and discussion.

Before
```
o = s.taboption('general', form.DummyValue, 'pukrequired');
o.rawhtml = true;
o = s.taboption('sim1', form.Value, 'puk1', _('PUK (Personal Unlocking Key)'),
	_("Your SIM requires a PUK to unlock it."));
o.depends({ pukrequired: "<p hidden>yes</p>", simslot: "1" })
```
After:
```
o = s.taboption('general', form.DummyValue, 'pukrequired');
// the new member
o.hidden = true; 

o = s.taboption('sim1', form.Value, 'puk1', _('PUK (Personal Unlocking Key)'),
	_("Your SIM requires a PUK to unlock it."));
// no more bad smells
o.depends({ pukrequired: "yes", simslot: "1" })
```
