### PR TITLE
luci-app-https-dns-proxy: add idnet.net provider

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.idnet.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.idnet.doh.lua
@@ -1,0 +1,6 @@
+return{
+	name = "IDNet (UK)",
+	label = _("IDNet.net (UK)"),
+	resolver_url = "https://doh.idnet.net/dns-query",
+	bootstrap_dns = "212.69.36.23,212.69.40.23"
+}


### PR DESCRIPTION
Adds the UK provider's [IDNet](https://www.idnet.com/) DoH. It allows for circumventing Google tracking.