### PR TITLE
luci-app-banip: small fixes

### DIFF
--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js
@@ -17,7 +17,7 @@ function handleAction(ev) {
 			]),
 			E('div', { 'class': 'right' }, [
 				E('button', {
-					'class': 'btn',
+					'class': 'btn cbi-button',
 					'click': L.hideModal
 				}, _('Cancel')),
 				' ',
@@ -68,7 +68,7 @@ function handleAction(ev) {
 			]),
 			E('div', { 'class': 'right' }, [
 				E('button', {
-					'class': 'btn',
+					'class': 'btn cbi-button',
 					'click': L.hideModal
 				}, _('Cancel')),
 				' ',
@@ -145,7 +145,7 @@ return view.extend({
 						urlprefix = content.ipsets[key].member_acc[i].member.includes('/') ? 'prefix/' : 'ip/';
 						member = '<a href="https://api.bgpview.io/' + urlprefix + encodeURIComponent(content.ipsets[key].member_acc[i].member) + '" target="_blank" rel="noreferrer noopener" title="IP/CIDR Lookup" >' + content.ipsets[key].member_acc[i].member + '</a>';
 						button = E('button', {
-							'class': 'cbi-button cbi-button-apply',
+							'class': 'btn cbi-button cbi-button-apply',
 							'style': 'word-break: inherit',
 							'name': 'whitelist',
 							'value': content.ipsets[key].member_acc[i].member,
@@ -206,14 +206,14 @@ return view.extend({
 				]),
 				E('div', { 'class': 'right' }, [
 					E('button', {
-						'class': 'cbi-button cbi-button-apply',
+						'class': 'btn cbi-button cbi-button-apply',
 						'click': ui.createHandlerFn(this, function() {
 							return handleAction('query');
 						})
 					}, [ _('IPSet Query...') ]),
 					'\xa0\xa0\xa0',
 					E('button', {
-						'class': 'cbi-button cbi-button-positive',
+						'class': 'btn cbi-button cbi-button-positive',
 						'click': ui.createHandlerFn(this, async function() {
 							L.resolveDefault(fs.exec_direct('/etc/init.d/banip', ['report', 'gen']),'');
 							var running = 1;

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -54,27 +54,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -83,62 +83,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "مجلد النسخ الاحتياطي"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -186,81 +186,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -279,31 +279,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -315,15 +315,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,15 +331,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -360,49 +360,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -410,27 +410,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -439,17 +439,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -520,12 +520,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -541,11 +541,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -553,27 +553,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -588,21 +588,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -610,92 +610,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -721,7 +721,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -770,11 +770,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -788,17 +788,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -4,42 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -47,27 +47,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -76,62 +76,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -179,81 +179,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -272,31 +272,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -308,15 +308,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -324,15 +324,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -353,49 +353,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -403,27 +403,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -432,17 +432,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -501,11 +501,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -513,12 +513,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -546,27 +546,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -581,21 +581,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -603,92 +603,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -714,7 +714,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -763,11 +763,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -781,17 +781,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Edita la llista blanca"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Darrera execució"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Actualitza"
 
@@ -532,7 +532,7 @@ msgstr "Actualitza"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "Dodatečné zpoždění v sekundách před začátkem zpracování banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Upravit whitelist"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "Informace o IPSet"
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Poslední spuštění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Aktualizovat"
 
@@ -532,7 +532,7 @@ msgstr "Aktualizovat"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr "12 Stunden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr "24 Stunden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr "Autonome Systemnummern"
 
@@ -53,27 +53,27 @@ msgstr "Autonome Systemnummern"
 msgid "Action"
 msgstr "Aktion"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr "Aktive Geräte"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr "Aktive Schnittstellen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr "Aktive Protokollbegriffe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr "Aktive Quellen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr "Aktive Subnetze"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -84,41 +84,41 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr "Fügen Sie diese IP / CIDR Ihrer lokalen Whitelist hinzu."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Zusätzliche Auslöseverzögerung in Sekunden, bevor die BanIP-Verarbeitung "
 "beginnt."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr "Erweiterte Ketteneinstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr "Fortgeschrittene E-Mail Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr "Erweiterte Protokolleinstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr "Automatische Blacklist"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr "Automatische Erkennung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr "Automatische Whitelist"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
@@ -126,28 +126,28 @@ msgstr ""
 "Automatische Übertragung von verdächtigen IP-Adressen aus dem Protokoll in "
 "die banIP Blacklist während der Laufzeit."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 "Automatische Übertragung von Uplink-IP-Adressen an die banIP Whitelist "
 "während der Laufzeit."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr "Basis-Temp-Verzeichnis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 "Basis Temp-Verzeichnis, das für alle banIP-bezogenen Laufzeitvorgänge "
 "verwendet wird."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -195,81 +195,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr "Download Parameter"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr "Download Warteschlange"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Empfängeradresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Absenderadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -288,31 +288,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Whitelist bearbeiten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -324,15 +324,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -340,15 +340,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "IPSet-Information"
 
@@ -369,49 +369,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Letzter Durchgang"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -419,27 +419,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -448,17 +448,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -517,11 +517,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -529,12 +529,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Aktualisieren"
 
@@ -542,7 +542,7 @@ msgstr "Aktualisieren"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -550,11 +550,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Neustart"
 
@@ -562,27 +562,27 @@ msgstr "Neustart"
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -597,21 +597,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -619,92 +619,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -779,11 +779,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
@@ -797,17 +797,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -4,42 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -47,27 +47,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -76,62 +76,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -179,81 +179,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -272,31 +272,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -308,15 +308,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -324,15 +324,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -353,49 +353,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -403,27 +403,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -432,17 +432,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -501,11 +501,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -513,12 +513,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -546,27 +546,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -581,21 +581,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -603,92 +603,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -714,7 +714,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -763,11 +763,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -781,17 +781,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -13,42 +13,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -56,27 +56,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -85,64 +85,64 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
 "procesamiento de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -152,7 +152,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -190,81 +190,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -283,31 +283,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Editar lista blanca"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -319,15 +319,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -335,15 +335,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "Información de IPSet"
 
@@ -364,49 +364,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Último inicio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -414,28 +414,28 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -444,17 +444,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -480,7 +480,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -513,11 +513,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -525,12 +525,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Refrescar"
 
@@ -538,7 +538,7 @@ msgstr "Refrescar"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -558,27 +558,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -593,21 +593,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -615,92 +615,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -776,11 +776,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
@@ -794,17 +794,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -812,7 +812,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Varmuuskopiohakemisto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Editoi sallittujen lista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Viimeksi ajettu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -532,7 +532,7 @@ msgstr "Päivitä"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,64 +82,64 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Délai de déclenchement supplémentaire en secondes avant le début du "
 "traitement banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -187,81 +187,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -280,31 +280,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Modifier la liste blanche"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -316,15 +316,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -332,15 +332,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "Informations IPSet"
 
@@ -361,49 +361,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Dernière exécution"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -411,27 +411,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -440,17 +440,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -509,11 +509,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Vue d’ensemble"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -521,12 +521,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -534,7 +534,7 @@ msgstr "Actualiser"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -542,11 +542,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -554,27 +554,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -589,21 +589,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -611,92 +611,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -772,11 +772,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
@@ -790,17 +790,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -54,27 +54,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -83,62 +83,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -186,81 +186,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -279,31 +279,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -315,15 +315,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,15 +331,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -360,49 +360,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -410,27 +410,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -439,17 +439,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -520,12 +520,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -541,11 +541,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -553,27 +553,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -588,21 +588,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -610,92 +610,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -721,7 +721,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -770,11 +770,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -788,17 +788,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -4,42 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -47,27 +47,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -76,62 +76,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -179,81 +179,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -272,31 +272,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -308,15 +308,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -324,15 +324,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -353,49 +353,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -403,27 +403,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -432,17 +432,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -501,11 +501,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -513,12 +513,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -546,27 +546,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -581,21 +581,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -603,92 +603,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -714,7 +714,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -763,11 +763,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -781,17 +781,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,64 +82,64 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "További aktiválókésleltetés másodpercben, mielőtt a banIP feldolgozása "
 "elkezdődik."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -187,81 +187,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -280,31 +280,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Fehérlista szerkesztése"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -316,15 +316,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -332,15 +332,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "IPSet információk"
 
@@ -361,49 +361,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Utolsó futás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -411,27 +411,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -440,17 +440,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -509,11 +509,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -521,12 +521,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Frissítés"
 
@@ -534,7 +534,7 @@ msgstr "Frissítés"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -542,11 +542,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -554,27 +554,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -589,21 +589,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -611,92 +611,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -773,11 +773,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
@@ -791,17 +791,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Directory del Backup"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Ricaricare"
 
@@ -532,7 +532,7 @@ msgstr "Ricaricare"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr "アクション"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr "アクティブなデバイス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr "アクティブなソース"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr "アクティブなサブネット"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr "追加設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr "Eメールの詳細設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr "ログの詳細設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr "自動ブラックリスト"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr "自動検出"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr "自動ホワイトリスト"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr "ベースとなるテンポラリディレクトリ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr "ブロックリスト提供元"
 
@@ -157,7 +157,7 @@ msgstr "ブロックリスト提供元"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr "MAC をカウント"
 msgid "Count SUM"
 msgstr "SUM をカウント"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr "国"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr "ダウンロードのパラメータ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr "ダウンロードキュー"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "ダウンロードユーティリティ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr "Eメールアクション"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "ホワイトリストの編集"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr "banIP サービスを有効にする。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "エラーが発生した際に詳細なデバッグロギングを有効にします。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr "有効"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr "banIP で IPv4 サポートを有効にする。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr "banIP で IPv6 サポートを有効にする。"
 
@@ -314,15 +314,15 @@ msgstr "エントリ詳細"
 msgid "Existing job(s)"
 msgstr "既存のジョブ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr "高い優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr "最高の優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "IPSet 情報"
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr "IPSet 詳細"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr "IPv4 サポート"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr "IPv6 サポート"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr "情報"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "最終実行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr "最低の優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr "低い優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr "削除する行番号"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "サポートされ、かつ設定済のダウンロード ユーティリティの一覧です。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr "ログ制限"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr "ログモニター"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr "ログビュー"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr "名前"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr "ネットワークインターフェース"
 
@@ -474,7 +474,7 @@ msgstr "検索結果がありません！"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr "通常の優先度 (デフォルト)"
 
@@ -507,11 +507,11 @@ msgstr "全エントリ数"
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr "検索"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "リフレッシュ"
 
@@ -532,7 +532,7 @@ msgstr "リフレッシュ"
 msgid "Refresh Timer"
 msgstr "リフレッシュタイマー"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr "タイマーをリフレッシュ..."
 
@@ -540,11 +540,11 @@ msgstr "タイマーをリフレッシュ..."
 msgid "Remove an existing job"
 msgstr "既存のジョブを削除"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "再起動"
 
@@ -552,27 +552,27 @@ msgstr "再起動"
 msgid "Result"
 msgstr "結果"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr "実行フラグ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr "実行情報"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr "サービス優先度"
 
@@ -609,92 +609,92 @@ msgstr "サービス優先度"
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr "選択したダウンロードユーティリティーの特別な設定オプション。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr "起動時トリガーインターフェース"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr "ステータス / バージョン"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr "時(必須、0-23の値)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "分(オプション、0-59の値)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
@@ -787,17 +787,17 @@ msgstr "タイプ"
 msgid "Unable to save changes: %s"
 msgstr "変更を保存できませんでした: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,63 +82,63 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 #, fuzzy
 msgid "Backup Directory"
 msgstr "백업 경로"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -186,81 +186,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -279,31 +279,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -315,15 +315,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,15 +331,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -360,49 +360,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -410,27 +410,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -439,17 +439,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -520,12 +520,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -541,11 +541,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -553,27 +553,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -588,21 +588,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -610,92 +610,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -721,7 +721,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -770,11 +770,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -788,17 +788,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr "Aktive kilder"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr "Ytterligere innstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr "Avanserte e-postinnstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr "Nedlastingsparametre"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr "Nedlastingskø"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr "E-postsenderadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr "E-postemne"
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Rediger hvitliste"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr "Info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Sist kjørt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr "Loggvisning"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr "Spørring"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Gjenoppfrisk"
 
@@ -532,7 +532,7 @@ msgstr "Gjenoppfrisk"
 msgid "Refresh Timer"
 msgstr "Gjenoppfrisk tidsur"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr "Gjenoppfrisk tidsur …"
 
@@ -540,11 +540,11 @@ msgstr "Gjenoppfrisk tidsur …"
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr "Rapportmappe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr "Resultat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr "Status/versjon"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Utløserforsinkelse"
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr "Kunne ikke lagre endringer: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr "1 godzina"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr "12 1 godzin"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr "24 godziny"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 minut"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr "6 godzin"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -54,27 +54,27 @@ msgstr ""
 msgid "Action"
 msgstr "Akcja"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr "Aktywne urządzenia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr "Aktywne interfejsy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr "Aktywne rejestratory"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr "Aktywne źródła"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr "Aktywne podsieci"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -85,64 +85,64 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr "Dodaj ten adres IP/CIDR do lokalnej białej listy."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr "Dodatkowe ustawienia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalania w sekundach przed rozpoczęciem przetwarzania "
 "banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr "Zaawansowane ustawienia e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr "Zaawansowane ustawienia dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr "Automatyczna czarna lista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr "Automatyczne wykrywanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr "Automatyczna biała lista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr "Podstawowy katalog tymczasowy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -152,7 +152,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -190,81 +190,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr "Kraje"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr "Domyślny łańcuch używany przez banIP 'input_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr "Kolejka pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -283,31 +283,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Biała lista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -319,15 +319,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -335,15 +335,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "Informacje IPSet"
 
@@ -364,49 +364,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Ostatnie uruchomienie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -414,27 +414,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -443,17 +443,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -479,7 +479,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -512,11 +512,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -524,12 +524,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Odśwież"
 
@@ -537,7 +537,7 @@ msgstr "Odśwież"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -545,11 +545,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -557,27 +557,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -592,21 +592,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -614,92 +614,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -776,11 +776,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
@@ -794,17 +794,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -812,7 +812,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,64 +82,64 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Atraso de gatilho adicional em segundos antes do início do processamento de "
 "banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -187,81 +187,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Ferramenta para Descarregar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -280,31 +280,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Editar lista de permissões"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -316,15 +316,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -332,15 +332,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "Informações IPSet"
 
@@ -361,49 +361,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -411,27 +411,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -440,17 +440,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -509,11 +509,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -521,12 +521,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -534,7 +534,7 @@ msgstr "Atualizar"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -542,11 +542,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -554,27 +554,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -589,21 +589,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -611,92 +611,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -772,11 +772,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
@@ -790,17 +790,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr "Fontes Ativas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,64 +82,64 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Atraso de disparo adicional em segundos antes do início do processamento de "
 "banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr "Configurações Avançadas do E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr "Fontes das listas de bloqueio"
 
@@ -159,7 +159,7 @@ msgstr "Fontes das listas de bloqueio"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -187,81 +187,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr "Fila de Download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -280,33 +280,33 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Editar a Lista Branca"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
 "processamento."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -318,15 +318,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -334,15 +334,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "Informações IPSet"
 
@@ -363,49 +363,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr "Suporte ao IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,27 +413,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -442,17 +442,17 @@ msgstr ""
 msgid "Log View"
 msgstr "Exibir o Registro Log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -466,7 +466,7 @@ msgstr ""
 msgid "Name"
 msgstr "Nome"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -478,7 +478,7 @@ msgstr "A Consulta Não Retornou Resultados!"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -511,11 +511,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Query"
 msgstr "Consulta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -536,7 +536,7 @@ msgstr "Atualizar"
 msgid "Refresh Timer"
 msgstr "Atualize o Temporizador"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr "Atualizando o Temporizador..."
 
@@ -544,11 +544,11 @@ msgstr "Atualizando o Temporizador..."
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -556,27 +556,27 @@ msgstr "Reiniciar"
 msgid "Result"
 msgstr "Resultado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr "Executar Flags"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -591,21 +591,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr "Prioridade do serviço"
 
@@ -613,93 +613,93 @@ msgstr "Prioridade do serviço"
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de download selecionado."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr "Interface do Gatilho de Inicialização"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr "Condição Geral / Versão"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr "A parte das horas (obg., intervalo: 0-23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "A parte dos minutos (obg., intervalo: 0-59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -776,11 +776,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
@@ -794,17 +794,17 @@ msgstr "Tipo"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -812,7 +812,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -54,27 +54,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -83,64 +83,64 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Întârziere suplimentară declanșare in secunde înainte de începerea "
 "procesării banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -150,7 +150,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -188,81 +188,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -281,31 +281,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Editare listă albă"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -317,15 +317,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -333,15 +333,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Ultima rulare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -412,27 +412,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -441,17 +441,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -465,7 +465,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,11 +510,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -522,12 +522,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
@@ -535,7 +535,7 @@ msgstr "Reîmprospătare"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -555,27 +555,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -590,21 +590,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -612,92 +612,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -772,11 +772,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
@@ -790,17 +790,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.4.1-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -54,27 +54,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -83,62 +83,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "Дополнительная задержка срабатывания правил banIP в секундах."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -186,81 +186,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Утилита для загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -279,31 +279,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Редактировать белый список"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -315,15 +315,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,15 +331,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -360,49 +360,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Последний запуск"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -410,27 +410,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -439,17 +439,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -520,12 +520,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -533,7 +533,7 @@ msgstr "Обновить"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -541,11 +541,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -553,27 +553,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -588,21 +588,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -610,92 +610,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -721,7 +721,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -770,11 +770,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
@@ -788,17 +788,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Upraviť bielu listinu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Redigera vitlista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Kördes senast"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Översikt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Uppdatera"
 
@@ -532,7 +532,7 @@ msgstr "Uppdatera"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -1,42 +1,42 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -44,27 +44,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -73,62 +73,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -176,81 +176,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,31 +269,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -305,15 +305,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -321,15 +321,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -350,49 +350,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -400,27 +400,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -429,17 +429,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -465,7 +465,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -498,11 +498,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -510,12 +510,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -523,7 +523,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -531,11 +531,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -543,27 +543,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -578,21 +578,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -600,92 +600,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -760,11 +760,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -778,17 +778,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Yedekleme Dizini"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "İndirme Aracı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Beyazlisteyi Düzenle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "Son çalışma zamanı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Yenile"
 
@@ -532,7 +532,7 @@ msgstr "Yenile"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -54,27 +54,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -83,62 +83,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -186,81 +186,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -279,31 +279,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "Редагувати білий список"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -315,15 +315,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,15 +331,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -360,49 +360,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -410,27 +410,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -439,17 +439,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -520,12 +520,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Оновити"
 
@@ -533,7 +533,7 @@ msgstr "Оновити"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -541,11 +541,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -553,27 +553,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -588,21 +588,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -610,92 +610,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -721,7 +721,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -770,11 +770,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr ""
 
@@ -788,17 +788,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr ""
 
@@ -53,27 +53,27 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr ""
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
@@ -787,18 +787,18 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 #, fuzzy
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/秒 (默认)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr "1 小时"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr "12 小时"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr "24 小时"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 分钟"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr "6 小时"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr "平均取样数"
 
@@ -53,27 +53,27 @@ msgstr "平均取样数"
 msgid "Action"
 msgstr "开始"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr "活动设备"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr "活动接口"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr "活动日志项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr "活动源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr "活动子网"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr "额外的与非banip相关的IPSets, 例如用于报告和查询."
@@ -82,62 +82,62 @@ msgstr "额外的与非banip相关的IPSets, 例如用于报告和查询."
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr "将此 IP/CIDR 添加到您的本地白名单."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr "其他设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "banIP 处理开始之前的额外触发延迟（以秒为单位）。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr "高级枷锁设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr "高级设置-邮箱"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr "高级设置-日志"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr "自动 黑名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr "自动检测"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr "自动 白名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr "运行时自动将可疑 IPs 从日志转移到 banIP 黑名单."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr "运行时自动传输上行的 IPs 到banIP白名单."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "备份文件夹"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr "基本缓存文件夹"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr "用于所有与banIP相关的运行时操作的基本临时目录."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr "超时黑名单"
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr "黑名单更改已经保存.刷新您的banIP列表使更改生效."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr "阻止列表内容"
 
@@ -157,16 +157,16 @@ msgstr "阻止列表内容"
 msgid "Cancel"
 msgstr "关闭"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
 "master/net/banip/files/README.md\" target=\"_blank\" rel=\"noreferrer "
 "noopener\" >check the online documentation</a>"
 msgstr ""
-"通过 IPSet 拦截 ip 地址/子网的 banIP 包的配置。更多信息<a href=\"https://github.com/openwrt/"
-"packages/blob/master/net/banip/files/README.md\" target=\"_blank\" rel="
-"\"noreferrer noopener\" >查看在线文档</a>"
+"通过 IPSet 拦截 ip 地址/子网的 banIP 包的配置。更多信息<a href=\"https://"
+"github.com/openwrt/packages/blob/master/net/banip/files/README.md\" target="
+"\"_blank\" rel=\"noreferrer noopener\" >查看在线文档</a>"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:124
 msgid "Count ACC"
@@ -188,81 +188,81 @@ msgstr "MAC统计"
 msgid "Count SUM"
 msgstr "SUM统计"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr "地区"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr "DST IPSet类型"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr "DST日志选项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr "DST的目标"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr "banIP使用的默认链是 '局域网转发规则'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr "banIP使用的默认链是 '广域网转发规则'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr "banIP使用的默认链是 '局域网出站规则'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr "banIP 使用的默认链是 '广域网出站规则'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr "自动检测相关的网络接口、设备、子网和协议。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr "下载队列"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr "电子邮件动作"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr "电子邮件通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr "电子邮件概要"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr "电子邮件收件人地址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -281,31 +281,31 @@ msgstr "编辑 Mac 地址列表"
 msgid "Edit Whitelist"
 msgstr "编辑白名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr "启用 DST 记录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr "启用 SRC 记录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr "启用 banIP 服务。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在任何处理错误的情况下启用详细调试日志记录."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr "启用"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr "在banIP中启用IPv4支持."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr "在banIP中启用IPv6支持."
 
@@ -317,15 +317,15 @@ msgstr "条目详情"
 msgid "Existing job(s)"
 msgstr "现有工作"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr "附加源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr "全局 IPSet 类型"
 
@@ -333,15 +333,15 @@ msgstr "全局 IPSet 类型"
 msgid "Grant access to LuCI app banIP"
 msgstr "授予 LuCi 应用 banIP 访问权"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr "高优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr "最高优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "IPSet 信息"
 
@@ -362,49 +362,49 @@ msgstr "IPSet 报告"
 msgid "IPSet details"
 msgstr "IPSet 详情"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr "IPv4 支持"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr "IPv6支持"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr "局域网转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr "局域网入站"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "最后运行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr "最低优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr "较低优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr "将电子邮件的触发限制为某些banIP操作."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr "将日志监视器限制为特定的日志术语."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr "将选择限制在特定的本地源。"
 
@@ -412,27 +412,27 @@ msgstr "将选择限制在特定的本地源。"
 msgid "Line number to remove"
 msgstr "要移除的行数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr "触发 banIP 启动的可用网络接口列表。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支持的和完全预先配置的下载实用程序列表."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr "本地源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr "日志限制"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr "日志监控器"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr "日志条款"
 
@@ -441,17 +441,19 @@ msgstr "日志条款"
 msgid "Log View"
 msgstr "日志视图"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr "记录可疑的传入数据包——通常是丢弃的。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
-msgstr "记录可疑的发送数据包 -- 通常是被拒绝的。由于需要额外的系统资源，记录这样的数据包可能会导致延迟增加。"
+msgstr ""
+"记录可疑的发送数据包 -- 通常是被拒绝的。由于需要额外的系统资源，记录这样的数"
+"据包可能会导致延迟增加。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr "Mac列表超时"
 
@@ -465,7 +467,7 @@ msgstr "Mac列表更改已保存。刷新你的 banIP 列表，使更改生效�
 msgid "Name"
 msgstr "名称"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr "网络接口"
 
@@ -477,7 +479,7 @@ msgstr "没有查询结果!"
 msgid "No banIP related logs yet!"
 msgstr "尚无 banIP 相关的日志！"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr "正常优先级 (默认)"
 
@@ -510,11 +512,11 @@ msgstr "所有条目的数字"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr "仅解析最后声明的可疑事件的日志条目数量。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "'msmtp' 所用的 banIP 通知电子邮件的配置。"
 
@@ -522,12 +524,12 @@ msgstr "'msmtp' 所用的 banIP 通知电子邮件的配置。"
 msgid "Query"
 msgstr "查询"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr "banIP 通知电子邮件的接收者地址。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "刷新"
 
@@ -535,7 +537,7 @@ msgstr "刷新"
 msgid "Refresh Timer"
 msgstr "定时恢复"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr "定时恢复中..."
 
@@ -543,11 +545,11 @@ msgstr "定时恢复中..."
 msgid "Remove an existing job"
 msgstr "移除一个现有的作业"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "重新启动"
 
@@ -555,27 +557,27 @@ msgstr "重新启动"
 msgid "Result"
 msgstr "结果"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr "运行标记"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr "运行信息"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr "SRC IPSet 类型"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr "SRC 日志选项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr "SRC 目标"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr "SRC+DST IPSet 类型"
 
@@ -588,23 +590,24 @@ msgstr "保存"
 msgid ""
 "Search the active banIP-related IPSets for a specific IP, CIDR or MAC "
 "address."
-msgstr "搜索处于活跃状态的 banIP 相关的 IPSets 查找一个特定的 IP、CIDR 或 MAC 地址。"
+msgstr ""
+"搜索处于活跃状态的 banIP 相关的 IPSets 查找一个特定的 IP、CIDR 或 MAC 地址。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr "手动搜索相关的网络接口。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr "发送 banIP 相关的通知电邮。这需要安装和设置额外的 'msmtp' 包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr "banIP 通知电邮的发送者地址。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr "服务优先级"
 
@@ -612,92 +615,92 @@ msgstr "服务优先级"
 msgid "Set a new banIP job"
 msgstr "设置一个新的 banIP 作业"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr "为每一 IPSet 设置单独的 DST 类型来仅拦截传出数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr "为每一 IPSet 设置单独的 SRC 类型来仅拦截传入数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr "为每一 IPSet 设置单独的 SRC+DST 类型来拦截传入和传出数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr "设定特殊的 DST 日志选项，如设置一个限制率。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr "设置特殊的 SRC 日志选项，如设置一个限制率。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr "设置黑名单 IPSet 超时。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr "设置所有 DST 相关规则的防火墙目标。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr "设置所有 SRC 相关规则的防火墙目标。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr "设置全局 IPSet 类型默认值，以拦截传入 (SRC) 和/或传出 (DST) 数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr "设置 mac 列表 IPSet 超时。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr "设置白名单 IPSet 超时。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr "用于并行下载处理的下载队列大小。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr "源 (信息)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr "所选下载实用程序的特殊配置选项."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr "在后台启动一个小日志监视器，阻止可疑的 SSH/LuCI 登录尝试。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr "启动触发接口"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr "状态 / 版本"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr "IPSet 相关的报告文件的目标目录。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr "压缩的源列表备份的目标目录。"
 
@@ -723,11 +726,12 @@ msgstr "时间分配 (要求., 范围: 0-23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "分钟部分 (可选., 范围: 0-59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
-msgstr "选择的优先级将被用于banIP后台处理.此更改需要完全重新启动banIP服务才能生效."
+msgstr ""
+"选择的优先级将被用于banIP后台处理.此更改需要完全重新启动banIP服务才能生效."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/logread.js:28
 msgid "The syslog output, pre-filtered for banIP related messages only."
@@ -740,8 +744,9 @@ msgid ""
 "line. Comments introduced with '#' are allowed - domains, wildcards and "
 "regex are not."
 msgstr ""
-"这是用于本地总是拒绝某些 IP/CIDR 地址的banIP黑名单.<br /> <em><b>请注意:</b></"
-"em>每行只能添加一个IPv4或IPv6地址.允许使用 '#' 引入注释 - 域, 通配符和正则表达式不允许."
+"这是用于本地总是拒绝某些 IP/CIDR 地址的banIP黑名单.<br /> <em><b>请注意:</"
+"b></em>每行只能添加一个IPv4或IPv6地址.允许使用 '#' 引入注释 - 域, 通配符和正"
+"则表达式不允许."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:23
 msgid ""
@@ -749,8 +754,8 @@ msgid ""
 "<em><b>Please note:</b></em> add only one MAC address per line. Comments "
 "introduced with '#' are allowed - domains, wildcards and regex are not."
 msgstr ""
-"这是当地 banIP 总是允许某些MAC地址的MAC列表..<br /> <em><b>请注意:</b></em>每行只添加一个MAC地址.允许使用 '#"
-"' 引入注释 - 域, 通配符和正则表达式不允许."
+"这是当地 banIP 总是允许某些MAC地址的MAC列表..<br /> <em><b>请注意:</b></em>每"
+"行只添加一个MAC地址.允许使用 '#' 引入注释 - 域, 通配符和正则表达式不允许."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/whitelist.js:23
 msgid ""
@@ -759,8 +764,9 @@ msgid ""
 "line. Comments introduced with '#' are allowed - domains, wildcards and "
 "regex are not."
 msgstr ""
-"这是本地banIP白名单总是允许某些 IP/CIDR 地址.<br /> <em><b>请注意:</b></"
-"em>仅添加每行一个IPv4或IPv6地址.允许使用 '#' 引入注释 - 域, 通配符和正则表达式不允许."
+"这是本地banIP白名单总是允许某些 IP/CIDR 地址.<br /> <em><b>请注意:</b></em>仅"
+"添加每行一个IPv4或IPv6地址.允许使用 '#' 引入注释 - 域, 通配符和正则表达式不允"
+"许."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
 msgid ""
@@ -778,11 +784,11 @@ msgid ""
 "job for these lists."
 msgstr "要使您的banIP列表保持最新, 您应该为这些列表设置一个自动更新作业."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr "banIP通知电子邮件的主题."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "触发延迟"
 
@@ -796,17 +802,17 @@ msgstr "类型"
 msgid "Unable to save changes: %s"
 msgstr "无法保存更改: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr "广域网转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr "广域网输入"
 
@@ -814,7 +820,7 @@ msgstr "广域网输入"
 msgid "Whitelist IP/CIDR"
 msgstr "白名单 IP/CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr "白名单超时"
 

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/秒 (預設)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:515
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
 msgid "1 hour"
 msgstr "1 小時"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "12 hours"
 msgstr "12 小時"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:518
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
 msgid "24 hours"
 msgstr "24 小時"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:514
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 分鈡"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:516
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
 msgid "6 hours"
 msgstr "6 小時"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:772
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:764
 msgid "ASNs"
 msgstr "平均取樣數"
 
@@ -53,27 +53,27 @@ msgstr "平均取樣數"
 msgid "Action"
 msgstr "開始"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Active Devices"
 msgstr "現用終端"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:294
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
 msgid "Active Interfaces"
 msgstr "現用介面"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:298
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:284
 msgid "Active Logterms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:286
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:272
 msgid "Active Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:302
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:288
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -82,62 +82,62 @@ msgstr ""
 msgid "Add this IP/CIDR to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "附加觸發 banIP 行程開始延遲的秒數。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:358
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
 msgid "Advanced Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:359
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid "Auto Blacklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:785
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:445
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:361
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
 msgid "Blocklist Sources"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:157
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:139
 msgid ""
 "Configuration of the banIP package to block ip adresses/subnets via IPSet. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,81 +185,81 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:759
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid ""
 "Detect relevant network interfaces, devices, subnets and protocols "
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Download Utility"
 msgstr "下載工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -278,31 +278,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr "編輯白名單"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Enable DST logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Enable SRC logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
 msgstr "啟用"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "Enables IPv4 support in banIP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "Enables IPv6 support in banIP."
 msgstr ""
 
@@ -314,15 +314,15 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:788
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
 msgid "Extra Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,15 +330,15 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:282
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:268
 msgid "IPSet Information"
 msgstr "IPSet信息"
 
@@ -359,49 +359,49 @@ msgstr ""
 msgid "IPSet details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:385
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:371
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:390
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:262
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:636
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:625
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
 msgid "LAN Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:300
 msgid "Last Run"
 msgstr "最後執行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:426
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:714
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -409,27 +409,27 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:457
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:781
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:773
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
 msgid "Log Terms"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:398
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
 msgid "Log suspicious incoming packets - usually dropped."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Network Interfaces"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:424
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:676
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -519,12 +519,12 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "重新整理"
 
@@ -532,7 +532,7 @@ msgstr "重新整理"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:309
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -540,11 +540,11 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr ""
 
@@ -552,27 +552,27 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:310
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:292
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
@@ -587,21 +587,21 @@ msgid ""
 "address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:377
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:363
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Service Priority"
 msgstr ""
 
@@ -609,92 +609,92 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:527
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:475
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:354
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:728
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:381
 msgid ""
 "Starts a small log monitor in the background to block suspicious SSH/LuCI "
 "login attempts."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:278
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:264
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:317
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -769,11 +769,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
@@ -787,17 +787,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
 msgid "Verbose Debug Logging"
 msgstr "詳細除錯日誌"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:599
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:647
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
 msgid "WAN Input"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
 msgid "Whitelist Timeout"
 msgstr ""
 


### PR DESCRIPTION
* individual settypes includes now local black- and whitelist as well
* simplify the frontpage poll logic
* add missing 'btn' class for screen readers
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>