### PR TITLE
[19.07] luci-app-simple-adblock: bugfix: default values for ListValue

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,6 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=50
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
@@ -232,18 +232,18 @@ s:tab("basic", translate("Basic Configuration"))
 o1 = s:taboption("basic", ListValue, "config_update_enabled", translate("Automatic Config Update"), translate("Perform config update before downloading the block/allow-lists."))
 o1:value("0", translate("Disable"))
 o1:value("1", translate("Enable"))
-o1.default = 0
+o1.default = "0"
 
 o2 = s:taboption("basic", ListValue, "verbosity", translate("Output Verbosity Setting"), translate("Controls system log and console output verbosity."))
 o2:value("0", translate("Suppress output"))
 o2:value("1", translate("Some output"))
 o2:value("2", translate("Verbose output"))
-o2.default = 2
+o2.default = "2"
 
 o3 = s:taboption("basic", ListValue, "force_dns", translate("Force Router DNS"), translate("Forces Router DNS use on local devices, also known as DNS Hijacking."))
 o3:value("0", translate("Let local devices use their own DNS servers if set"))
 o3:value("1", translate("Force Router DNS server to all local devices"))
-o3.default = 1
+o3.default = "1"
 
 local sysfs_path = "/sys/class/leds/"
 local leds = {}
@@ -312,7 +312,7 @@ o7.datatype = "range(0,30)"
 o8 = s:taboption("advanced", ListValue, "parallel_downloads", translate("Simultaneous processing"), translate("Launch all lists downloads and processing simultaneously, reducing service start time."))
 o8:value("0", translate("Do not use simultaneous processing"))
 o8:value("1", translate("Use simultaneous processing"))
-o8.default = 1
+o8.default = "1"
 
 o10 = s:taboption("advanced", ListValue, "compressed_cache", translate("Store compressed cache file on router"), translate("Attempt to create a compressed cache of block-list in the persistent memory."))
 o10:value("0", translate("Do not store compressed cache"))

--- a/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm
+++ b/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm
@@ -49,23 +49,23 @@
 
 <div class="cbi-value"><label class="cbi-value-title">Service Control</label>
 	<div class="cbi-value-field">
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
 			onclick="button_action(this)" />
 		<span id="btn_start_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Force Re-Download%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Force Re-Download%>"
 			onclick="button_action(this)" />
 		<span id="btn_action_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
+		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
 			onclick="button_action(this)" />
 		<span id="btn_stop_spinner" class="btn_spinner"></span>
 		&nbsp;
 		&nbsp;
 		&nbsp;
 		&nbsp;
-		<input type="button" class="cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
+		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
 			onclick="button_action(this)" />
 		<span id="btn_enable_spinner" class="btn_spinner"></span>
-		<input type="button" class="cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
+		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
 			onclick="button_action(this)" />
 		<span id="btn_disable_spinner" class="btn_spinner"></span>
 	</div>

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -185,6 +185,10 @@ msgstr ""
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
+#: applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json:3
+msgid "Grant UCI and file access for luci-app-simple-adblock"
+msgstr ""
+
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
 msgid "IPv6 Support"
 msgstr ""


### PR DESCRIPTION
Default values were not quoted before, resulting in them not working.
Signed-off-by: Stan Grishin <stangri@melmac.net>