### PR TITLE
rpcd-mod-luci: Fix parsing of DUID-LLT's in duid2ea

### DIFF
--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -285,7 +285,7 @@ duid2ea(const char *duid)
 	switch (len) {
 	case 28:
 		if (!strncmp(duid, "00010001", 8))
-			p = duid + 8;
+			p = duid + 16;
 
 		break;
 


### PR DESCRIPTION
Fix parsing of DUID-LLT's in duid2ea.  Unlike DUID-LL's, DUID-LLT's have a 32-bit time field between the hardware type and link-layer address fields, see RFC 3315 Sections 9.2 and 9.4:

https://tools.ietf.org/html/rfc3315#section-9.2
https://tools.ietf.org/html/rfc3315#section-9.4

therefore, the link-layer address starts at offset 16 instead of 8.

Signed-off-by: Niels Widger <niels@qacafe.com>