### PR TITLE
[21.02] luci-app-https-dns-proxy: add Force DNS option support

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -69,37 +69,35 @@ local ubusStatus = util.ubus("service", "list", { name = packageName })
 local packageVersion = getPackageVersion()
 
 if packageVersion == "" then
-	packageStatusCode = -1
-	packageStatus = translatef("%s is not installed or not found", packageName)
+	packageStatusCode, packageStatus = -1, translatef("%s is not installed or not found", packageName)
 else  
-	if not ubusStatus or not ubusStatus[packageName] then
+	packageStatusCode, packageStatus = 1, ""
+	for n = 1,20 do
+		if ubusStatus and ubusStatus[packageName] and 
+			 ubusStatus[packageName]["instances"] and 
+			 ubusStatus[packageName]["instances"]["instance" .. n] and 
+			 ubusStatus[packageName]["instances"]["instance" .. n]["running"] then
+			local value, k, v, url, url_flag, la, la_flag, lp, lp_flag
+			for k, v in pairs(ubusStatus[packageName]["instances"]["instance" .. n]["command"]) do
+				if la_flag then la, la_flag = v, false end
+				if lp_flag then lp, lp_flag = v, false end
+				if url_flag then url, url_flag = v, false end
+				if v == "-a" then la_flag = true end
+				if v == "-p" then lp_flag = true end
+				if v == "-r" then url_flag = true end
+			end
+			la = la or "127.0.0.1"
+			lp = lp or n + 5053
+			packageStatus = packageStatus .. translatef("Running: %s DoH at %s:%s", getProviderName(url), la, lp) .. "\n"
+		else
+			break
+		end
+	end
+	if packageStatus == "" then
 		packageStatusCode = 0
 		packageStatus = translate("Stopped")
 		if not sys.init.enabled(packageName) then
 			packageStatus = packageStatus .. " (" .. translate("disabled") .. ")"
-		end
-	else
-		packageStatusCode, packageStatus = 1, ""
-		for n = 1,1000 do
-			if ubusStatus and ubusStatus[packageName] and 
-				 ubusStatus[packageName]["instances"] and 
-				 ubusStatus[packageName]["instances"]["instance" .. n] and 
-				 ubusStatus[packageName]["instances"]["instance" .. n]["running"] then
-				local value, k, v, url, url_flag, la, la_flag, lp, lp_flag
-				for k, v in pairs(ubusStatus[packageName]["instances"]["instance" .. n]["command"]) do
-					if la_flag then la, la_flag = v, false end
-					if lp_flag then lp, lp_flag = v, false end
-					if url_flag then url, url_flag = v, false end
-					if v == "-a" then la_flag = true end
-					if v == "-p" then lp_flag = true end
-					if v == "-r" then url_flag = true end
-				end
-				la = la or "127.0.0.1"
-				lp = lp or n + 5053
-				packageStatus = packageStatus .. translatef("Running: %s DoH at %s:%s", getProviderName(url), la, lp) .. "\n"
-			else
-				break
-			end
 		end
 	end
 end
@@ -123,8 +121,8 @@ else
 	buttons.template = packageName .. "/buttons"
 end
 
-c = m:section(NamedSection, "config", "https-dns-proxy", translate("Configuration"), translatef("If update DNSMASQ config is selected, when you add/remove any instances below, they will be used to override the 'DNS forwardings' section of %sDHCP and DNS%s (%smore information%s).", "<a href=\"" .. dispatcher.build_url("admin/network/dhcp") .. "\">", "</a>", "<a href=\"" .. readmeURL .. "#default-settings" .. "\" target=\"_blank\">", "</a>"))
-d1 = c:option(ListValue, "update_dnsmasq_config", translate("Update DNSMASQ Config on Start/Stop"))
+c = m:section(NamedSection, "config", "https-dns-proxy", translate("Configuration"))
+d1 = c:option(ListValue, "update_dnsmasq_config", translate("Update DNSMASQ Config on Start/Stop"), translatef("If update option is selected, the 'DNS forwardings' section of %sDHCP and DNS%s will be automatically updated to use selected DoH providers (%smore information%s).", "<a href=\"" .. dispatcher.build_url("admin/network/dhcp") .. "\">", "</a>", "<a href=\"" .. readmeURL .. "#default-settings" .. "\" target=\"_blank\">", "</a>"))
 d1:value('*', translate("Update all configs"))
 local dnsmasq_num = 0
 uci:foreach("dhcp", "dnsmasq", function(s)
@@ -133,6 +131,10 @@ dnsmasq_num = dnsmasq_num + 1
 end)
 d1:value('-', translate("Do not update configs"))
 d1.default = '*'
+f1 = c:option(ListValue, "force_dns", translate("Force Router DNS"), translate("Forces Router DNS use on local devices, also known as DNS Hijacking."))
+f1:value("0", translate("Let local devices use their own DNS servers if set"))
+f1:value("1", translate("Force Router DNS server to all local devices"))
+f1.default = '1'
 
 createHelperText()
 s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), 

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:73
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:72
 msgid "%s is not installed or not found"
 msgstr ""
 
@@ -53,7 +53,7 @@ msgstr ""
 msgid "Cloudflare (Security Protection)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:126
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:124
 msgid "Configuration"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "DNS HTTPS Proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:107
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:105
 msgid "DNS HTTPS Proxy Settings"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "DNSPod.cn Public DNS"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:189
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:191
 msgid "DSCP Codepoint"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:134
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:132
 msgid "Do not update configs"
 msgstr ""
 
@@ -105,6 +105,18 @@ msgstr ""
 msgid "For more information on different options check"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:134
+msgid "Force Router DNS"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:136
+msgid "Force Router DNS server to all local devices"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:134
+msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua:3
 msgid "Google"
 msgstr ""
@@ -113,15 +125,23 @@ msgstr ""
 msgid "Grant UCI and file access for luci-app-https-dns-proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:126
-msgid ""
-"If update DNSMASQ config is selected, when you add/remove any instances "
-"below, they will be used to override the 'DNS forwardings' section of %sDHCP "
-"and DNS%s (%smore information%s)."
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.idnet.doh.lua:3
+msgid "IDNet.net (UK)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:138
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:125
+msgid ""
+"If update option is selected, the 'DNS forwardings' section of %sDHCP and DNS"
+"%s will be automatically updated to use selected DoH providers (%smore "
+"information%s)."
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:140
 msgid "Instances"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:135
+msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua:3
@@ -132,11 +152,11 @@ msgstr ""
 msgid "LibreDNS (No Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:172
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:174
 msgid "Listen Address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:185
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:187
 msgid "Listen Port"
 msgstr ""
 
@@ -160,7 +180,7 @@ msgstr ""
 msgid "OpenDNS (Family Shield)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:193
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:195
 msgid "Proxy Server"
 msgstr ""
 
@@ -188,19 +208,19 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:145
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:147
 msgid "Resolver"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:99
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:91
 msgid "Running: %s DoH at %s:%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:111
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:109
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:109
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:107
 msgid "Service Status [%s %s]"
 msgstr ""
 
@@ -212,7 +232,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:77
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:98
 msgid "Stopped"
 msgstr ""
 
@@ -220,15 +240,15 @@ msgstr ""
 msgid "Unknown Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:131
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:129
 msgid "Update %s config"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:125
 msgid "Update DNSMASQ Config on Start/Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:128
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:126
 msgid "Update all configs"
 msgstr ""
 
@@ -236,7 +256,7 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:79
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:100
 msgid "disabled"
 msgstr ""
 


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.net>

Depends on https://github.com/openwrt/packages/pull/14866.