### PR TITLE
luci-app-vpnbypass: add missing btn class to buttons

### DIFF
--- a/applications/luci-app-vpnbypass/Makefile
+++ b/applications/luci-app-vpnbypass/Makefile
@@ -10,7 +10,6 @@ LUCI_TITLE:=VPN Bypass Web UI
 LUCI_DESCRIPTION:=Provides Web UI for VPNBypass service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +vpnbypass
 LUCI_PKGARCH:=all
-PKG_RELEASE:=20
 
 include ../../luci.mk
 

--- a/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
@@ -1,8 +1,8 @@
-local readmeURL = "https://github.com/openwrt/packages/blob/master/net/vpnbypass/files/README.md"
 local uci = require "luci.model.uci".cursor()
 local sys = require "luci.sys"
 local util = require "luci.util"
 local packageName = "vpnbypass"
+local readmeURL = "https://docs.openwrt.melmac.net/" .. packageName .. "/"
 
 function getPackageVersion()
 	local opkgFile = "/usr/lib/opkg/status"

--- a/applications/luci-app-vpnbypass/luasrc/view/vpnbypass/buttons.htm
+++ b/applications/luci-app-vpnbypass/luasrc/view/vpnbypass/buttons.htm
@@ -38,23 +38,23 @@
 
 <div class="cbi-value"><label class="cbi-value-title">Service Control</label>
 	<div class="cbi-value-field">
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
 			onclick="button_action(this)" />
 		<span id="btn_start_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Restart%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Restart%>"
 			onclick="button_action(this)" />
 		<span id="btn_action_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
+		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
 			onclick="button_action(this)" />
 		<span id="btn_stop_spinner" class="btn_spinner"></span>
 		&nbsp;
 		&nbsp;
 		&nbsp;
 		&nbsp;
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
 			onclick="button_action(this)" />
 		<span id="btn_enable_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
+		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
 			onclick="button_action(this)" />
 		<span id="btn_disable_spinner" class="btn_spinner"></span>
 	</div>


### PR DESCRIPTION
This fixes the button rendering on luci-theme-openwrt-2020 as per https://github.com/openwrt/luci/issues/3909.
Signed-off-by: Stan Grishin <stangri@melmac.net>