### PR TITLE
luci-{app,proto}-wireguard: remove kmod-wireguard

### DIFF
--- a/applications/luci-app-wireguard/Makefile
+++ b/applications/luci-app-wireguard/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=WireGuard Status
-LUCI_DEPENDS:=+wireguard-tools +kmod-wireguard +luci-proto-wireguard
+LUCI_DEPENDS:=+wireguard-tools +luci-proto-wireguard
 LUCI_PKGARCH:=all
 
 include ../../luci.mk

--- a/protocols/luci-proto-wireguard/Makefile
+++ b/protocols/luci-proto-wireguard/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for WireGuard VPN
-LUCI_DEPENDS:=+kmod-wireguard +wireguard-tools
+LUCI_DEPENDS:=+wireguard-tools
 LUCI_PKGARCH:=all
 
 include ../../luci.mk


### PR DESCRIPTION
Prepares for 5.10 migration. wireguard-tools will bring in the correct
wireguard kernel module dependency - either kmod-wireguard or
kmod-wireguard-oot.

Depends on openwrt/openwrt#3885