### PR TITLE
lua-base: dispatcher lua not ignore action type "call" on looking for subpages

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -636,6 +636,7 @@ local function find_subnode(root, prefix, recurse, descended)
 
 	if descended then
 		if not recurse or
+		   root.action.type == "call" or
 		   root.action.type == "cbi" or
 		   root.action.type == "form" or
 		   root.action.type == "view" or


### PR DESCRIPTION
Function "find_subnode" in dispatcher.lua script of "luci-base" module recognizes all LuCI handler actions besides "call" type.

As a result path rendered by handler with "call" action
    cannot be opened just after login on WebUI,
      even if such path has high order (1) among others
         in /usr/share/luci/menu.d/*.json files

Add check "call" action type in logic of "find_subnode" function similar
to other standard LuCI handlers: "view", "cbi", "form", etc