### PR TITLE
luci-base: add validation for APN datatype

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -569,6 +569,13 @@ var ValidatorFactory = baseclass.extend({
 				_('hexadecimal encoded value'));
 		},
 
+		apn: function() {
+			if (this.value.length <= 63)
+				return this.assert(this.value.match(/^[a-zA-Z0-9\-.]*[a-zA-Z0-9]$/), _('valid APN'));
+
+			return this.assert(false, _('valid APN'));
+		},
+
 		string: function() {
 			return true;
 		}


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas@nbembedded.com>

Adds a new datatype/validation for **APN** ([Access Point Name](https://en.wikipedia.org/wiki/Access_Point_Name))

![bad apn](https://user-images.githubusercontent.com/18670565/107112076-89bf3e00-68a0-11eb-8d3a-ec98b1570393.png)

Use like this:
```
o = s.taboption('general', form.Value, 'apn', 
			_('APN'),
			_("Setting the appropriate APN for your SIM and data subscription is recommended."));
o.datatype = 'apn';
```
