### PR TITLE
luci-app-tor-hs: add new application

### DIFF
--- a/applications/luci-app-tor-hs/Makefile
+++ b/applications/luci-app-tor-hs/Makefile
@@ -1,0 +1,12 @@
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI Support for Tor Hidden Service
+LUCI_DEPENDS:=+tor-hs
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_common.js
+++ b/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_common.js
@@ -24,16 +24,18 @@ return view.extend({
 		m  = new form.Map('tor-hs', 'Common settings');
 
 		s = m.section(form.NamedSection, 'common', _('Global settings'));
-		o = s.option(form.Value, 'HSDir', _('HSDir'),_('Path to directory with hidden services.'));
+		o = s.option(form.Value, 'HSDir', _('HSDir'), _('Path to directory with hidden services.'));
 		o.rmempty = false;
+		o.datatype = "directory";
 
-		o = s.option(form.Value, 'GenConf', _('GenConf'),_('Path to generated config file.'));
+		o = s.option(form.Value, 'GenConf', _('GenConf'), _('Path to generated config file.'));
 		o.rmempty = false;
+		o.datatype = "file";
 
 		o = s.option(form.Flag, 'RestartTor', _('Restart Tor'), _('Restart Tor daemon after tor-hs config change'));
 		o.rmempty = false;
 
-		o = s.option(form.Flag, 'UpdateTorConf', _('Auto-update Tor config'),_('Auto-update Tor uci config.'));
+		o = s.option(form.Flag, 'UpdateTorConf', _('Auto-update Tor config'), _('Auto-update Tor uci config.'));
 		o.rmempty = false;
 		o.default=0;
 

--- a/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_common.js
+++ b/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_common.js
@@ -1,0 +1,42 @@
+'use strict';
+'require view';
+'require ui';
+'require rpc';
+'require form';
+
+var callTorHSList = rpc.declare({
+			object: 'tor-hs-rpc',
+			method: 'list-hs',
+			expect: {'':{}  }});
+
+return view.extend({
+	formdata: { torhs: {} },
+
+	load: function() {
+		return Promise.all([
+			callTorHSList()
+		]);
+	},
+
+	render: function(data) {
+		var m, s, o;
+
+		m  = new form.Map('tor-hs', 'Common settings');
+
+		s = m.section(form.NamedSection, 'common', _('Global settings'));
+		o = s.option(form.Value, 'HSDir', _('HSDir'),_('Path to directory with hidden services.'));
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'GenConf', _('GenConf'),_('Path to generated config file.'));
+		o.rmempty = false;
+
+		o = s.option(form.Flag, 'RestartTor', _('Restart Tor'), _('Restart Tor daemon after tor-hs config change'));
+		o.rmempty = false;
+
+		o = s.option(form.Flag, 'UpdateTorConf', _('Auto-update Tor config'),_('Auto-update Tor uci config.'));
+		o.rmempty = false;
+		o.default=0;
+
+		return m.render();
+	},
+});

--- a/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_setting.js
+++ b/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_setting.js
@@ -1,0 +1,26 @@
+'use strict';
+'require view';
+'require ui';
+'require form';
+
+return view.extend({
+	formdata: { torhs: {} },
+
+	render: function(data) {
+		var m, s, o;
+
+		m  = new form.Map('tor-hs', _('Hidden service configuration'));
+		m.readonly=false;
+
+		o = m.section(form.TableSection, "hidden-service");
+		o.option(form.Value, "Name", _("Name"));
+		o.option(form.Value, "Description", _("Description"));
+		o.option(form.Flag, "Enabled", _("Enabled"));
+		o.option(form.Value, "IPv4", _("IPv4"));
+		o.option(form.DynamicList, "PublicLocalPort", _("Public Local Port"));
+		o.option(form.Value, "HookScript", _("HookScript"));
+		o.anonymous = true;
+		o.addremove = true;
+		return m.render();
+	}
+});

--- a/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_setting.js
+++ b/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_setting.js
@@ -17,6 +17,7 @@ return view.extend({
 		o.option(form.Value, "Description", _("Description"));
 		o.option(form.Flag, "Enabled", _("Enabled"));
 		o.option(form.Value, "IPv4", _("IPv4"));
+		o.datatype = 'ip4addr("nomask")';
 		o.option(form.DynamicList, "PublicLocalPort", _("Public Local Port"));
 		o.option(form.Value, "HookScript", _("HookScript"));
 		o.anonymous = true;

--- a/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_status.js
+++ b/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_status.js
@@ -1,0 +1,69 @@
+'use strict';
+'require view';
+'require dom';
+'require ui';
+'require rpc';
+'require form';
+
+var callTorHSList = rpc.declare({
+		object: 'tor-hs-rpc',
+		method: 'list-hs',
+		expect: {'':{}  }});
+
+return view.extend({
+	formdata: { torhs: {} },
+
+	load: function() {
+		return Promise.all([
+			callTorHSList()
+		]);
+	},
+
+	render: function(data) {
+		var m, s, o;
+
+		var uci_hs_list=data[0]["hs-list"];
+		var tbl_lines=[];
+
+
+		tbl_lines.push(
+				E('tr',{'class':'tr'},[
+				E('th',{'class':'th'} ,_("Name")),
+				E('th',{'class':'th'} ,_("Description")),
+				E('th',{'class':'th'} ,_("Enabled")),
+				E('th',{'class':'th'} ,_("Hidden service address")),
+				E('th',{'class':'th'} ,_("External port"))
+		]));
+
+		uci_hs_list.forEach(function(entry) {
+			var extern_ports=[]
+			entry.ports.forEach(function(port) {
+				extern_ports.push(port.split(";")[0]);
+			});
+
+			tbl_lines.push(
+				E('tr',{'class':'tr'},[
+					E('td',{'class':'td'} ,entry.name),
+					E('td',{'class':'td'} ,entry.description),
+					E('td',{'class':'td'} ,entry.enabled),
+					E('td',{'class':'td'} ,entry.hostname),
+					E('td',{'class':'td'} ,extern_ports.join(", "))
+			]));
+		});
+
+		var tbl=E('table',{'class': 'table'}, tbl_lines);
+
+		m = new form.JSONMap(this.formdata, _('Hidden service list'));
+
+		s = m.section(form.NamedSection, 'global');
+		s.render = L.bind(function(view, section_id) {
+			return tbl;
+		}, o, this);
+
+		return m.render();
+	},
+
+	addFooter: function() {
+		return E('div', { 'class': 'cbi-page-actions' },'');
+	}
+});

--- a/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_status.js
+++ b/applications/luci-app-tor-hs/htdocs/luci-static/resources/view/tor_hs_status.js
@@ -25,7 +25,6 @@ return view.extend({
 		var uci_hs_list=data[0]["hs-list"];
 		var tbl_lines=[];
 
-
 		tbl_lines.push(
 				E('tr',{'class':'tr'},[
 				E('th',{'class':'th'} ,_("Name")),
@@ -35,21 +34,23 @@ return view.extend({
 				E('th',{'class':'th'} ,_("External port"))
 		]));
 
-		uci_hs_list.forEach(function(entry) {
-			var extern_ports=[]
-			entry.ports.forEach(function(port) {
-				extern_ports.push(port.split(";")[0]);
-			});
+		if(typeof uci_hs_list  !== 'undefined'){
+			uci_hs_list.forEach(function(entry) {
+				var extern_ports=[]
+				entry.ports.forEach(function(port) {
+					extern_ports.push(port.split(";")[0]);
+				});
 
-			tbl_lines.push(
-				E('tr',{'class':'tr'},[
-					E('td',{'class':'td'} ,entry.name),
-					E('td',{'class':'td'} ,entry.description),
-					E('td',{'class':'td'} ,entry.enabled),
-					E('td',{'class':'td'} ,entry.hostname),
-					E('td',{'class':'td'} ,extern_ports.join(", "))
-			]));
-		});
+				tbl_lines.push(
+					E('tr',{'class':'tr'},[
+						E('td', {'class':'td'}, entry.name),
+						E('td', {'class':'td'}, entry.description),
+						E('td', {'class':'td'}, entry.enabled),
+						E('td', {'class':'td'}, entry.hostname),
+						E('td', {'class':'td'}, extern_ports.join(", "))
+				]));
+			});
+		}
 
 		var tbl=E('table',{'class': 'table'}, tbl_lines);
 

--- a/applications/luci-app-tor-hs/root/usr/share/luci/menu.d/luci-app-tor-hs.json
+++ b/applications/luci-app-tor-hs/root/usr/share/luci/menu.d/luci-app-tor-hs.json
@@ -1,0 +1,48 @@
+{
+	"admin/services/tor-hs": {
+		"title": "Tor Hidden service",
+		"order": 90,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-tor-hs" ],
+			"uci": { "tor-hs":true }
+		}
+	},
+	"admin/services/tor-hs/common": {
+		"title": "Common settings",
+		"order": 90,
+		"action": {
+			"type": "view",
+			"path": "tor_hs_common"
+		},
+		"depends": {
+			"acl": [ "luci-app-tor-hs" ]
+		}
+	},
+	"admin/services/tor-hs/setting": {
+		"title": "Hidden service configuration",
+		"order": 90,
+		"action": {
+			"type": "view",
+			"path": "tor_hs_setting"
+		},
+		"depends": {
+			"acl": [ "luci-app-tor-hs" ],
+			"uci": { "tor-hs":true }
+		}
+	},
+	"admin/services/tor-hs/status": {
+		"title": "Hidden service status",
+		"order": 90,
+		"action": {
+			"type": "view",
+			"path": "tor_hs_status"
+		},
+		"depends": {
+			"acl": [ "luci-app-tor-hs" ],
+			"uci": { "tor-hs":true }
+		}
+	}
+}

--- a/applications/luci-app-tor-hs/root/usr/share/rpcd/acl.d/luci-app-tor-hs.json
+++ b/applications/luci-app-tor-hs/root/usr/share/rpcd/acl.d/luci-app-tor-hs.json
@@ -1,0 +1,16 @@
+{
+	"luci-app-tor-hs": {
+		"description": "Grant access to Tor hidden service configurator",
+		"read": {
+			"ubus": {
+				"file":["read","list"],
+				"tor-hs-rpc": ["list-hs"]
+			},
+			"uci": [  "tor-hs" ],
+			"file": {"/etc/tor":["list","read"]}
+		},
+		"write": {
+			"uci": ["tor-hs"]
+		}
+	}
+}


### PR DESCRIPTION
This PR adds luci app for tor-hs package which helps with creating tor hidden services for router so they can be accessible  throught tor network.

https://github.com/openwrt/packages/tree/master/net/tor-hs


![tor-hs-list](https://user-images.githubusercontent.com/20402413/107662441-97066f00-6c8a-11eb-8645-b784ea640967.png)
![tor-hs-config](https://user-images.githubusercontent.com/20402413/107662445-98379c00-6c8a-11eb-8f75-ba0082fc4f52.png)

