### PR TITLE
luci-app-advanced-reboot: add missing btn class to buttons

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -7,6 +7,7 @@ PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
+LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/
 LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot supported Linksys and ZyXEL routers to\
 	an alternative partition. Also provides Web UI to shut down (power off) your device. 	Supported dual-partition\
 	routers are listed at https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
+++ b/applications/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
@@ -51,7 +51,7 @@ return view.extend({
 					'click': ui.hideModal
 				}, _('Cancel')), ' ',
 				E('button', {
-					'class': 'cbi-button cbi-button-positive important',
+					'class': 'btn cbi-button cbi-button-positive important',
 					'click': L.bind(this.callPowerOff, this)
 				}, _('Proceed'))
 			])
@@ -134,7 +134,7 @@ return view.extend({
 						'click': ui.hideModal
 					}, _('Cancel')), ' ',
 					E('button', {
-						'class': 'cbi-button cbi-button-positive important',
+						'class': 'btn cbi-button cbi-button-positive important',
 						'click': L.bind(this.handleTogglePartition, this)
 					}, _('Proceed'))
 				])
@@ -161,7 +161,7 @@ return view.extend({
 				_(partition.state),
 				partition.os.replace("Unknown", _("Unknown")).replace("Compressed", _("Compressed")),
 				E('button', {
-					'class': 'cbi-button cbi-button-apply important',
+					'class': 'btn cbi-button cbi-button-apply important',
 					'click': ui.createHandlerFn(this, func)
 				}, text)
 			])
@@ -220,7 +220,7 @@ return view.extend({
 		body.appendChild(E('hr'));
 		body.appendChild(
 			poweroff_supported ? E('button', {
-				'class': 'cbi-button cbi-button-apply important',
+				'class': 'btn cbi-button cbi-button-apply important',
 				'click': ui.createHandlerFn(this, 'handlePowerOff')
 			}, _('Perform power off...'))
 

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices.disabled/netgear-wac510.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices.disabled/netgear-wac510.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Netgear",
+	"deviceName": "WAC510",
+	"boardNames": [ "netgear,wac510" ],
+	"partition1MTD": "mtd9",
+	"partition2MTD": "mtd10",
+	"labelOffset": null,
+	"bootEnv1": "primary",
+	"bootEnv1Partition1Value": 0,
+	"bootEnv1Partition2Value": 3800000,
+	"bootEnv2": "secondary",
+	"bootEnv2Partition1Value": 3800000,
+	"bootEnv2Partition2Value": 0
+}


### PR DESCRIPTION
This fixes the button rendering on luci-theme-openwrt-2020 as per https://github.com/openwrt/luci/issues/3909.
Signed-off-by: Stan Grishin <stangri@melmac.net>