### PR TITLE
[Bug-Fix] luci-app-firewall: add wan6 support

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
@@ -191,7 +191,7 @@ return view.extend({
 		o.modalonly = true;
 		o.rmempty = false;
 		o.nocreate = true;
-		o.default = 'wan6' ? 'wan6' : 'wan';
+		o.default = 'wan6';
 
 		o = fwtool.addMACOption(s, 'advanced', 'src_mac', _('Source MAC address'),
 			_('Only match incoming traffic from these MACs.'), hosts);

--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
@@ -191,7 +191,7 @@ return view.extend({
 		o.modalonly = true;
 		o.rmempty = false;
 		o.nocreate = true;
-		o.default = 'wan';
+		o.default = 'wan6' ? 'wan6' : 'wan';
 
 		o = fwtool.addMACOption(s, 'advanced', 'src_mac', _('Source MAC address'),
 			_('Only match incoming traffic from these MACs.'), hosts);


### PR DESCRIPTION
Firewall zones Forwarding was not working properly if `wan` was disabled, and `wan6` is enabled with both IPv4 and IPv6 Active Upstreams. 