### PR TITLE
luci-app-https-dns-proxy: add missing btn class to buttons

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm
+++ b/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm
@@ -38,23 +38,23 @@
 
 <div class="cbi-value"><label class="cbi-value-title">Service Control</label>
 	<div class="cbi-value-field">
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
 			onclick="button_action(this)" />
 		<span id="btn_start_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Reload%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Reload%>"
 			onclick="button_action(this)" />
 		<span id="btn_action_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
+		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
 			onclick="button_action(this)" />
 		<span id="btn_stop_spinner" class="btn_spinner"></span>
 		&nbsp;
 		&nbsp;
 		&nbsp;
 		&nbsp;
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
 			onclick="button_action(this)" />
 		<span id="btn_enable_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
+		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
 			onclick="button_action(this)" />
 		<span id="btn_disable_spinner" class="btn_spinner"></span>
 	</div>


### PR DESCRIPTION
This fixes the button rendering on luci-theme-openwrt-2020 as per https://github.com/openwrt/luci/issues/3909.
Signed-off-by: Stan Grishin <stangri@melmac.net>