### PR TITLE
luci-app-banip: sync with banIP 0.7.1

### DIFF
--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
@@ -490,11 +490,35 @@ return view.extend({
 
 		o = s.taboption('adv_chain', form.DummyValue, '_sub');
 		o.rawhtml = true;
-		o.default = '<em><b>Individual IPSet Types</b></em>';
+		o.default = '<em><b>Individual IPSet Settings</b></em>';
 
-		/*
-			prepare source data
-		*/
+		o = s.taboption('adv_chain', form.ListValue, 'ban_maclist_timeout', _('Maclist Timeout'), _('Set the maclist IPSet timeout.'));
+		o.value('1800', _('30 minutes'));
+		o.value('3600', _('1 hour'));
+		o.value('21600', _('6 hours'));
+		o.value('43200', _('12 hours'));
+		o.value('86400', _('24 hours'));
+		o.optional = true;
+		o.rmempty = true;
+
+		o = s.taboption('adv_chain', form.ListValue, 'ban_whitelist_timeout', _('Whitelist Timeout'), _('Set the whitelist IPSet timeout.'));
+		o.value('1800', _('30 minutes'));
+		o.value('3600', _('1 hour'));
+		o.value('21600', _('6 hours'));
+		o.value('43200', _('12 hours'));
+		o.value('86400', _('24 hours'));
+		o.optional = true;
+		o.rmempty = true;
+
+		o = s.taboption('adv_chain', form.ListValue, 'ban_blacklist_timeout', _('Blacklist Timeout'), _('Set the blacklist IPSet timeout.'));
+		o.value('1800', _('30 minutes'));
+		o.value('3600', _('1 hour'));
+		o.value('21600', _('6 hours'));
+		o.value('43200', _('12 hours'));
+		o.value('86400', _('24 hours'));
+		o.optional = true;
+		o.rmempty = true;
+
 		var info, source, sources = [];
 		if (result[0]) {
 			sources = result[0].trim().split('\n');
@@ -753,6 +777,18 @@ return view.extend({
 		o = s.taboption('sources', form.DummyValue, '_sub');
 		o.rawhtml = true;
 		o.default = '<em><b>Local Sources</b></em>';
+
+		o = s.taboption('sources', form.MultiValue, 'ban_localsources', _('Local Sources'), _('Limit the selection to certain local sources.'));
+		o.value('maclist');
+		o.value('whitelist');
+		o.value('blacklist');
+		o.optional = true;
+		o.rmempty = true;
+
+		o = s.taboption('sources', form.DynamicList, 'ban_extrasources', _('Extra Sources'), _('Add additional, non-banIP related IPSets e.g. for reporting and queries.'));
+		o.datatype = 'uciname';
+		o.optional = true;
+		o.rmempty = true;
 
 		o = s.taboption('sources', form.Flag, 'ban_autoblacklist', _('Auto Blacklist'), _('Automatically transfers suspicious IPs from the log to the banIP blacklist during runtime.'));
 		o.rmempty = false;

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -11,12 +11,42 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -44,6 +74,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -68,7 +103,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -76,17 +111,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -101,6 +136,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -147,15 +186,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -163,23 +202,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -201,7 +240,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -209,7 +248,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -217,11 +256,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -274,6 +313,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -329,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -351,12 +394,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -371,7 +418,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -379,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -396,6 +447,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -453,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -506,11 +561,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -518,7 +573,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -543,7 +598,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -555,25 +610,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -590,6 +649,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -598,7 +665,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -703,7 +770,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -725,18 +792,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -4,12 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -37,6 +67,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -61,7 +96,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -69,17 +104,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -94,6 +129,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -140,15 +179,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -156,23 +195,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -194,7 +233,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -210,11 +249,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,6 +306,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -322,13 +365,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -344,12 +387,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -364,7 +411,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -372,7 +423,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -389,6 +440,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -446,11 +501,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -499,11 +554,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -511,7 +566,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -536,7 +591,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -548,25 +603,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -583,6 +642,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -591,7 +658,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -696,7 +763,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -718,18 +785,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -41,6 +71,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -69,7 +104,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -77,17 +112,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -102,6 +137,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -148,15 +187,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -164,23 +203,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -210,7 +249,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -218,11 +257,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -275,6 +314,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -330,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -352,12 +395,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -372,7 +419,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -380,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -397,6 +448,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -454,11 +509,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -507,11 +562,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -519,7 +574,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -544,7 +599,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -556,25 +611,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -591,6 +650,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -599,7 +666,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -704,7 +771,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -726,18 +793,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -4,12 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -37,6 +67,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -61,7 +96,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -69,17 +104,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -94,6 +129,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -140,15 +179,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -156,23 +195,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -194,7 +233,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -210,11 +249,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,6 +306,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -322,13 +365,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -344,12 +387,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -364,7 +411,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -372,7 +423,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -389,6 +440,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -446,11 +501,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -499,11 +554,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -511,7 +566,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -536,7 +591,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -548,25 +603,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -583,6 +642,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -591,7 +658,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -696,7 +763,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -718,18 +785,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -13,12 +13,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -44,6 +74,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -72,7 +107,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -80,17 +115,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -105,6 +140,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -151,15 +190,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -167,23 +206,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -205,7 +244,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -213,7 +252,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -221,11 +260,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,6 +317,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -333,13 +376,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -355,12 +398,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -376,7 +423,11 @@ msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -384,7 +435,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -401,6 +452,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -458,11 +513,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -511,11 +566,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -523,7 +578,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -548,7 +603,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -560,25 +615,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -595,6 +654,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -603,7 +670,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -709,7 +776,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -731,18 +798,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -41,6 +71,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -69,7 +104,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -77,17 +112,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -102,6 +137,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -148,15 +187,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -164,23 +203,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -210,7 +249,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -218,11 +257,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -275,6 +314,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -330,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -352,12 +395,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -372,7 +419,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -380,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -397,6 +448,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -454,11 +509,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Vue d’ensemble"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -507,11 +562,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -519,7 +574,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -544,7 +599,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -556,25 +611,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -591,6 +650,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -599,7 +666,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -705,7 +772,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -727,18 +794,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -11,12 +11,42 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -44,6 +74,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -68,7 +103,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -76,17 +111,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -101,6 +136,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -147,15 +186,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -163,23 +202,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -201,7 +240,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -209,7 +248,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -217,11 +256,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -274,6 +313,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -329,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -351,12 +394,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -371,7 +418,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -379,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -396,6 +447,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -453,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -506,11 +561,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -518,7 +573,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -543,7 +598,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -555,25 +610,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -590,6 +649,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -598,7 +665,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -703,7 +770,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -725,18 +792,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -4,12 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -37,6 +67,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -61,7 +96,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -69,17 +104,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -94,6 +129,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -140,15 +179,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -156,23 +195,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -194,7 +233,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -210,11 +249,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,6 +306,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -322,13 +365,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -344,12 +387,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -364,7 +411,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -372,7 +423,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -389,6 +440,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -446,11 +501,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -499,11 +554,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -511,7 +566,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -536,7 +591,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -548,25 +603,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -583,6 +642,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -591,7 +658,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -696,7 +763,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -718,18 +785,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -41,6 +71,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -69,7 +104,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -77,17 +112,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -102,6 +137,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -148,15 +187,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -164,23 +203,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -210,7 +249,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -218,11 +257,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -275,6 +314,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -330,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -352,12 +395,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -372,7 +419,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -380,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -397,6 +448,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -454,11 +509,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -507,11 +562,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -519,7 +574,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -544,7 +599,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -556,25 +611,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -591,6 +650,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -599,7 +666,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -706,7 +773,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -728,18 +795,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "ダウンロードユーティリティ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -101,6 +136,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -147,15 +186,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -163,23 +202,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -201,7 +240,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -209,7 +248,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -217,11 +256,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -274,6 +313,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -329,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -351,12 +394,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -371,7 +418,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -379,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -396,6 +447,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -453,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -506,11 +561,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -518,7 +573,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -543,7 +598,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -555,25 +610,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -590,6 +649,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -598,7 +665,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -703,7 +770,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -725,18 +792,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -11,12 +11,42 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -42,6 +72,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -70,7 +105,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -78,17 +113,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -103,6 +138,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -149,15 +188,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -165,23 +204,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -203,7 +242,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -211,7 +250,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -219,11 +258,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -276,6 +315,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -331,13 +374,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -353,12 +396,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -373,7 +420,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -381,7 +432,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -398,6 +449,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -455,11 +510,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -508,11 +563,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -520,7 +575,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -545,7 +600,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -557,25 +612,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -592,6 +651,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -600,7 +667,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -707,7 +774,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -729,18 +796,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -41,6 +71,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -69,7 +104,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -77,17 +112,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -102,6 +137,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -148,15 +187,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -164,23 +203,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Ferramenta para Descarregar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -210,7 +249,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -218,11 +257,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -275,6 +314,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -330,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -352,12 +395,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -372,7 +419,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -380,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -397,6 +448,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -454,11 +509,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -507,11 +562,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -519,7 +574,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -544,7 +599,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -556,25 +611,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -591,6 +650,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -599,7 +666,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -705,7 +772,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -727,18 +794,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -41,6 +71,11 @@ msgstr "Fontes Ativas"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -69,7 +104,7 @@ msgstr "Configurações Avançadas do E-Mail"
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -77,17 +112,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -102,6 +137,10 @@ msgstr "Diretório Base Temporário"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -148,15 +187,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -164,23 +203,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -202,7 +241,7 @@ msgstr "Fila de Download"
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -210,7 +249,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
@@ -218,11 +257,11 @@ msgstr "E-Mail do Perfil"
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -279,6 +318,10 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
 msgid "General Settings"
 msgstr "Configurações Gerais"
@@ -332,13 +375,13 @@ msgstr "Suporte ao IPv6"
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -354,12 +397,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -374,7 +421,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -382,7 +433,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -399,6 +450,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -456,11 +511,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -509,11 +564,11 @@ msgstr "Executar Flags"
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -521,7 +576,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -546,7 +601,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -558,25 +613,29 @@ msgstr "Prioridade do serviço"
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -593,6 +652,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr "Configurações"
@@ -601,7 +668,7 @@ msgstr "Configurações"
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -709,7 +776,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -731,18 +798,22 @@ msgstr "Impossível salvar as modificações: %s"
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -11,12 +11,42 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -42,6 +72,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
 msgid "Active Subnets"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
@@ -70,7 +105,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -78,17 +113,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -103,6 +138,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -149,15 +188,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -165,23 +204,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -203,7 +242,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -211,7 +250,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -219,11 +258,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -276,6 +315,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -331,13 +374,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -353,12 +396,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -373,7 +420,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -381,7 +432,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -398,6 +449,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -455,11 +510,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -508,11 +563,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -520,7 +575,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -545,7 +600,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -557,25 +612,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -592,6 +651,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -600,7 +667,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -705,7 +772,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -727,18 +794,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -11,12 +11,42 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.4.1-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -44,6 +74,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -68,7 +103,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -76,17 +111,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -101,6 +136,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -147,15 +186,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -163,23 +202,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -201,7 +240,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Утилита для загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -209,7 +248,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -217,11 +256,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -274,6 +313,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -329,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -351,12 +394,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -371,7 +418,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -379,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -396,6 +447,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -453,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -506,11 +561,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -518,7 +573,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -543,7 +598,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -555,25 +610,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -590,6 +649,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -598,7 +665,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -703,7 +770,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -725,18 +792,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.1-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Översikt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -1,12 +1,42 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -34,6 +64,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -58,7 +93,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -66,17 +101,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -91,6 +126,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -137,15 +176,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -153,23 +192,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -191,7 +230,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -199,7 +238,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -207,11 +246,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -264,6 +303,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -319,13 +362,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -341,12 +384,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -361,7 +408,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -369,7 +420,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -386,6 +437,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -443,11 +498,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -496,11 +551,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -508,7 +563,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -533,7 +588,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -545,25 +600,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -580,6 +639,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -588,7 +655,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -693,7 +760,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -715,18 +782,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "İndirme Aracı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -11,12 +11,42 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -44,6 +74,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -68,7 +103,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -76,17 +111,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -101,6 +136,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -147,15 +186,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -163,23 +202,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -201,7 +240,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -209,7 +248,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -217,11 +256,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -274,6 +313,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -329,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -351,12 +394,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -371,7 +418,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -379,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -396,6 +447,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -453,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -506,11 +561,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -518,7 +573,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -543,7 +598,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -555,25 +610,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -590,6 +649,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -598,7 +665,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -703,7 +770,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -725,18 +792,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -725,18 +792,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr "高级设置-邮箱"
 msgid "Advanced Log Settings"
 msgstr "高级设置-日志"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr "自动 黑名单"
 
@@ -75,17 +110,17 @@ msgstr "自动 黑名单"
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr "自动 白名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr "基本缓存文件夹"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -10,12 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:669
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:677
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+msgid "1 hour"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+msgid "24 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+msgid "30 minutes"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+msgid "6 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
 msgid "ASNs"
 msgstr ""
 
@@ -43,6 +73,11 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid ""
+"Add additional, non-banIP related IPSets e.g. for reporting and queries."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:12
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
@@ -67,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -75,17 +110,17 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:757
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:760
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
@@ -100,6 +135,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
 msgid "Base Temp Directory used for all banIP related runtime operations."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Blacklist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blacklist.js:15
@@ -146,15 +185,15 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "DST Log Options"
 msgstr ""
 
@@ -162,23 +201,23 @@ msgstr ""
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -200,7 +239,7 @@ msgstr ""
 msgid "Download Utility"
 msgstr "下載工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "E-Mail Actions"
 msgstr ""
 
@@ -208,7 +247,7 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -216,11 +255,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -273,6 +312,10 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:18
 msgid "Existing job(s)"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+msgid "Extra Sources"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
@@ -328,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:564
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
 msgid "LAN Input"
 msgstr ""
 
@@ -350,12 +393,16 @@ msgstr ""
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Limit the log monitor to certain log terms."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Limit the selection to certain local sources."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:66
@@ -370,7 +417,11 @@ msgstr ""
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+msgid "Local Sources"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Log Limit"
 msgstr ""
 
@@ -378,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "Log Terms"
 msgstr ""
 
@@ -395,6 +446,10 @@ msgstr ""
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Maclist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:15
@@ -452,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:652
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -505,11 +560,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "SRC Log Options"
 msgstr ""
 
@@ -517,7 +572,7 @@ msgstr ""
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -542,7 +597,7 @@ msgid ""
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -554,25 +609,29 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:523
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:666
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special SRC log options, e.g. to set a limit rate."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
@@ -589,6 +648,14 @@ msgid ""
 "(DST) packets."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+msgid "Set the maclist IPSet timeout."
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Set the whitelist IPSet timeout."
+msgstr ""
+
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
 msgid "Settings"
 msgstr ""
@@ -597,7 +664,7 @@ msgstr ""
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:712
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
 msgid "Sources (Info)"
 msgstr ""
 
@@ -702,7 +769,7 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:689
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -724,18 +791,22 @@ msgstr ""
 msgid "Verbose Debug Logging"
 msgstr "詳細除錯日誌"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:586
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
 msgid "WAN Input"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:11
 msgid "Whitelist IP/CIDR"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+msgid "Whitelist Timeout"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:33


### PR DESCRIPTION
* sync with current banIP release
* expose 'ban_localsources' and 'ban_extrasources' to LuCI
* expose IPSet timeout settings for local sources to LuCI
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>