### PR TITLE
luci-proto-modemmanager: validate APN and PIN

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -90,7 +90,8 @@ return network.registerProtocol('modemmanager', {
 			}, this));
 		};
 
-		s.taboption('general', form.Value, 'apn', _('APN'));
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.datatype = 'apn';
 
 		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
 		o.datatype = 'and(uinteger,maxlength(4))';

--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -91,7 +91,9 @@ return network.registerProtocol('modemmanager', {
 		};
 
 		s.taboption('general', form.Value, 'apn', _('APN'));
-		s.taboption('general', form.Value, 'pincode', _('PIN'));
+
+		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o.datatype = 'and(uinteger,maxlength(4))';
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));
 		o.value('both', _('PAP/CHAP (both)'));


### PR DESCRIPTION
The APN validation requires the new APN datatype to be available: https://github.com/openwrt/luci/pull/4771/files 