### PR TITLE
fix %s in Chinese translation for luci-app-https-dns-proxy

### DIFF
--- a/applications/luci-app-https-dns-proxy/po/zh_Hans/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/zh_Hans/https-dns-proxy.po
@@ -135,7 +135,7 @@ msgid ""
 "and DNS%s (%smore information%s)."
 msgstr ""
 "如果选择了更新DNSMASQ配置，则当您添加/删除下面的任何实例时，它们将用于覆"
-"盖％sDHCP和DNS％s（％s更多信息％s）的“ DNS转发”部分。"
+"盖%sDHCP和DNS%s（%s更多信息%s）的“ DNS转发”部分。"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:138
 msgid "Instances"
@@ -231,7 +231,7 @@ msgstr "未知的提供商"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:131
 msgid "Update %s config"
-msgstr "更新％s配置"
+msgstr "更新%s配置"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
 msgid "Update DNSMASQ Config on Start/Stop"

--- a/applications/luci-app-https-dns-proxy/po/zh_Hant/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/zh_Hant/https-dns-proxy.po
@@ -231,7 +231,7 @@ msgstr "未知的提供商"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:131
 msgid "Update %s config"
-msgstr "更新 ％s 設置"
+msgstr "更新 %s 設置"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
 msgid "Update DNSMASQ Config on Start/Stop"


### PR DESCRIPTION
In Chinese translation po files for luci-app-https-dns-proxy, some "%s" was translated as "％s" in full-width character,  witch made the luci ui not displayed rightly.